### PR TITLE
Implemented the supportsSubscriptions function to distinguish the way the provider works

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -509,7 +509,7 @@ var startWatching = function (mutableConfirmationPack, existingReceipt) {
       method
     } = mutableConfirmationPack
   // if provider allows PUB/SUB
-  if (_.isFunction(method.requestManager.provider.on)) {
+  if (method.requestManager.provider.supportsSubscriptions()) {
     _klaytnCall.subscribe('newBlockHeaders', checkConfirmation.bind(null, mutableConfirmationPack, existingReceipt, false));
   } else {
     mutableConfirmationPack.intervalId = setInterval(checkConfirmation.bind(null, mutableConfirmationPack, existingReceipt, true), 1000);

--- a/packages/caver-core-requestmanager/caver-providers-http/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-http/src/index.js
@@ -140,4 +140,8 @@ HttpProvider.prototype.send = function(payload, callback) {
     }
 }
 
+HttpProvider.prototype.supportsSubscriptions = function() {
+    return false
+}
+
 module.exports = HttpProvider;

--- a/packages/caver-core-requestmanager/caver-providers-ipc/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-ipc/src/index.js
@@ -305,4 +305,8 @@ IpcProvider.prototype.reset = function () {
     this.addDefaultEvents();
 };
 
+IpcProvider.prototype.supportsSubscriptions = function() {
+    return true
+}
+
 module.exports = IpcProvider;

--- a/packages/caver-core-requestmanager/caver-providers-ws/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-ws/src/index.js
@@ -377,4 +377,8 @@ WebsocketProvider.prototype.reset = function () {
     this.addDefaultEvents();
 };
 
+WebsocketProvider.prototype.supportsSubscriptions = function() {
+    return true
+}
+
 module.exports = WebsocketProvider;

--- a/test/supportsSubscriptions.js
+++ b/test/supportsSubscriptions.js
@@ -1,0 +1,38 @@
+/*
+    Copyright 2019 The caver-js Authors
+    This file is part of the caver-js library.
+ 
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+ 
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+ 
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+require('it-each')({ testPerIteration: true })
+const { expect } = require('./extendedChai')
+
+const testRPCURL = require('./testrpc')
+const websocketURL = require('./testWebsocket')
+
+const Caver = require('../index.js')
+
+
+describe('supportsSubscriptions from Providers', () => {
+    it('HttpProvider should return false', () => {
+        const caver = new Caver(testRPCURL)
+        expect(caver.klay.currentProvider.supportsSubscriptions()).to.be.false
+    })
+
+    it('WebSocketProvider should return true', () => {
+        const caver = new Caver(websocketURL)
+        expect(caver.klay.currentProvider.supportsSubscriptions()).to.be.true
+    })
+})


### PR DESCRIPTION
## Proposed changes

Implement supportsSubscriptions to distinguish the behavior of the provider and use it in the startWatching function.
The way the provider works is largely divided into the way that it **works like 'webSocket' or not**.
The provider acting on the webSocket method will return true in the supportsSubscriptions function, otherwise it will return false.

This change in the way that the **'supportsSubscriptions' function must be implemented** when defining the Provider in the future.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/27

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
