### PR TITLE
Add data 0x prefix formatter for signTransaction

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -164,8 +164,8 @@ var inputTransactionFormatter = function (options) {
         options.from = inputAddressFormatter(options.from);
     }
 
-    if (options.data && options.data.slice(0, 2) !== '0x') {
-      options.data = '0x' + options.data
+    if (options.data) {
+      options.data = utils.addHexPrefix(options.data)
     }
 
     const err = validateParams(options)
@@ -198,8 +198,8 @@ var inputPersonalTransactionFormatter = function (options) {
       options.from = inputAddressFormatter(options.from);
   }
 
-  if (options.data && options.data.slice(0, 2) !== '0x') {
-    options.data = '0x' + options.data
+  if (options.data) {
+    options.data = utils.addHexPrefix(options.data)
   }
   
   return options;

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -53,7 +53,7 @@ var isNot = function(value) {
 function coverInitialTxValue(tx) {
   if (typeof tx !== 'object') throw ('Invalid transaction')
   tx.to = tx.to || '0x'
-  tx.data = tx.data || '0x'
+  tx.data = utils.addHexPrefix(tx.data || '0x')
   tx.chainId = utils.numberToHex(tx.chainId)
   return tx
 }

--- a/test/transactionType/contractDeploy.js
+++ b/test/transactionType/contractDeploy.js
@@ -330,4 +330,23 @@ describe('SMART_CONTRACT_DEPLOY transaction', () => {
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"to" cannot be used with SMART_CONTRACT_DEPLOY transaction')
   }).timeout(200000)
+  
+  it('CAVERJS-UNIT-TX-577: If data field of transaction is not 0x-hex prefixed, signTransaction should formatting and sign', async() => {
+    deployObject.data = caver.utils.stripHexPrefix(deployObject.data)
+    expect(deployObject.data.slice(0, 2) !== '0x').to.be.true
+
+    let { rawTransaction } = await caver.klay.accounts.signTransaction(deployObject, senderPrvKey)
+    const receipt = await caver.klay.sendSignedTransaction(rawTransaction)
+
+    expect(receipt.status).to.be.true
+  }).timeout(200000)
+  
+  it('CAVERJS-UNIT-TX-578: If data field of transaction is not 0x-hex prefixed, sendTransaction should formatting and sign', async() => {
+    deployObject.data = caver.utils.stripHexPrefix(deployObject.data)
+    expect(deployObject.data.slice(0, 2) !== '0x').to.be.true
+
+    const receipt = await caver.klay.sendTransaction(deployObject)
+
+    expect(receipt.status).to.be.true
+  }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedContractDeploy.js
+++ b/test/transactionType/feeDelegatedContractDeploy.js
@@ -24,21 +24,25 @@ const testRPCURL = require('../testrpc')
 const Caver = require('../../index.js')
 
 let caver
-var senderPrvKey
-var senderAddress
+var senderPrvKey, payerPrvKey
+var senderAddress, payerAddress
 var testAccount
 
 before(() => {
   caver = new Caver(testRPCURL)
-  if (process.env.privateKey) {
+  if (process.env.privateKey && process.env.privateKey2) {
     senderPrvKey = process.env.privateKey && String(process.env.privateKey).indexOf('0x') === -1
       ? '0x' + process.env.privateKey
       : process.env.privateKey
+      payerPrvKey = process.env.privateKey2 && String(process.env.privateKey2).indexOf('0x') === -1
+      ? '0x' + process.env.privateKey2
+      : process.env.privateKey2
 
-    caver.klay.accounts.wallet.add(senderPrvKey)
+    const sender = caver.klay.accounts.wallet.add(senderPrvKey)
+    const payer = caver.klay.accounts.wallet.add(payerPrvKey)
   
-    const sender = caver.klay.accounts.privateKeyToAccount(senderPrvKey)
     senderAddress = sender.address
+    payerAddress = payer.address
   } else {
     const sender = caver.klay.accounts.wallet.add(caver.klay.accounts.create())
     senderPrvKey = sender.privateKey
@@ -327,5 +331,19 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction', () => {
     const tx = Object.assign({to: "0x5e008646fde91fb6eda7b1fdabc7d84649125cf5"}, deployObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"to" cannot be used with FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction')
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-579: If data field of transaction is not 0x-hex prefixed, signTransaction should formatting and sign', async() => {
+    deployObject.data = caver.utils.stripHexPrefix(deployObject.data)
+    expect(deployObject.data.slice(0, 2) !== '0x').to.be.true
+
+    let { rawTransaction } = await caver.klay.accounts.signTransaction(deployObject, senderPrvKey)
+
+    const receipt = await caver.klay.sendTransaction({
+      senderRawTransaction: rawTransaction,
+      feePayer: payerAddress
+    })
+
+    expect(receipt.status).to.be.true
   }).timeout(200000)
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces adding formatter for data filed for handling when data filed is not 0x hex prefixed.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
