### PR TITLE
Fix setProvider bug

### DIFF
--- a/packages/caver-klay/src/index.js
+++ b/packages/caver-klay/src/index.js
@@ -50,7 +50,7 @@ var Klay = function Klay(...args) {
 
     // overwrite setProvider
     var setProvider = this.setProvider;
-    this.setProvider = function () {
+    this.setProvider = function (...args) {
         setProvider.apply(_this, args);
         _this.net.setProvider.apply(_this, args);
         _this.personal.setProvider.apply(_this, args);


### PR DESCRIPTION
## Proposed changes

- Bug fix connection setProvider

## Types of changes

Please put an x in the boxes related to your change.

- [ x ] Bugfix

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)

## Description

before this change, Caver cannot any rpc requests after calling setProvider method.