### PR TITLE
Implement toBuffer, numberToBuffer function in caver.utils

### DIFF
--- a/test/packages/caver.klay.utils.js
+++ b/test/packages/caver.klay.utils.js
@@ -799,3 +799,63 @@ describe('caver.utils.stripHexPrefix', () => {
     expect(typeof(caver.utils.stripHexPrefix({}))).to.equals('object')
   })
 })
+
+describe('caver.utils.toBuffer', () => {
+  it('caver.utils.toBuffer should return input when input is Buffer', ()=>{
+    expect(caver.utils.toBuffer(Buffer.from('test Buffer'))).to.deep.equal(Buffer.from('test Buffer'))
+  })
+  it('caver.utils.toBuffer should convert null or undefined to buffer', ()=>{
+    expect(caver.utils.toBuffer(null)).to.deep.equal(Buffer.alloc(0))
+    expect(caver.utils.toBuffer(undefined)).to.deep.equal(Buffer.alloc(0))
+  })
+  it('caver.utils.toBuffer should convert Array to buffer', ()=>{
+    expect(caver.utils.toBuffer([1,2,3,4,5])).to.deep.equal(Buffer.from([1,2,3,4,5]))
+    expect(caver.utils.toBuffer([])).to.deep.equal(Buffer.alloc(0))
+  })
+  it('caver.utils.toBuffer should convert BN to buffer', ()=>{
+    expect(caver.utils.toBuffer(new BN(1))).to.deep.equal(Buffer.from([1]))
+    expect(caver.utils.toBuffer(new BN(255)).toString('hex')).to.deep.equal('ff')
+    expect(caver.utils.toBuffer(new BN('ff', 16)).toString('hex')).to.deep.equal('ff')
+    expect(caver.utils.toBuffer(new BN('377', 8)).toString('hex')).to.deep.equal('ff')
+    expect(caver.utils.toBuffer(new BN('11111111', 2)).toString('hex')).to.deep.equal('ff')
+  })
+  it('caver.utils.toBuffer should convert Object has toArray function to buffer', ()=>{
+    expect(caver.utils.toBuffer({toArray: function () {return [1, 2, 3, 4, 5]}})).to.deep.equal(Buffer.from([1,2,3,4,5]))
+  })
+  it('caver.utils.toBuffer should convert String to buffer', ()=>{
+    expect(caver.utils.toBuffer('0x01').toString('hex')).to.deep.equal('01')
+    expect(caver.utils.toBuffer('0x1').toString('hex')).to.deep.equal('01')
+    expect(caver.utils.toBuffer('0x1234').toString('hex')).to.deep.equal('1234')
+    expect(caver.utils.toBuffer('0x12345').toString('hex')).to.deep.equal('012345')
+    expect(caver.utils.toBuffer('0x11')).to.deep.equal(Buffer.from([17]))
+    expect(caver.utils.toBuffer('0x')).to.deep.equal(Buffer.from([]))
+  })
+  it('caver.utils.toBuffer should convert Number to buffer', ()=>{
+    expect(caver.utils.toBuffer(1)).to.deep.equal(Buffer.from([1]))
+    expect(caver.utils.toBuffer(1).toString('hex')).to.deep.equal('01')
+    expect(caver.utils.toBuffer(100).toString('hex')).to.deep.equal('64')
+  })
+
+  it('caver.utils.toBuffer should throw error when input type is not supported with toBuffer function', ()=>{
+    expect(()=>caver.utils.toBuffer({})).to.throw('To convert an object to a buffer, the toArray function must be implemented inside the object')
+    expect(()=>caver.utils.toBuffer({toArray: [1,2,3,4,5]})).to.throw('To convert an object to a buffer, the toArray function must be implemented inside the object')
+  })
+  it('caver.utils.toBuffer should throw error when String is not 0x-prefixed', ()=>{
+    expect(()=>caver.utils.toBuffer('010x')).to.throw(`Failed to convert string to Buffer. 'toBuffer' function only supports 0x-prefixed hex string`)
+    expect(()=>caver.utils.toBuffer('01')).to.throw(`Failed to convert string to Buffer. 'toBuffer' function only supports 0x-prefixed hex string`)
+    expect(()=>caver.utils.toBuffer('')).to.throw(`Failed to convert string to Buffer. 'toBuffer' function only supports 0x-prefixed hex string`)
+    expect(()=>caver.utils.toBuffer('0xqwer')).to.throw(`Failed to convert string to Buffer. 'toBuffer' function only supports 0x-prefixed hex string`)
+    expect(()=>caver.utils.toBuffer('qwer')).to.throw(`Failed to convert string to Buffer. 'toBuffer' function only supports 0x-prefixed hex string`)
+  })
+})
+
+describe('caver.utils.numberToBuffer', () => {
+  it('caver.utils.numberToBuffer should convert number to buffer', ()=>{
+    expect(caver.utils.numberToBuffer(6003400).toString('hex')).to.equals('5b9ac8')
+    expect(caver.utils.numberToBuffer(1).toString('hex')).to.equals('01')
+    expect(caver.utils.numberToBuffer(12345).toString('hex')).to.equals('3039')
+    expect(caver.utils.numberToBuffer(123456789).toString('hex')).to.equals('075bcd15')
+    expect(caver.utils.numberToBuffer(100000000).toString('hex')).to.equals('05f5e100')
+    expect(caver.utils.numberToBuffer(819263839023).toString('hex')).to.equals('bebfee1b2f')
+  })
+})

