### PR TITLE
Add logic in resolveRawKeyToAccountKey

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/transactionType/account.js
+++ b/packages/caver-klay/caver-klay-accounts/src/transactionType/account.js
@@ -138,6 +138,14 @@ function rlpEncodeForFeeDelegatedAccountUpdateWithRatio(transaction) {
 }
 
 function resolveRawKeyToAccountKey(transaction) {
+  // Handles the case where AccountForUpdate is set in key field in transaction object to update account.
+  if (transaction.key) {
+    if (transaction.from && transaction.from.toLowerCase() !== transaction.key.address.toLowerCase()) {
+      throw new Error(`The value of the from field of the transaction does not match the address of AccountForUpdate.`)
+    }
+    transaction.key.fillUpdateObject(transaction)
+  }
+
   if (!!transaction.legacyKey) return ACCOUNT_KEY_LEGACY_TAG
   if (!!transaction.failKey) return ACCOUNT_KEY_FAIL_TAG
   
@@ -167,17 +175,20 @@ function resolveRawKeyToAccountKey(transaction) {
   }
   
   if (transaction.roleTransactionKey || transaction.roleAccountUpdateKey || transaction.roleFeePayerKey) {
-    transaction.roleTransactionKey = transaction.roleTransactionKey
+    // Create a new object so as not to damage the input transaction object.
+    const roleBasedObject = {}
+
+    roleBasedObject.roleTransactionKey = transaction.roleTransactionKey
       ? resolveRawKeyToAccountKey(transaction.roleTransactionKey) 
       : ACCOUNT_KEY_NIL_TAG
-    transaction.roleAccountUpdateKey = transaction.roleAccountUpdateKey 
+    roleBasedObject.roleAccountUpdateKey = transaction.roleAccountUpdateKey 
       ? resolveRawKeyToAccountKey(transaction.roleAccountUpdateKey)
       : ACCOUNT_KEY_NIL_TAG
-    transaction.roleFeePayerKey = transaction.roleFeePayerKey 
+    roleBasedObject.roleFeePayerKey = transaction.roleFeePayerKey 
       ? resolveRawKeyToAccountKey(transaction.roleFeePayerKey) 
       : ACCOUNT_KEY_NIL_TAG
     
-    var keys = [transaction.roleTransactionKey, transaction.roleAccountUpdateKey, transaction.roleFeePayerKey]
+    var keys = [roleBasedObject.roleTransactionKey, roleBasedObject.roleAccountUpdateKey, roleBasedObject.roleFeePayerKey]
     return ACCOUNT_KEY_ROLE_BASED_TAG + RLP.encode(keys).slice(2)
   }
   


### PR DESCRIPTION
## Proposed changes

This PR introduces the logic to handle the case where AccountForUpdate is set in the key field in the transaction object for account update.

And in case of roleBased, new object for key setting is created to prevent modify to the transaction object which is received as input value.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
