### PR TITLE
Throw error when sign legacy tx with decoupled account

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -193,6 +193,7 @@ Accounts.prototype.determineAddress = function determineAddress(legacyAccount, a
 Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, callback) {
     var _this = this,
         error = false,
+        isLegacy = false,
         result
 
     callback = callback || function () {}
@@ -214,6 +215,10 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
 
       if (!tx.senderRawTransaction) {
         error = helpers.validateFunction.validateParams(tx)
+        
+        // Attempting to sign with decoupled account into a legacy type transaction throw an error.
+        isLegacy = tx.type === undefined || tx.type === 'LEGACY' ? true : false
+        if (isLegacy && _this.isDecoupled(privateKey, tx.from)) throw new Error('A legacy transaction must be with a legacy account key')
       }
       if (error) {
         callback(error);

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -137,20 +137,19 @@ describe('caver.klay.accounts.privateKeyToAccount', () => {
 })
 
 describe('caver.klay.accounts.signTransaction', () => {
-  const txObj = {
-    from: setting.toAddress,
-    nonce: '0x0',
-    to: setting.toAddress,
-    gas: setting.gas,
-    gasPrice: setting.gasPrice,
-    value: '0x1',
-    chainId: 2019,
-  }
-
-  let account
+  let txObj, account
 
   beforeEach(() => {
     account = caver.klay.accounts.create()
+    txObj = {
+      from: account.address,
+      nonce: '0x0',
+      to: setting.toAddress,
+      gas: setting.gas,
+      gasPrice: setting.gasPrice,
+      value: '0x1',
+      chainId: 2019,
+    }
   })
 
   context('CAVERJS-UNIT-WALLET-023 : input: tx, privateKey', () => {
@@ -276,6 +275,25 @@ describe('caver.klay.accounts.signTransaction', () => {
       expect(result.senderTxHash).to.equal('0x1b7c0f2fc7548056e90d9690e8c397acf99eb38e622ac91ee22c2085065f8a55')
     })
   })
+
+  context('CAVERJS-UNIT-WALLET-122 : input: legacyTx, privateKey of decoupled account', () => {
+    it('should return signature and rawTransaction', () => {
+      const decoupledAccount = caver.klay.accounts.create()
+      decoupledAccount.privateKey = caver.klay.accounts.create().privateKey
+
+      let tx = {
+        from: decoupledAccount.address,
+        nonce: '0x0',
+        to: setting.toAddress,
+        gas: setting.gas,
+        gasPrice: setting.gasPrice,
+        value: '0x1',
+        chainId: 2019,
+      }
+
+      expect(()=>caver.klay.accounts.signTransaction(tx, decoupledAccount.privateKey)).to.throws('A legacy transaction must be with a legacy account key')
+    })
+  })
 })
 
 describe('caver.klay.accounts.recoverTransaction', () => {
@@ -286,7 +304,7 @@ describe('caver.klay.accounts.recoverTransaction', () => {
     account = caver.klay.accounts.create()
 
     const txObj = {
-      from: setting.fromAddress,
+      from: account.address,
       nonce: '0x0',
       to: setting.toAddress,
       gas: setting.gas,


### PR DESCRIPTION
## Proposed changes

Implement throw error logic when user try to sign legacy transaction with decoupled account.
"CAVERJS-UNIT-WALLET-122" is test case for this.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

Some integeration test case should be modified. (CAVER-INT-LEGACY-002, CAVER-INT-LEGACY-019)
refer https://github.com/klaytn/klaytn-integration-tests/pull/3