### PR TITLE
Implemented functions for extract signatures and split fee payer

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/makeRawTransaction.js
+++ b/packages/caver-klay/caver-klay-accounts/src/makeRawTransaction.js
@@ -189,7 +189,7 @@ function extractSignatures(rawTransaction) {
   return { senderSignatures, feePayerSignatures, decodedTransaction: decoded }
 }
 
-function decodeTxForFeePayer(rawTransaction) {
+function splitFeePayer(rawTransaction) {
   const typeString = utils.getTxTypeStringFromRawTransaction(rawTransaction)
   
   if (!typeString || !typeString.includes('FEE_DELEGATED')) throw new Error(`The RLP encoded transaction is not a fee delegated transaction type: '${typeString? typeString : 'LEGACY'}'`)
@@ -361,6 +361,6 @@ module.exports = {
   decodeFromRawTransaction,
   overwriteSignature,
   getSenderTxHash,
-  decodeTxForFeePayer,
+  splitFeePayer,
   extractSignatures,
 }

--- a/packages/caver-klay/caver-klay-accounts/src/makeRawTransaction.js
+++ b/packages/caver-klay/caver-klay-accounts/src/makeRawTransaction.js
@@ -190,6 +190,10 @@ function extractSignatures(rawTransaction) {
 }
 
 function decodeTxForFeePayer(rawTransaction) {
+  const typeString = utils.getTxTypeStringFromRawTransaction(rawTransaction)
+  
+  if (!typeString || !typeString.includes('FEE_DELEGATED')) throw new Error(`The RLP encoded transaction is not a fee delegated transaction type: '${typeString? typeString : 'LEGACY'}'`)
+
   const txType = rawTransaction.slice(0, 4)
   const decodedValues = RLP.decode(utils.addHexPrefix(rawTransaction.slice(4)))
 

--- a/packages/caver-klay/caver-klay-accounts/src/makeRawTransaction.js
+++ b/packages/caver-klay/caver-klay-accounts/src/makeRawTransaction.js
@@ -213,7 +213,6 @@ function decodeFromRawTransaction (rawTransaction, type) {
   return decodeResult
 }
 
-
 function _decodeFromRawTransaction(rawTransaction, type) {
   var typeString = type
   if (typeString === undefined || typeString !== 'LEGACY') {


### PR DESCRIPTION
## Proposed changes

This PR introduces new functions in makeRawTransaciton.js file named 'extractSignatures' and 'splitFeePayer'.

extractSignatures function extracts signatures and feePayerSignatures from rawTransaction.
splitFeePayer function deocde rawTransaction and make fee payer tx format.

And also deocdeRawTransaction function is modified to call _decodeFromRawTransaction.
Because when combine raw transaction string(not included in this PR), transaction have to compare with other transaction string.
For easier comparison, _decodeFromRawTransaction returns string format of accountKey without parsing.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
