### PR TITLE
Rename determineAddress to _determineAddress

### DIFF
--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -778,57 +778,6 @@ describe('caver.klay.accounts.isDecoupled', () => {
   })
 })
 
-describe('caver.klay.accounts.determineAddress', () => {
-  context('CAVERJS-UNIT-WALLET-117 : input: valid nonDecoupledAccount', () => {
-    it('should return address of nonDecoupledAccount', () => {
-      const testAccount = caver.klay.accounts.create()
-      
-      expect(caver.klay.accounts.determineAddress(testAccount)).to.equals(testAccount.address)
-    })
-  })
-
-  context('CAVERJS-UNIT-WALLET-118 : input: valid nonDecoupledAccount and addressFromKey', () => {
-    it('should return address of account', () => {
-      const testAccount = caver.klay.accounts.create()
-      const addressFromKey = caver.klay.accounts.create().address
-      
-      expect(caver.klay.accounts.determineAddress(testAccount, addressFromKey)).to.equals(addressFromKey)
-    })
-  })
-
-  context('CAVERJS-UNIT-WALLET-119 : input: valid nonDecoupledAccount, addressFromKey and userInputAddress', () => {
-    it('should return address of account', () => {
-      const testAccount = caver.klay.accounts.create()
-      const addressFromKey = ''
-      const userInputAddress = caver.klay.accounts.create().address
-      
-      expect(caver.klay.accounts.determineAddress(testAccount, addressFromKey, userInputAddress)).to.equals(userInputAddress)
-    })
-  })
-
-  context('CAVERJS-UNIT-WALLET-120 : input: valid nonDecoupledAccount, addressFromKey and userInputAddress', () => {
-    it('should return address of account', () => {
-      const testAccount = caver.klay.accounts.create()
-      const addressFromKey = caver.klay.accounts.create().address
-      const userInputAddress = addressFromKey
-      
-      expect(caver.klay.accounts.determineAddress(testAccount, addressFromKey, userInputAddress)).to.equals(userInputAddress)
-    })
-  })
-
-  context('CAVERJS-UNIT-WALLET-121 : input: valid nonDecoupledAccount, addressFromKey and userInputAddress', () => {
-    it('should throw error if addressFromKey and userInputAddress is not matched', () => {
-      const testAccount = caver.klay.accounts.create()
-      const addressFromKey = caver.klay.accounts.create().address
-      const userInputAddress = caver.klay.accounts.create().address
-
-      const expectedError = 'The address extracted from the private key does not match the address received as the input value.'
-      
-      expect(() => caver.klay.accounts.determineAddress(testAccount, addressFromKey, userInputAddress)).to.throws(expectedError)
-    })
-  })
-})
-
 describe('caver.klay.accounts.wallet', () => {
 
   it('CAVERJS-UNIT-WALLET-043 : should return valid wallet instance', () => {


### PR DESCRIPTION
## Proposed changes

I renamed determineAddress to _determineAddress, because determineAddress is used for inside logic.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
