### PR TITLE
Modify xyPointFromPublicKey test code for cover leading zero

### DIFF
--- a/test/packages/caver.klay.utils.js
+++ b/test/packages/caver.klay.utils.js
@@ -896,6 +896,30 @@ describe('caver.utils.xyPointFromPublicKey', () => {
     const xyPoint = caver.utils.xyPointFromPublicKey(publicKey)
     expect(Array.isArray(xyPoint)).to.be.true
     expect(xyPoint.length).to.equals(2)
-    expect(publicKey).to.equals(xyPoint[0]+xyPoint[1].slice(2))
+    expect(publicKey).to.equals(caver.utils.leftPad(xyPoint[0], 64)+caver.utils.leftPad(xyPoint[1], 64).slice(2))
+  })
+
+  it('caver.utils.xyPointFromPublicKey should return x, y point remove leading zeros', ()=>{
+    const publicKey1 = '0x046241c7524030e5b44fff78021e35227d708c8630757b35090d56527b615f605b8d366782c86dee49356be574e1172f75ef5ce5d03b6e8c17dbf10f3fa2d9a3'
+    const publicKey2 = '0xba7135b75cae89b958e7bb78009bda52f6a348150757cc078e3e5e5d25519c500ed4ccec1f78ba4e1c21c7b1e57751cec4cf42e3997a476e3ecbf360ad095336'
+    const publicKey3 = '0x12b97e6756861ac0257a240d985d761cee9ca7719a29c233c644cfcc421885000c8e4c69cdb71665377b9e8ffb702355ca53917e66c7444619049c3dd0252ab6'
+    const publicKey4 = '0x05b3b58259770871a1cc18534f2d438935fa2dcdb04116cbfbde8adfe858c23e50047c5aea3c2f55de7de04203f8fe8ccc3b491029338d038a7ef6d6903b302e'
+
+    const xyPoint1 = caver.utils.xyPointFromPublicKey(publicKey1)
+    const xyPoint2 = caver.utils.xyPointFromPublicKey(publicKey2)
+    const xyPoint3 = caver.utils.xyPointFromPublicKey(publicKey3)
+    const xyPoint4 = caver.utils.xyPointFromPublicKey(publicKey4)
+
+    expect(xyPoint1[0]).to.equals('0x46241c7524030e5b44fff78021e35227d708c8630757b35090d56527b615f60')
+    expect(xyPoint1[1]).to.equals('0x5b8d366782c86dee49356be574e1172f75ef5ce5d03b6e8c17dbf10f3fa2d9a3')
+
+    expect(xyPoint2[0]).to.equals('0xba7135b75cae89b958e7bb78009bda52f6a348150757cc078e3e5e5d25519c50')
+    expect(xyPoint2[1]).to.equals('0xed4ccec1f78ba4e1c21c7b1e57751cec4cf42e3997a476e3ecbf360ad095336')
+
+    expect(xyPoint3[0]).to.equals('0x12b97e6756861ac0257a240d985d761cee9ca7719a29c233c644cfcc42188500')
+    expect(xyPoint3[1]).to.equals('0xc8e4c69cdb71665377b9e8ffb702355ca53917e66c7444619049c3dd0252ab6')
+
+    expect(xyPoint4[0]).to.equals('0x5b3b58259770871a1cc18534f2d438935fa2dcdb04116cbfbde8adfe858c23e')
+    expect(xyPoint4[1]).to.equals('0x50047c5aea3c2f55de7de04203f8fe8ccc3b491029338d038a7ef6d6903b302e')
   })
 })


### PR DESCRIPTION
## Proposed changes
This test code now sometimes fails because it simply concats and compares the two strings that result from xyPointFromPublicKey.

xyPointFromPublicKey removes and returns when there is a leading zero, so we need to set the right length of x and y points for comparison.

Added test code to verify that xyPointFromPublicKey removes leading zeros.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
