### PR TITLE
Add functions to validate transaction hex strings (TPT-596)

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -506,6 +506,7 @@ module.exports = {
     rightPad: utils.rightPad,
     toTwosComplement: utils.toTwosComplement,
     isTxHash: utils.isTxHash,
+    isTxHashStrict: utils.isTxHashStrict,
     // Moved promiEvent to utils,
     promiEvent: promiEvent,
     Iban: Iban,

--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -505,6 +505,7 @@ module.exports = {
     padRight: utils.rightPad,
     rightPad: utils.rightPad,
     toTwosComplement: utils.toTwosComplement,
+    isTxHash: utils.isTxHash,
     // Moved promiEvent to utils,
     promiEvent: promiEvent,
     Iban: Iban,

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -408,6 +408,13 @@ var isHex = function (hex) {
  */
 const isTxHash = (tx) => new RegExp(`^(0x|0X)?[0-9a-fA-F]{${TRANSACTION_HASH_LENGTH - 2}}$`).test(tx)
 
+/**
+ * Checks if the given string is a hexadecimal transaction hash that starts with 0x
+ * @method isTxHashStrict
+ * @param {String} tx given hexadecimal transaction hash
+ * @return {Boolean}
+ */
+const isTxHashStrict = (tx) => new RegExp(`^(0x|0X)[0-9a-fA-F]{${TRANSACTION_HASH_LENGTH - 2}}$`).test(tx)
 
 /**
  * Returns true if given string is a valid Klaytn block header bloom.
@@ -728,4 +735,5 @@ module.exports = {
     isCompressedPublicKey,
     compressPublicKey,
     isTxHash,
+    isTxHashStrict,
 };

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -57,6 +57,8 @@ const txTypeToString = {
   '0x48': 'CHAIN_DATA_ANCHORING',
 }
 
+const TRANSACTION_HASH_LENGTH = 66
+
 /**
  * Returns true if object is BN, otherwise false
  *
@@ -398,6 +400,14 @@ var isHex = function (hex) {
     return ((_.isString(hex) || _.isNumber(hex)) && /^(-0x|0x)?[0-9a-f]*$/i.test(hex));
 };
 
+/**
+ * Checks if the given string is a hexadecimal transaction hash with or without prefix 0x
+ * @method isTxHash
+ * @param {String} tx given hexadecimal transaction hash
+ * @return {Boolean}
+ */
+const isTxHash = (tx) => new RegExp(`^(0x|0X)?[0-9a-fA-F]{${TRANSACTION_HASH_LENGTH - 2}}$`).test(tx)
+
 
 /**
  * Returns true if given string is a valid Klaytn block header bloom.
@@ -717,4 +727,5 @@ module.exports = {
     txTypeToString,
     isCompressedPublicKey,
     compressPublicKey,
+    isTxHash,
 };

--- a/test/packages/caver.klay.utils.js
+++ b/test/packages/caver.klay.utils.js
@@ -337,6 +337,39 @@ describe('CAVERJS-UNIT-ETC-117: caver.utils.toHex', () => {
   })
 })
 
+describe('caver.utils.isTxHash', () => {
+  const example = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+  context('input: valid transaction hex', () => {
+    it.each([
+      [example, true], // all lower long
+      [example.slice(2), true], // all lower short
+      [example.toUpperCase(), true], // all upper long
+      [example.slice(2).toUpperCase(), true], // all upper short
+      [example.slice(0, 10) + example.slice(10).toUpperCase(), true], // mixed long
+      [example.slice(2, 10) + example.slice(10).toUpperCase(), true], // mixed short
+    ],
+    'should return true',
+    ([tx, expected]) => {
+      const result = caver.utils.isTxHash(tx)
+      expect(result).to.be.equal(expected)
+    })
+  })
+
+  context('input: invalid transaction hex', () => {
+    it.each([
+      [example.slice(4), false], // length is not enough (62)
+      [`${example.slice(0, 62)}ZZ`, false], // not hex
+      [`${example.slice(2)}00`, false], // length is too long (66 without 0x)
+      [`${example}00`, false], // length is too long (68)
+    ],
+    'should return false',
+    ([tx, expected]) => {
+      const result = caver.utils.isTxHash(tx)
+      expect(result).to.be.equal(expected)
+    })
+  })
+})
+
 describe('caver.utils.toBN', () => {
   context('CAVERJS-UNIT-ETC-118: input: valid value', () => {
     const tests = [

--- a/test/packages/caver.klay.utils.js
+++ b/test/packages/caver.klay.utils.js
@@ -337,6 +337,36 @@ describe('CAVERJS-UNIT-ETC-117: caver.utils.toHex', () => {
   })
 })
 
+describe('caver.utils.isTxHashStrict', () => {
+  const example = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+  context('input: valid strict transaction hex', () => {
+    it.each([
+      [example, true], // all lower
+      [example.toUpperCase(), true], // all upper
+      [example.slice(0, 10) + example.slice(10).toUpperCase(), true], // mixed
+    ],
+    'should return true',
+    ([tx, expected]) => {
+      const result = caver.utils.isTxHashStrict(tx)
+      expect(result).to.be.equal(expected)
+    })
+  })
+
+  context('input: invalid strict transaction hex', () => {
+    it.each([
+      [`00${example.slice(2)}`, false], // doesn't start with 0x
+      [example.slice(2), false], // doesn't start with 0x
+      [`${example.slice(0, 64)}ZZ`, false], // not hex
+      [example.slice(0, 10), false], // length is not enough
+    ],
+    'should return false',
+    ([tx, expected]) => {
+      const result = caver.utils.isTxHashStrict(tx)
+      expect(result).to.be.equal(expected)
+    })
+  })
+})
+
 describe('caver.utils.isTxHash', () => {
   const example = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
   context('input: valid transaction hex', () => {


### PR DESCRIPTION
## Proposed changes

- add `isTransactionStrict` function: checks if string is a transaction hex (must start with 0x and have length of 66)
- add `isTransaction` function: checks if string is a transaction hex (with or without 0x)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
