### PR TITLE
Implement isDecoupled getLegacyAccount determineAddress in Account package

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -113,7 +113,7 @@ Accounts.prototype.create = function create(entropy) {
  * privateKeyToAccount creates and returns an Account through the input passed as parameters.
  *
  * @method privateKeyToAccount
- * @param {String} key The key parameter can be either normal private key or klaytnWalletKey format.
+ * @param {String} key The key parameter can be either normal private key or KlaytnWalletKey format.
  * @param {String} userInputAddress The address entered by the user for use in creating an account.
  * @return {Object}
  */

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -131,7 +131,7 @@ Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(key, userI
  * isDecoupled determines whether or not it is decoupled based on the input value.
  *
  * @method isDecoupled
- * @param {String} key The key parameter can be either normal private key or klaytnWalletKey format.
+ * @param {String} key The key parameter can be either normal private key or KlaytnWalletKey format.
  * @param {String} userInputAddress The address to use when determining whether it is decoupled.
  * @return {Boolean}
  */

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -590,7 +590,15 @@ Accounts.prototype.decrypt = function (v3Keystore, password, nonStrict) {
       "id":"dfde6a32-4b0e-404f-8b9f-2b18f279fe21",
     }
  */
-// The key parameter can be either normal private key or klaytnWalletKey format.
+/**
+ * encrypt encrypts an account and returns key store.
+ *
+ * @method privateKeyToAccount
+ * @param {String} key The key parameter can be either normal private key or KlaytnWalletKey format.
+ * @param {String} password The password to be used for account encryption. The encrypted key store can be decrypted with this password.
+ * @param {Object} options The options to use when encrypt an account.
+ * @return {Object}
+ */
 Accounts.prototype.encrypt = function (key, password, options) {
     /**
      * options can include below

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -110,7 +110,7 @@ Accounts.prototype.create = function create(entropy) {
 };
 
 Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey, targetAddressRaw) {
-  let {nonDecoupledAccount: account, klaytnWalletKeyAddress} = this.getNonDecoupledAccount(privateKey)
+  let {legacyAccount: account, klaytnWalletKeyAddress} = this.getLegacyAccount(privateKey)
 
   account.address = this.determineAddress(account, klaytnWalletKeyAddress, targetAddressRaw)
   account.address = account.address.toLowerCase()
@@ -120,25 +120,25 @@ Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey
 }
 
 Accounts.prototype.isDecoupled = function isDecoupled(privateKey, userInputAddress) {
-  let { nonDecoupledAccount, klaytnWalletKeyAddress } = this.getNonDecoupledAccount(privateKey)
-  let actualAddress = this.determineAddress(nonDecoupledAccount, klaytnWalletKeyAddress, userInputAddress)
+  let { legacyAccount, klaytnWalletKeyAddress } = this.getLegacyAccount(privateKey)
+  let actualAddress = this.determineAddress(legacyAccount, klaytnWalletKeyAddress, userInputAddress)
 
-  return nonDecoupledAccount.address.toLowerCase() !== actualAddress.toLowerCase()
+  return legacyAccount.address.toLowerCase() !== actualAddress.toLowerCase()
 }
 
-Accounts.prototype.getNonDecoupledAccount = function getNonDecoupledAccount(privateKey) {
+Accounts.prototype.getLegacyAccount = function getLegacyAccount(privateKey) {
   var { privateKey: prvKey, address: klaytnWalletKeyAddress, isHumanReadable } = utils.parsePrivateKey(privateKey)
 
   if (!utils.isValidPrivateKey(prvKey)) throw new Error('Invalid private key')
 
   prvKey = utils.addHexPrefix(prvKey)
 
-  return { nonDecoupledAccount: Account.fromPrivate(prvKey), klaytnWalletKeyAddress }
+  return { legacyAccount: Account.fromPrivate(prvKey), klaytnWalletKeyAddress }
 }
 
 // The determineAddress function determines the priority of the parameters entered 
 // and returns the address that should be used for the account.
-Accounts.prototype.determineAddress = function determineAddress(nonDecoupledAccount, addressFromKey, userInputAddress) {
+Accounts.prototype.determineAddress = function determineAddress(legacyAccount, addressFromKey, userInputAddress) {
   if (userInputAddress) {
     if(addressFromKey && addressFromKey !== userInputAddress) {
       throw new Error('The address extracted from the private key does not match the address received as the input value.')
@@ -156,7 +156,7 @@ Accounts.prototype.determineAddress = function determineAddress(nonDecoupledAcco
     // If targetAddressRaw is undefined and address which is came from private is existed, set address in account.
     return addressFromKey
   }
-  return nonDecoupledAccount.address
+  return legacyAccount.address
 }
 
 Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, callback) {

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -161,7 +161,7 @@ Accounts.prototype.getLegacyAccount = function getLegacyAccount(key) {
 }
 
 /**
- * The determineAddress function determines the priority of the parameters entered and returns the address that should be used for the account.
+ * determineAddress determines the priority of the parameters entered and returns the address that should be used for the account.
  *
  * @method determineAddress
  * @param {Object} legacyAccount Account with legacy account key extracted from private key to be used for address determination.

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -109,8 +109,9 @@ Accounts.prototype.create = function create(entropy) {
     return this._addAccountFunctions(Account.create(entropy || utils.randomHex(32)));
 };
 
-Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey, targetAddressRaw) {
-  let {legacyAccount: account, klaytnWalletKeyAddress} = this.getLegacyAccount(privateKey)
+// The key parameter can be either normal private key or klaytnWalletKey format.
+Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(key, targetAddressRaw) {
+  let {legacyAccount: account, klaytnWalletKeyAddress} = this.getLegacyAccount(key)
 
   account.address = this.determineAddress(account, klaytnWalletKeyAddress, targetAddressRaw)
   account.address = account.address.toLowerCase()
@@ -119,21 +120,23 @@ Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey
   return this._addAccountFunctions(account)
 }
 
-Accounts.prototype.isDecoupled = function isDecoupled(privateKey, userInputAddress) {
-  let { legacyAccount, klaytnWalletKeyAddress } = this.getLegacyAccount(privateKey)
+// The key parameter can be either normal private key or klaytnWalletKey format.
+Accounts.prototype.isDecoupled = function isDecoupled(key, userInputAddress) {
+  let { legacyAccount, klaytnWalletKeyAddress } = this.getLegacyAccount(key)
   let actualAddress = this.determineAddress(legacyAccount, klaytnWalletKeyAddress, userInputAddress)
 
   return legacyAccount.address.toLowerCase() !== actualAddress.toLowerCase()
 }
 
-Accounts.prototype.getLegacyAccount = function getLegacyAccount(privateKey) {
-  var { privateKey: prvKey, address: klaytnWalletKeyAddress, isHumanReadable } = utils.parsePrivateKey(privateKey)
+// The key parameter can be either normal private key or klaytnWalletKey format.
+Accounts.prototype.getLegacyAccount = function getLegacyAccount(key) {
+  var { privateKey, address: klaytnWalletKeyAddress, isHumanReadable } = utils.parsePrivateKey(key)
 
-  if (!utils.isValidPrivateKey(prvKey)) throw new Error('Invalid private key')
+  if (!utils.isValidPrivateKey(privateKey)) throw new Error('Invalid private key')
 
-  prvKey = utils.addHexPrefix(prvKey)
+  privateKey = utils.addHexPrefix(privateKey)
 
-  return { legacyAccount: Account.fromPrivate(prvKey), klaytnWalletKeyAddress }
+  return { legacyAccount: Account.fromPrivate(privateKey), klaytnWalletKeyAddress }
 }
 
 // The determineAddress function determines the priority of the parameters entered 
@@ -559,7 +562,8 @@ Accounts.prototype.decrypt = function (v3Keystore, password, nonStrict) {
       "id":"dfde6a32-4b0e-404f-8b9f-2b18f279fe21",
     }
  */
-Accounts.prototype.encrypt = function (privateKey, password, options) {
+// The key parameter can be either normal private key or klaytnWalletKey format.
+Accounts.prototype.encrypt = function (key, password, options) {
     /**
      * options can include below
      * {
@@ -578,7 +582,7 @@ Accounts.prototype.encrypt = function (privateKey, password, options) {
      */
     options = options || {};
 
-    var account = this.privateKeyToAccount(privateKey, options.address);
+    var account = this.privateKeyToAccount(key, options.address);
 
     var salt = options.salt || cryp.randomBytes(32);
     var iv = options.iv || cryp.randomBytes(16);

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -110,7 +110,7 @@ Accounts.prototype.create = function create(entropy) {
 };
 
 /**
- * The privateKeyToAccount function creates and returns an Account through the input passed as parameters.
+ * privateKeyToAccount creates and returns an Account through the input passed as parameters.
  *
  * @method privateKeyToAccount
  * @param {String} key The key parameter can be either normal private key or klaytnWalletKey format.

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -591,7 +591,7 @@ Accounts.prototype.decrypt = function (v3Keystore, password, nonStrict) {
     }
  */
 /**
- * encrypt encrypts an account and returns key store.
+ * encrypt encrypts an account and returns a key store object.
  *
  * @method privateKeyToAccount
  * @param {String} key The key parameter can be either normal private key or KlaytnWalletKey format.

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -143,7 +143,7 @@ Accounts.prototype.isDecoupled = function isDecoupled(key, userInputAddress) {
 }
 
 /**
- * The getLegacyAccount function extracts the privateKey from the input key and returns an Account with the corresponding legacy account key.
+ * getLegacyAccount extracts the private key from the input key and returns an account with the corresponding legacy account key.
  * If the input key is KlaytnWalletKey format, it returns klaytnWalletKeyAddress, which is the address extracted from KlaytnWalletKey.
  *
  * @method getLegacyAccount

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -164,7 +164,7 @@ Accounts.prototype.getLegacyAccount = function getLegacyAccount(key) {
  * determineAddress determines the priority of the parameters entered and returns the address that should be used for the account.
  *
  * @method determineAddress
- * @param {Object} legacyAccount Account with legacy account key extracted from private key to be used for address determination.
+ * @param {Object} legacyAccount Account with a legacy account key extracted from private key to be used for address determination.
  * @param {String} addressFromKey Address extracted from key.
  * @param {String} userInputAddress Address passed as parameter by user.
  * @return {String}

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -128,7 +128,7 @@ Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(key, userI
 }
 
 /**
- * The isDecoupled function determines whether or not it is decoupled based on the input value.
+ * isDecoupled determines whether or not it is decoupled based on the input value.
  *
  * @method isDecoupled
  * @param {String} key The key parameter can be either normal private key or klaytnWalletKey format.

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -147,7 +147,7 @@ Accounts.prototype.isDecoupled = function isDecoupled(key, userInputAddress) {
  * If the input key is KlaytnWalletKey format, it returns klaytnWalletKeyAddress, which is the address extracted from KlaytnWalletKey.
  *
  * @method getLegacyAccount
- * @param {String} key The key parameter can be either normal private key or klaytnWalletKey format.
+ * @param {String} key The key parameter can be either normal private key or KlaytnWalletKey format.
  * @return {Object}
  */
 Accounts.prototype.getLegacyAccount = function getLegacyAccount(key) {

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -518,6 +518,8 @@ var sha3 = function (value) {
 sha3._Hash = Hash;
 
 function parsePrivateKey(privateKey) {
+  if (typeof privateKey !== 'string') throw new Error(`The private key must be of type string`)
+
   const has0xPrefix = privateKey.slice(0, 2) === '0x'
   privateKey = has0xPrefix ? privateKey.slice(2) : privateKey
 

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -627,6 +627,189 @@ describe('caver.klay.accounts.decrypt', () => {
   */
 })
 
+describe('caver.klay.accounts.getNonDecoupledAccount', () => {
+  context('CAVERJS-UNIT-WALLET-106 : input: valid privateKey', () => {
+    it('should return account which is derived from private key', () => {
+      const testAccount = caver.klay.accounts.create()
+      let result = caver.klay.accounts.getNonDecoupledAccount(testAccount.privateKey)
+
+      expect(result.klaytnWalletKeyAddress).to.equals('')
+      expect(result.nonDecoupledAccount.address).to.equals(testAccount.address)
+      expect(result.nonDecoupledAccount.privateKey).to.equals(testAccount.privateKey)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-107 : input: nonDecoupled valid KlaytnWalletKey format', () => {
+    it('should return account which is derived from private key and address from KlaytnWalletKey format', () => {
+      const testAccount = caver.klay.accounts.create()
+      let result = caver.klay.accounts.getNonDecoupledAccount(testAccount.getKlaytnWalletKey())
+
+      expect(result.klaytnWalletKeyAddress).to.equals(testAccount.address)
+      expect(result.nonDecoupledAccount.address).to.equals(result.klaytnWalletKeyAddress)
+      expect(result.nonDecoupledAccount.privateKey).to.equals(testAccount.privateKey)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-108 : input: decoupled valid KlaytnWalletKey format', () => {
+    it('should return account which is derived from private key and address from KlaytnWalletKey format', () => {
+      // decoupled
+      const testAccount = caver.klay.accounts.create()
+      testAccount.privateKey = caver.klay.accounts.create().privateKey
+
+      let result = caver.klay.accounts.getNonDecoupledAccount(testAccount.getKlaytnWalletKey())
+
+      expect(result.klaytnWalletKeyAddress).to.equals(testAccount.address)
+      expect(result.nonDecoupledAccount.address).not.to.equals(result.klaytnWalletKeyAddress)
+      expect(result.nonDecoupledAccount.privateKey).to.equals(testAccount.privateKey)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-109 : input: invalid privateKey', () => {
+    it('should throw error if input is invalid privateKey string', () => {
+      const expectedError = 'Invalid private key'
+
+      expect(() => caver.klay.accounts.getNonDecoupledAccount('0x')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount('1')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount('a')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140FF')).to.throws(expectedError)
+    })
+
+    it('should throw error if input is invalid privateKey type', () => {
+      const expectedError = 'The private key must be of type string'
+
+      expect(() => caver.klay.accounts.getNonDecoupledAccount(1234)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount({})).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount()).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount(undefined)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getNonDecoupledAccount(null)).to.throws(expectedError)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-110 : input: invalid KlaytnWalletKey format', () => {
+    it('should throw error if input is invalid KlaytnWalletKey string', () => {
+      const expectedError = 'Invalid private key'
+      expect(() => caver.klay.accounts.getNonDecoupledAccount(caver.klay.accounts.create().privateKey+'0x000x00')).to.throws(expectedError)
+    })
+  })
+})
+
+describe('caver.klay.accounts.isDecoupled', () => {
+  context('CAVERJS-UNIT-WALLET-111 : input: valid privateKey and decoupled address', () => {
+    it('should return true if input is decoupled private and address', () => {
+      const testAccount = caver.klay.accounts.create()
+      testAccount.privateKey = caver.klay.accounts.create().privateKey
+      expect(caver.klay.accounts.isDecoupled(testAccount.privateKey, testAccount.address)).to.be.true
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-112 : input: valid KlaytnWalletKey', () => {
+    it('should return true if input is decoupled KlaytnWalletKey', () => {
+      const testAccount = caver.klay.accounts.create()
+      testAccount.privateKey = caver.klay.accounts.create().privateKey
+      expect(caver.klay.accounts.isDecoupled(testAccount.getKlaytnWalletKey())).to.be.true
+      expect(caver.klay.accounts.isDecoupled(testAccount.getKlaytnWalletKey(), testAccount.address)).to.be.true
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-113 : input: valid privateKey', () => {
+    it('should return false if input is valid privateKey', () => {
+      expect(caver.klay.accounts.isDecoupled(caver.klay.accounts.create().privateKey)).to.be.false
+      expect(caver.klay.accounts.isDecoupled(caver.klay.accounts.create().privateKey.slice(2))).to.be.false
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-114 : input: valid KlaytnWalletKey', () => {
+    it('should return true if input is nonDecoupled KlaytnWalletKey', () => {
+      const testAccount = caver.klay.accounts.create()
+      expect(caver.klay.accounts.isDecoupled(testAccount.getKlaytnWalletKey())).to.be.false
+      expect(caver.klay.accounts.isDecoupled(testAccount.getKlaytnWalletKey(), testAccount.address)).to.be.false
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-115 : input: invalid privateKey', () => {
+    it('should throw error if input is invalid privateKey string', () => {
+      const expectedError = 'Invalid private key'
+
+      expect(() => caver.klay.accounts.isDecoupled('0x')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled('1')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled('a')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140FF')).to.throws(expectedError)
+    })
+
+    it('should throw error if input is invalid privateKey type', () => {
+      const expectedError = 'The private key must be of type string'
+
+      expect(() => caver.klay.accounts.isDecoupled(1234)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled({})).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled()).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled(undefined)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.isDecoupled(null)).to.throws(expectedError)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-116 : input: not match address with KlaytnWalletKey and input', () => {
+    it('should throw error if input is invalid privateKey string', () => {
+      const testAccount = caver.klay.accounts.create()
+      testAccount.privateKey = caver.klay.accounts.create().privateKey
+
+      const expectedError = 'The address extracted from the private key does not match the address received as the input value.'
+
+      expect(() => caver.klay.accounts.isDecoupled(testAccount.getKlaytnWalletKey(), caver.klay.accounts.create().address)).to.throws(expectedError)
+    })
+  })
+})
+
+describe('caver.klay.accounts.determineAddress', () => {
+  context('CAVERJS-UNIT-WALLET-117 : input: valid nonDecoupledAccount', () => {
+    it('should return address of nonDecoupledAccount', () => {
+      const testAccount = caver.klay.accounts.create()
+      
+      expect(caver.klay.accounts.determineAddress(testAccount)).to.equals(testAccount.address)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-118 : input: valid nonDecoupledAccount and addressFromKey', () => {
+    it('should return address of account', () => {
+      const testAccount = caver.klay.accounts.create()
+      const addressFromKey = caver.klay.accounts.create().address
+      
+      expect(caver.klay.accounts.determineAddress(testAccount, addressFromKey)).to.equals(addressFromKey)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-119 : input: valid nonDecoupledAccount, addressFromKey and userInputAddress', () => {
+    it('should return address of account', () => {
+      const testAccount = caver.klay.accounts.create()
+      const addressFromKey = ''
+      const userInputAddress = caver.klay.accounts.create().address
+      
+      expect(caver.klay.accounts.determineAddress(testAccount, addressFromKey, userInputAddress)).to.equals(userInputAddress)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-120 : input: valid nonDecoupledAccount, addressFromKey and userInputAddress', () => {
+    it('should return address of account', () => {
+      const testAccount = caver.klay.accounts.create()
+      const addressFromKey = caver.klay.accounts.create().address
+      const userInputAddress = addressFromKey
+      
+      expect(caver.klay.accounts.determineAddress(testAccount, addressFromKey, userInputAddress)).to.equals(userInputAddress)
+    })
+  })
+
+  context('CAVERJS-UNIT-WALLET-121 : input: valid nonDecoupledAccount, addressFromKey and userInputAddress', () => {
+    it('should throw error if addressFromKey and userInputAddress is not matched', () => {
+      const testAccount = caver.klay.accounts.create()
+      const addressFromKey = caver.klay.accounts.create().address
+      const userInputAddress = caver.klay.accounts.create().address
+
+      const expectedError = 'The address extracted from the private key does not match the address received as the input value.'
+      
+      expect(() => caver.klay.accounts.determineAddress(testAccount, addressFromKey, userInputAddress)).to.throws(expectedError)
+    })
+  })
+})
+
 describe('caver.klay.accounts.wallet', () => {
 
   it('CAVERJS-UNIT-WALLET-043 : should return valid wallet instance', () => {

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -627,26 +627,26 @@ describe('caver.klay.accounts.decrypt', () => {
   */
 })
 
-describe('caver.klay.accounts.getNonDecoupledAccount', () => {
+describe('caver.klay.accounts.getLegacyAccount', () => {
   context('CAVERJS-UNIT-WALLET-106 : input: valid privateKey', () => {
     it('should return account which is derived from private key', () => {
       const testAccount = caver.klay.accounts.create()
-      let result = caver.klay.accounts.getNonDecoupledAccount(testAccount.privateKey)
+      let result = caver.klay.accounts.getLegacyAccount(testAccount.privateKey)
 
       expect(result.klaytnWalletKeyAddress).to.equals('')
-      expect(result.nonDecoupledAccount.address).to.equals(testAccount.address)
-      expect(result.nonDecoupledAccount.privateKey).to.equals(testAccount.privateKey)
+      expect(result.legacyAccount.address).to.equals(testAccount.address)
+      expect(result.legacyAccount.privateKey).to.equals(testAccount.privateKey)
     })
   })
 
   context('CAVERJS-UNIT-WALLET-107 : input: nonDecoupled valid KlaytnWalletKey format', () => {
     it('should return account which is derived from private key and address from KlaytnWalletKey format', () => {
       const testAccount = caver.klay.accounts.create()
-      let result = caver.klay.accounts.getNonDecoupledAccount(testAccount.getKlaytnWalletKey())
+      let result = caver.klay.accounts.getLegacyAccount(testAccount.getKlaytnWalletKey())
 
       expect(result.klaytnWalletKeyAddress).to.equals(testAccount.address)
-      expect(result.nonDecoupledAccount.address).to.equals(result.klaytnWalletKeyAddress)
-      expect(result.nonDecoupledAccount.privateKey).to.equals(testAccount.privateKey)
+      expect(result.legacyAccount.address).to.equals(result.klaytnWalletKeyAddress)
+      expect(result.legacyAccount.privateKey).to.equals(testAccount.privateKey)
     })
   })
 
@@ -656,11 +656,11 @@ describe('caver.klay.accounts.getNonDecoupledAccount', () => {
       const testAccount = caver.klay.accounts.create()
       testAccount.privateKey = caver.klay.accounts.create().privateKey
 
-      let result = caver.klay.accounts.getNonDecoupledAccount(testAccount.getKlaytnWalletKey())
+      let result = caver.klay.accounts.getLegacyAccount(testAccount.getKlaytnWalletKey())
 
       expect(result.klaytnWalletKeyAddress).to.equals(testAccount.address)
-      expect(result.nonDecoupledAccount.address).not.to.equals(result.klaytnWalletKeyAddress)
-      expect(result.nonDecoupledAccount.privateKey).to.equals(testAccount.privateKey)
+      expect(result.legacyAccount.address).not.to.equals(result.klaytnWalletKeyAddress)
+      expect(result.legacyAccount.privateKey).to.equals(testAccount.privateKey)
     })
   })
 
@@ -668,27 +668,27 @@ describe('caver.klay.accounts.getNonDecoupledAccount', () => {
     it('should throw error if input is invalid privateKey string', () => {
       const expectedError = 'Invalid private key'
 
-      expect(() => caver.klay.accounts.getNonDecoupledAccount('0x')).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount('1')).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount('a')).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140FF')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount('0x')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount('1')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount('a')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140FF')).to.throws(expectedError)
     })
 
     it('should throw error if input is invalid privateKey type', () => {
       const expectedError = 'The private key must be of type string'
 
-      expect(() => caver.klay.accounts.getNonDecoupledAccount(1234)).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount({})).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount()).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount(undefined)).to.throws(expectedError)
-      expect(() => caver.klay.accounts.getNonDecoupledAccount(null)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount(1234)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount({})).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount()).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount(undefined)).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount(null)).to.throws(expectedError)
     })
   })
 
   context('CAVERJS-UNIT-WALLET-110 : input: invalid KlaytnWalletKey format', () => {
     it('should throw error if input is invalid KlaytnWalletKey string', () => {
       const expectedError = 'Invalid private key'
-      expect(() => caver.klay.accounts.getNonDecoupledAccount(caver.klay.accounts.create().privateKey+'0x000x00')).to.throws(expectedError)
+      expect(() => caver.klay.accounts.getLegacyAccount(caver.klay.accounts.create().privateKey+'0x000x00')).to.throws(expectedError)
     })
   })
 })


### PR DESCRIPTION
## Proposed changes

Implement isDecoupled, getLegacyAccount, determineAddress functions in Account package.

**isDecoupled** function will be used for checking possibility of signing with legacy transaction.

And there are few duplicated logic between privateKeyToAccount and isDecoupled function, so getLegacyAccount and determineAddress functions are implemented for preventing duplicate code.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
