### PR TITLE
Implemented hex util functions

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -368,6 +368,40 @@ function _flattenTypes (includeTuple, puts) {
    return types;
 };
 
+/**
+ *
+ * @method isHexPrefixed
+ * @param {String} string
+ * @return {bool}
+ */
+var isHexPrefixed = function (str) {
+  return isHexParameter(str)
+}
+
+/**
+ *
+ * @method addHexPrefix
+ * @param {String} string
+ * @return {String}
+ */
+var addHexPrefix = function (str) {
+  if (typeof str !== 'string') return str
+
+  return isHexParameter(str) ? str : '0x' + str
+}
+
+/**
+ * 
+ * @method stripHexPrefix
+ * @param {String} string
+ * @return {String}
+ */
+var stripHexPrefix = function (str) {
+  if (typeof str !== 'string') return str
+
+  return isHexParameter(str) ? str.slice(2) : str
+}
+
 module.exports = {
     _fireError: _fireError,
     _jsonInterfaceMethodToString: _jsonInterfaceMethodToString,
@@ -432,6 +466,10 @@ module.exports = {
     Iban: Iban,
     // Newly added for supporting rpc.js
     isHexParameter: isHexParameter,
+    isHexPrefixed: isHexPrefixed,
+    addHexPrefix: addHexPrefix,
+    stripHexPrefix: stripHexPrefix,
+
     // Newly added for supporting of setting default block.
     parsePredefinedBlockNumber: utils.parsePredefinedBlockNumber,
     isPredefinedBlockNumber: utils.isPredefinedBlockNumber,

--- a/test/packages/caver.klay.utils.js
+++ b/test/packages/caver.klay.utils.js
@@ -774,3 +774,28 @@ describe('caver.utils.toTwosComplement', () => {
     }
   )
 })
+
+describe('caver.utils.isHexPrefixed', () => {
+  it('caver.utils.isHexPrefixed should return boolean depends on parameter', ()=>{
+    expect(caver.utils.isHexPrefixed('0x')).to.be.true
+    expect(caver.utils.isHexPrefixed('01')).to.be.false
+    expect(caver.utils.isHexPrefixed({})).to.be.false
+  })
+})
+
+describe('caver.utils.addHexPrefix', () => {
+  it('caver.utils.addHexPrefix should return 0x hex format string', ()=>{
+    expect(caver.utils.addHexPrefix('0x')).to.equals('0x')
+    expect(caver.utils.addHexPrefix('01')).to.equals('0x01')
+    expect(typeof(caver.utils.addHexPrefix({}))).to.equals('object')
+  })
+})
+
+describe('caver.utils.stripHexPrefix', () => {
+  it('caver.utils.stripHexPrefix should strip 0x prefix and return string', ()=>{
+    expect(caver.utils.stripHexPrefix('0x')).to.equals('')
+    expect(caver.utils.stripHexPrefix('01')).to.equals('01')
+    expect(caver.utils.stripHexPrefix('0x01')).to.equals('01')
+    expect(typeof(caver.utils.stripHexPrefix({}))).to.equals('object')
+  })
+})


### PR DESCRIPTION
## Proposed changes

Implement isHexPrefixed, addHexPrefix, stripHexPrefix functions in caver.utils package

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/58

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
