### PR TITLE
Tidy up error handling code in signTransaction

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -327,9 +327,8 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
             // If wallet was found, sign tx, and send using sendRawTransaction
             return method.accounts.signTransaction(tx, wallet.privateKey)
                 .then(sendSignedTx)
-                .catch((e)=>{
+                .catch((e) => {
                   sendTxCallback(e)
-                  return Promise.reject(e)
                 })
           }
           

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -239,8 +239,8 @@ describe('caver.klay.accounts.signTransaction', () => {
 
       const errorMessage = 'Invalid private key'
 
-      expect(() => caver.klay.accounts.signTransaction(txObj, invalidPrivateKey))
-        .to.throw(errorMessage)
+      expect(caver.klay.accounts.signTransaction(txObj, invalidPrivateKey))
+        .to.be.rejectedWith(errorMessage)
     })
   })
 
@@ -291,7 +291,8 @@ describe('caver.klay.accounts.signTransaction', () => {
         chainId: 2019,
       }
 
-      expect(()=>caver.klay.accounts.signTransaction(tx, decoupledAccount.privateKey)).to.throws('A legacy transaction must be with a legacy account key')
+      expect(caver.klay.accounts.signTransaction(tx, decoupledAccount.privateKey))
+        .to.be.rejectedWith('A legacy transaction must be with a legacy account key')
     })
   })
 })


### PR DESCRIPTION
## Proposed changes

Tidy up error handling code in signTransaction for avoiding "UnhandledPromiseRejectionWarning"

1. Remove unnecessary reject statement in packages/caver-core-method/src/index.js file.
    Already return statement is called with above, so it seems like does't need to for handling error.
    And that cause keep warning error is handled though

2. Change error handling logic in signTransaction.
    Only few logic throw error in that function, so change logic to use same error handling strategy

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
