### PR TITLE
Handling response null

### DIFF
--- a/packages/caver-core-helpers/src/errors.js
+++ b/packages/caver-core-helpers/src/errors.js
@@ -42,6 +42,7 @@ module.exports = {
     return new Error(`Returned error: ${message}`)
   },
   InvalidResponse: (result) => {
+    if (result === null) return new Error(`Invalid response: null`)
     const message = hasErrorMessage(result)
       ? result.error.message
       : `Invalid JSON RPC response: ${JSON.stringify(result)}`

--- a/packages/caver-core-requestmanager/caver-providers-http/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-http/src/index.js
@@ -92,17 +92,22 @@ HttpProvider.prototype.send = function(payload, callback) {
         clearTimeout(timer)
       }
       
-      if (request.readyState === 4 && request.timeout !== 1 && request.response !== null) {
+      if (request.readyState === 4 && request.timeout !== 1) {
           var result = request.responseText;
           var error = null;
 
-          try {
-              result = JSON.parse(result);
-          } catch(e) {
-              console.error(`Invalid JSON RPC response: ${JSON.stringify(request.responseText)}`)
-              error = errors.InvalidResponse(request.responseText);
+          if (request.response === null) {
+            error = errors.InvalidResponse(request.response)
+            clearTimeout(timer)
+          } else {
+            try {
+                result = JSON.parse(result);
+            } catch(e) {
+                console.error(`Invalid JSON RPC response: ${JSON.stringify(request.responseText)}`)
+                error = errors.InvalidResponse(request.responseText);
+            }
           }
-
+          
           _this.connected = true;
           callback(error, result);
       }

--- a/test/invalidResponse.js
+++ b/test/invalidResponse.js
@@ -1,0 +1,39 @@
+const { expect } = require('./extendedChai')
+const assert = require('assert')
+const Caver = require('../index')
+
+let caver
+
+describe('Connection error test', () => {
+    it('host url is invalid, return connection error.', async () => {
+        caver = new Caver(new Caver.providers.HttpProvider('invalid:1234', { timeout: 5000 }))
+        try {
+            await caver.klay.getNodeInfo()
+            assert(false)
+        } catch(err) {
+            expect(err.message).to.equals('CONNECTION ERROR: Couldn\'t connect to node invalid:1234.')
+        }
+    }).timeout(10000)
+})
+
+describe('Invalid response test', () => {
+    it('without timeout return Invalid response: null error.', async () => {
+        caver = new Caver('http://localhost:1234/')
+        try {
+            await caver.klay.getNodeInfo()
+            assert(false)
+        } catch(err) {
+            expect(err.message).to.equals('Invalid response: null')
+        }
+    })
+
+    it('with timeout return Invalid response: null error.', async () => {
+        caver = new Caver(new Caver.providers.HttpProvider('http://localhost:1234/', { timeout: 5000 }))
+        try {
+            await caver.klay.getNodeInfo()
+            assert(false)
+        } catch(err) {
+            expect(err.message).to.equals('Invalid response: null')
+        }
+    })
+})


### PR DESCRIPTION
## Proposed changes

If you use the HttpProvider to send a request to an invalid host url without setting the timeout, no action is taken.
When checking for a response, if it is null, the logic that handles null is implemented under the if check statement.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/14

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
