### PR TITLE
Modified formatter for default address

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -474,6 +474,8 @@ var outputPostFormatter = function(post){
 };
 
 var inputAddressFormatter = function (address) {
+    // For handling coverInitialTxValue to value
+    if (address === '0x') return address
 
     var iban = new utils.Iban(address);
     if (iban.isValid() && iban.isDirect()) {


### PR DESCRIPTION
## Proposed changes

This PR introduces modification for default address in formatter.

When a contract deploy transaction wants to sign an RLP-encoded raw string, decode the string and return '0x' in the to field.
In such cases, the current logic throws an error with an invalid address.

An if statement has been added to handle this.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
