### PR TITLE
Allow a custom client configuration on WS connection

### DIFF
--- a/packages/caver-core-requestmanager/caver-providers-ws/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-ws/src/index.js
@@ -76,8 +76,12 @@ var WebsocketProvider = function WebsocketProvider(url, options)  {
         headers.authorization = 'Basic ' + _btoa(parsedURL.username + ':' + parsedURL.password);
     }
 
-    this.connection = new Ws(url, protocol, undefined, headers);
-    this.reconnect = () => new Ws(url, protocol, undefined, headers);
+    // Allow a custom client configuration
+    var clientConfig = options.clientConfig || undefined;
+
+    this.connection = new Ws(url, protocol, undefined, headers, undefined, clientConfig);
+    this.reconnect = () => new Ws(url, protocol, undefined, headers, undefined, clientConfig);
+
 
     this.addDefaultEvents();
 


### PR DESCRIPTION
## Proposed changes

This commit provides custom client configuration way to WS connection.

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)

## Further comments

It prevent disconnection from large response on WS connection. by configuring `maxReceivedFrameSize`

```
klay.getBlock(7944514,true) // baobab // Response contains larger than 0x100000(default) bytes
```