### PR TITLE
Omit the step of getting information that is not needed when feePayer signs

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -228,7 +228,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
     return Promise.all([
         isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._klaytnCall.getGasPrice() : tx.gasPrice,
-        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from) : tx.nonce 
+        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from || _this.privateKeyToAccount(privateKey).address) : tx.nonce 
     ]).then(function (args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2])) {
             throw new Error('One of the values "chainId", "gasPrice", or "nonce" couldn\'t be fetched: '+ JSON.stringify(args));

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -212,12 +212,23 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         return Promise.resolve(signed(tx));
     }
 
+    // When feePayer sign to transaction, information needed for signing is only chainId.
+    if (tx.senderRawTransaction !== undefined) {
+      return Promise.all([
+          isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
+      ]).then(function (args) {
+          if (isNot(args[0])) {
+              throw new Error('"chainId" couldn\'t be fetched: '+ JSON.stringify(args));
+          }
+          return signed(_.extend(tx, {chainId: args[0]}));
+      });
+    }
 
     // Otherwise, get the missing info from the Klaytn Node
     return Promise.all([
         isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._klaytnCall.getGasPrice() : tx.gasPrice,
-        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.feePayer || tx.from || _this.privateKeyToAccount(privateKey).address) : tx.nonce
+        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from) : tx.nonce 
     ]).then(function (args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2])) {
             throw new Error('One of the values "chainId", "gasPrice", or "nonce" couldn\'t be fetched: '+ JSON.stringify(args));

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -212,7 +212,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         return Promise.resolve(signed(tx));
     }
 
-    // When feePayer sign to transaction, information needed for signing is only chainId.
+    // When the feePayer signs a transaction, required information is only chainId.
     if (tx.senderRawTransaction !== undefined) {
       return Promise.all([
           isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,


### PR DESCRIPTION
## Proposed changes

Separate the logic so that only chainId is used for signing with feePayer.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/64

## Further comments

This issue was discovered in the process of separating the serialization test code, and after this code is applied, the serialization test should operate normally **without the request to Klaytn Node**.

After this PR, i will create a PR that separates the serialization test code. 

When testing serialization, if chainId is set in the transaction that fee payer signs, it **should work without asking to node**. 
To check this out, the serialization test will be done by not setting a host for the provider.