### PR TITLE
Error when contract call via Contract instance with account in Node.

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -107,7 +107,7 @@ function createFunction(requestManager, accounts) {
   // call is directly used for rpc calling,
   // ex) 'klay_sendTransaction'
   func.call = this.call
-
+  
   return func
 }
 
@@ -285,7 +285,7 @@ const buildSendTxCallbackFunc = (defer, method, payload, isSendTx) => (err, resu
 
   // fire callback
   if (payload.callback) payload.callback(null, result)
-
+  
   // return PROMISE
   if (!isSendTx) {
     defer.resolve(result)
@@ -309,7 +309,7 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
       switch (payload.method) {
         case 'klay_sendTransaction': {
           var tx = payload.params[0]
-          
+
           // TODO : Check signTransactionWithSignature function with this logic
           //        and if need, implement sendTransactionWithSignature function.
           // if (tx.signature) {
@@ -429,7 +429,7 @@ function _confirmTransaction (defer, result, payload) {
     timeoutCount: 0,
     intervalId: null,
     gasProvided: payloadTxObject.gas || null,
-    isContractDeployment: payloadTxObject.data && payloadTxObject.from && !payloadTxObject.to,
+    isContractDeployment: payloadTxObject.data && payloadTxObject.from && (!payloadTxObject.to || payloadTxObject.to === '0x'),
     defer,
     result,
     _klaytnCall: {},

--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -107,7 +107,7 @@ function createFunction(requestManager, accounts) {
   // call is directly used for rpc calling,
   // ex) 'klay_sendTransaction'
   func.call = this.call
-  
+
   return func
 }
 
@@ -285,7 +285,7 @@ const buildSendTxCallbackFunc = (defer, method, payload, isSendTx) => (err, resu
 
   // fire callback
   if (payload.callback) payload.callback(null, result)
-  
+
   // return PROMISE
   if (!isSendTx) {
     defer.resolve(result)
@@ -309,7 +309,7 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
       switch (payload.method) {
         case 'klay_sendTransaction': {
           var tx = payload.params[0]
-
+          
           // TODO : Check signTransactionWithSignature function with this logic
           //        and if need, implement sendTransactionWithSignature function.
           // if (tx.signature) {

--- a/packages/caver-klay/caver-klay-contract/src/index.js
+++ b/packages/caver-klay/caver-klay-contract/src/index.js
@@ -1039,7 +1039,7 @@ Contract.prototype._executeMethod = function _executeMethod(){
                 if (args.options.type !== 'SMART_CONTRACT_EXECUTION' && args.options.type !== 'SMART_CONTRACT_DEPLOY') {
                     throw new Error('Unsupported transaction type. Please use SMART_CONTRACT_EXECUTION or SMART_CONTRACT_DEPLOY.')
                 } 
-                
+
                 var sendTransaction = (new Method({
                     name: 'sendTransaction',
                     call: 'klay_sendTransaction',

--- a/packages/caver-klay/caver-klay-contract/src/index.js
+++ b/packages/caver-klay/caver-klay-contract/src/index.js
@@ -1039,7 +1039,7 @@ Contract.prototype._executeMethod = function _executeMethod(){
                 if (args.options.type !== 'SMART_CONTRACT_EXECUTION' && args.options.type !== 'SMART_CONTRACT_DEPLOY') {
                     throw new Error('Unsupported transaction type. Please use SMART_CONTRACT_EXECUTION or SMART_CONTRACT_DEPLOY.')
                 } 
-
+                
                 var sendTransaction = (new Method({
                     name: 'sendTransaction',
                     call: 'klay_sendTransaction',
@@ -1051,6 +1051,11 @@ Contract.prototype._executeMethod = function _executeMethod(){
                     defaultBlock: _this._parent.defaultBlock,
                     extraFormatters: extraFormatters
                 })).createFunction();
+
+                const fromInWallet = sendTransaction.method.accounts.wallet[args.options.from.toLowerCase()]
+                if (!fromInWallet || !fromInWallet.privateKey) {
+                    args.options.type = 'LEGACY'
+                }
 
                 return sendTransaction(args.options, args.callback);
 

--- a/test/contractInstance.js
+++ b/test/contractInstance.js
@@ -1,0 +1,116 @@
+/*
+    Copyright 2019 The caver-js Authors
+    This file is part of the caver-js library.
+ 
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+ 
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+ 
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+require('it-each')({ testPerIteration: true })
+const { expect } = require('./extendedChai')
+
+const testRPCURL = require('./testrpc')
+
+var Caver = require('../index.js')
+var caver
+
+var senderPrvKey
+var senderAddress
+
+const byteCode = '0x6080604052348015600f57600080fd5b5060e98061001e6000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063954ab4b2146044575b600080fd5b348015604f57600080fd5b5060566058565b005b7f90a042becc42ba1b13a5d545701bf5ceff20b24d9e5cc63b67f96ef814d80f0933604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390a15600a165627a7a723058200ebb53e9d575350ceb2d92263b7d4920888706b5221f024e7bbc10e3dbb8e18d0029'
+const helloContractABI = [
+  {
+     "constant": false,
+     "inputs": [],
+     "name": "say",
+     "outputs": [],
+     "payable": false,
+     "stateMutability": "nonpayable",
+     "type": "function"
+  },
+  {
+     "anonymous": false,
+     "inputs": [
+        {
+           "indexed": false,
+           "name": "who",
+           "type": "address"
+        }
+     ],
+     "name": "callevent",
+     "type": "event"
+  }
+]
+
+before(() => {
+    senderPrvKey = process.env.privateKey && String(process.env.privateKey).indexOf('0x') === -1
+        ? '0x' + process.env.privateKey
+        : process.env.privateKey
+})
+
+beforeEach(() => {
+    caver = new Caver(testRPCURL)
+})
+
+describe('caver.klay.contract with using caver-js wallet account', () => {
+    it('Deploy and execute contract with caver.klay.Contract instance', async () => {
+        // When using account in caver-js wallet, then contract instance send transaction with
+        // 'SMART_CONTRACT_DEPLOY' or 'SMART_CONTRACT_EXECUTION' type
+        senderAddress = caver.klay.accounts.wallet.add(senderPrvKey).address
+
+        const contractInst = new caver.klay.Contract(helloContractABI)
+        let receipt
+        const newInstance = await contractInst.deploy({data: byteCode}).send({
+            from: senderAddress,
+            gas: 100000000,
+            value: 0,
+        }).on('receipt', (r) => receipt = r)
+        expect(receipt.type).to.equals('TxTypeSmartContractDeploy')
+
+        const execReceipt = await newInstance.methods.say().send({
+            from: senderAddress,
+            gas: 30000,
+        })
+
+        expect(execReceipt.type).to.equals('TxTypeSmartContractExecution')
+    }).timeout(200000)
+})
+
+describe('caver.klay.contract with using account exists in Node', () => {
+    it('Deploy and execute contract with caver.klay.Contract instance', async () => {
+        // When using account in node, then contract instance send transaction with 'LEGACY' type
+        senderAddress = caver.klay.accounts.privateKeyToAccount(senderPrvKey).address
+
+        try {
+            await caver.klay.personal.importRawKey(senderPrvKey, 'passphrase')
+        } catch(e) {}
+        const isUnlock = await caver.klay.personal.unlockAccount(senderAddress, 'passphrase')
+        expect(isUnlock).to.be.true
+
+        const contractInst = new caver.klay.Contract(helloContractABI)
+        let receipt
+        const newInstance = await contractInst.deploy({data: byteCode}).send({
+            from: senderAddress,
+            gas: 100000000,
+            value: 0,
+        }).on('receipt', (r) => receipt = r)
+        expect(receipt.type).to.equals('TxTypeLegacyTransaction')
+
+        const execReceipt = await newInstance.methods.say().send({
+            from: senderAddress,
+            gas: 30000,
+        })
+
+        expect(execReceipt.type).to.equals('TxTypeLegacyTransaction')
+    }).timeout(200000)
+  })


### PR DESCRIPTION
## Proposed changes

Use Legacy transaction type when call or deploy the contract via Contract instance with account in Node.
And also to return new Contract instance as a return value of deploy, modify the condition check to decide 'isContractDeployment'.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/34

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
