### PR TITLE
Modify functions related with HexPrefix to work with prefix only

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -378,7 +378,8 @@ function _flattenTypes (includeTuple, puts) {
  * @return {bool}
  */
 var isHexPrefixed = function (str) {
-  return isHexParameter(str)
+  if (typeof str !== 'string') return false
+  return str.slice(0, 2) === '0x'
 }
 
 /**
@@ -390,7 +391,7 @@ var isHexPrefixed = function (str) {
 var addHexPrefix = function (str) {
   if (typeof str !== 'string') return str
 
-  return isHexParameter(str) ? str : '0x' + str
+  return isHexPrefixed(str) ? str : '0x' + str
 }
 
 /**
@@ -402,7 +403,7 @@ var addHexPrefix = function (str) {
 var stripHexPrefix = function (str) {
   if (typeof str !== 'string') return str
 
-  return isHexParameter(str) ? str.slice(2) : str
+  return isHexPrefixed(str) ? str.slice(2) : str
 }
 
 /**

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -876,6 +876,7 @@ describe('CAVERJS-UNIT-ETC-144: caver.utils.toTwosComplement', () => {
 describe('CAVERJS-UNIT-ETC-145: caver.utils.isHexPrefixed', () => {
   it('caver.utils.isHexPrefixed should return boolean depends on parameter', ()=>{
     expect(caver.utils.isHexPrefixed('0x')).to.be.true
+    expect(caver.utils.isHexPrefixed('0x0x')).to.be.true
     expect(caver.utils.isHexPrefixed('01')).to.be.false
     expect(caver.utils.isHexPrefixed({})).to.be.false
   })
@@ -885,6 +886,7 @@ describe('CAVERJS-UNIT-ETC-146: caver.utils.addHexPrefix', () => {
   it('caver.utils.addHexPrefix should return 0x hex format string', ()=>{
     expect(caver.utils.addHexPrefix('0x')).to.equals('0x')
     expect(caver.utils.addHexPrefix('01')).to.equals('0x01')
+    expect(caver.utils.addHexPrefix('x')).to.equals('0xx')
     expect(typeof(caver.utils.addHexPrefix({}))).to.equals('object')
   })
 })
@@ -894,6 +896,7 @@ describe('CAVERJS-UNIT-ETC-147: caver.utils.stripHexPrefix', () => {
     expect(caver.utils.stripHexPrefix('0x')).to.equals('')
     expect(caver.utils.stripHexPrefix('01')).to.equals('01')
     expect(caver.utils.stripHexPrefix('0x01')).to.equals('01')
+    expect(caver.utils.stripHexPrefix('0xx')).to.equals('x')
     expect(typeof(caver.utils.stripHexPrefix({}))).to.equals('object')
   })
 })


### PR DESCRIPTION
## Proposed changes

Modify util functions named isHexPrefixed, addHexPrefix, stripHexPrefix to work with only prefix.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/97

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
