### PR TITLE
Emit transactionHash event when result is not Object

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -289,7 +289,7 @@ const buildSendTxCallbackFunc = (defer, method, payload, isSendTx) => (err, resu
   // return PROMISE
   if (!isSendTx) {
     defer.resolve(result)
-  } else {
+  } else if (!_.isObject(result)) {
     defer.eventEmitter.emit('transactionHash', result)
     method._confirmTransaction(defer, result, payload)
   }

--- a/test/eventEmitter.js
+++ b/test/eventEmitter.js
@@ -1,0 +1,49 @@
+/*
+    Copyright 2019 The caver-js Authors
+    This file is part of the caver-js library.
+ 
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+ 
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+ 
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const { expect } = require('chai')
+const testRPCURL = require('./testrpc')
+
+const Caver = require('../index.js')
+const caver = new Caver(testRPCURL)
+
+let senderPrvKey, senderAddress
+let receiver
+
+before(() => {
+    senderPrvKey = process.env.privateKey && String(process.env.privateKey).indexOf('0x') === -1
+        ? '0x' + process.env.privateKey
+        : process.env.privateKey
+
+    caver.klay.accounts.wallet.add(senderPrvKey)
+    senderAddress = caver.klay.accounts.privateKeyToAccount(senderPrvKey).address
+
+    receiver = caver.klay.accounts.wallet.add(caver.klay.accounts.create())
+})
+
+
+describe('eventEmitter with transactionHash', () => {
+  it('transactionHash event is called only with transactionHash.', () => {
+      caver.klay.sendTransaction({
+        from: senderAddress,
+        to: receiver.address,
+        value: 1,
+        gas: 900000,
+      }).on('transactionHash', (hash)=> expect(typeof(hash)).to.equals('string'))
+  }).timeout(10000)
+})


### PR DESCRIPTION
## Proposed changes
The transactionHash event is not called when the buildSendTxCallbackFunc function is called with the result value of signTransaction (Object type).

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/19

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