--- a/test/packages/caver.klay.utils.js
+++ b/test/packages/caver.klay.utils.js
@@ -859,3 +859,32 @@ describe('caver.utils.numberToBuffer', () => {
     expect(caver.utils.numberToBuffer(819263839023).toString('hex')).to.equals('bebfee1b2f')
   })
 })
+
+describe('caver.utils.isHexParameter', () => {
+  it('caver.utils.isHexParameter should return true if input is hex string', ()=>{
+    expect(caver.utils.isHexParameter('0x01')).to.be.true
+    expect(caver.utils.isHexParameter('0xa')).to.be.true
+    expect(caver.utils.isHexParameter('0x256d774a7a1bbd469d4fb08545d171df1c755a78')).to.be.true
+    expect(caver.utils.isHexParameter('0x256d774a7a1bbd469d4fb08545d171df1c755a78171df1c755a78')).to.be.true
+  })
+
+  it('caver.utils.isHexParameter should return false if input is not hex string', ()=>{
+    // string type input
+    expect(caver.utils.isHexParameter('')).to.be.false
+    expect(caver.utils.isHexParameter('1')).to.be.false
+    expect(caver.utils.isHexParameter('0xqwer')).to.be.false
+    expect(caver.utils.isHexParameter('10x')).to.be.false
+    expect(caver.utils.isHexParameter('0x14qr')).to.be.false
+    expect(caver.utils.isHexParameter('0x1!')).to.be.false
+    expect(caver.utils.isHexParameter(' 0x256d774a7a1bbd469d4fb08545d171df1c755a78')).to.be.false
+    // not string type input
+    expect(caver.utils.isHexParameter(null)).to.be.false
+    expect(caver.utils.isHexParameter(undefined)).to.be.false
+    expect(caver.utils.isHexParameter(true)).to.be.false
+    expect(caver.utils.isHexParameter(1)).to.be.false
+    expect(caver.utils.isHexParameter({})).to.be.false
+    expect(caver.utils.isHexParameter([])).to.be.false
+    expect(caver.utils.isHexParameter(Buffer.alloc(0))).to.be.false
+    expect(caver.utils.isHexParameter(new BN())).to.be.false
+  })
+})


### PR DESCRIPTION
## Proposed changes

Implement toBuffer and numberToBuffer functions in caver.utils
Test code for toBuffer and numberToBuffer functions is added

Also the logic of the isHexParameter function has also been modified. 
This is because if the parameter is a 0x-prefixed but it is not a hexadecimal string, it cannot be well identified.
Test code has also been added to test this.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/71

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
