### PR TITLE
Modify isCompressedPublicKey to handle without '0x' prefix case

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -668,7 +668,8 @@ const isValidPublicKey = (publicKey) => {
 
 const isCompressedPublicKey = (publicKey) => {
   const compressedIndicators = ['02', '03']
-  return publicKey.replace('0x', '').length === 66 && compressedIndicators.includes(publicKey.slice(2, 4))
+  const withoutPrefix = publicKey.replace('0x', '')
+  return withoutPrefix.length === 66 && compressedIndicators.includes(withoutPrefix.slice(0, 2))
 }
 
 const compressPublicKey = (uncompressedPublicKey) => {

--- a/test/isCompressedPublicKey.js
+++ b/test/isCompressedPublicKey.js
@@ -32,6 +32,9 @@ describe('caver.utils.isCompressedPublicKey', (done) => {
     expect(caver.utils.isCompressedPublicKey(uncompressedPublicKey1)).to.false
     expect(caver.utils.isCompressedPublicKey(uncompressedPublicKey2)).to.false
     expect(caver.utils.isCompressedPublicKey(uncompressedPublicKey3)).to.false
+    expect(caver.utils.isCompressedPublicKey(uncompressedPublicKey1.slice(2))).to.false
+    expect(caver.utils.isCompressedPublicKey(uncompressedPublicKey2.slice(2))).to.false
+    expect(caver.utils.isCompressedPublicKey(uncompressedPublicKey3.slice(2))).to.false
   })
   
   it('CAVERJS-UNIT-SER-026 : Should return true if the argument is compressed public key', () => {
@@ -45,5 +48,8 @@ describe('caver.utils.isCompressedPublicKey', (done) => {
     expect(caver.utils.isCompressedPublicKey(compressedPublicKey1)).to.true
     expect(caver.utils.isCompressedPublicKey(compressedPublicKey2)).to.true
     expect(caver.utils.isCompressedPublicKey(compressedPublicKey3)).to.true
+    expect(caver.utils.isCompressedPublicKey(compressedPublicKey1.slice(2))).to.true
+    expect(caver.utils.isCompressedPublicKey(compressedPublicKey2.slice(2))).to.true
+    expect(caver.utils.isCompressedPublicKey(compressedPublicKey3.slice(2))).to.true
   })
 })

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -1024,3 +1024,56 @@ describe('caver.utils.xyPointFromPublicKey', () => {
     expect(xyPoint4[1]).to.equals('0x50047c5aea3c2f55de7de04203f8fe8ccc3b491029338d038a7ef6d6903b302e')
   })
 })
+
+describe('caver.utils.isValidPublicKey', () => {
+  it('CAVERJS-UNIT-ETC-171: caver.utils.isValidPublicKey should true with valid uncompressed public key', ()=>{
+    const account = caver.klay.accounts.create()
+    
+    const unCompressedPublicKey = caver.klay.accounts.privateKeyToPublicKey(account.privateKey)
+    
+    let isValid = caver.utils.isValidPublicKey(unCompressedPublicKey)
+    expect(isValid).to.be.true
+  })
+
+  it('CAVERJS-UNIT-ETC-172: caver.utils.isValidPublicKey should true with valid compressed public key', ()=>{
+    const account = caver.klay.accounts.create()
+    
+    const unCompressedPublicKey = caver.klay.accounts.privateKeyToPublicKey(account.privateKey)
+    const compressed = caver.utils.compressPublicKey(unCompressedPublicKey)
+    
+    let isValid = caver.utils.isValidPublicKey(compressed)
+    expect(isValid).to.be.true
+  })
+
+  it('CAVERJS-UNIT-ETC-173: caver.utils.isValidPublicKey should false with invalid uncompressed public key', ()=>{
+    const account = caver.klay.accounts.create()
+    
+    const unCompressedPublicKey = caver.klay.accounts.privateKeyToPublicKey(account.privateKey)
+    
+    let isValid = caver.utils.isValidPublicKey(unCompressedPublicKey.slice(1))
+    expect(isValid).to.be.false
+  })
+
+  it('CAVERJS-UNIT-ETC-174: caver.utils.isValidPublicKey should false with invalid compressed public key', ()=>{
+    const account = caver.klay.accounts.create()
+    
+    const unCompressedPublicKey = caver.klay.accounts.privateKeyToPublicKey(account.privateKey)
+    const compressed = caver.utils.compressPublicKey(unCompressedPublicKey)
+    
+    let isValid = caver.utils.isValidPublicKey(compressed.slice(1))
+    expect(isValid).to.be.false
+  })
+
+  it('CAVERJS-UNIT-ETC-175: caver.utils.isValidPublicKey should false with invalid indicated compressed public key', ()=>{
+    const account = caver.klay.accounts.create()
+    
+    const unCompressedPublicKey = caver.klay.accounts.privateKeyToPublicKey(account.privateKey)
+    let compressed = caver.utils.compressPublicKey(unCompressedPublicKey)
+    compressed = compressed.replace('0x', '')
+    compressed = compressed.slice(2)
+    compressed = '05' + compressed
+
+    let isValid = caver.utils.isValidPublicKey(compressed)
+    expect(isValid).to.be.false
+  })
+})


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of isCompressedPublicKey to handle without '0x' prefix case.

And also test case for isValidPublicKey is added.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
