### PR TITLE
Modification of validateParams function

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -471,9 +471,6 @@ var outputPostFormatter = function(post){
 };
 
 var inputAddressFormatter = function (address) {
-    // For handling coverInitialTxValue to value
-    if (address === '0x') return address
-
     var iban = new utils.Iban(address);
     if (iban.isValid() && iban.isDirect()) {
         return iban.toAddress().toLowerCase();

--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -140,12 +140,9 @@ var inputTransactionFormatter = function (options) {
 
     options = _txInputFormatter(options);
 
-    // If 'feePayer' or 'senderRawTransaction' exist in transaction, it means it doesn't need 'from' field.
-    if (options.feePayer || options.senderRawTransaction) {
-      if (options.senderRawTransaction === undefined) {
-        throw new Error('The "senderRawTransaction" field must be defined for signing with feePayer!');
-      }
-
+    // If senderRawTransaction' exist in transaction, it means object is fee payer transaction format like below
+    // { senderRawTransaction: '', feePayer: '' }
+    if (options.senderRawTransaction) {
       if (options.feePayer === undefined) {
         throw new Error('The "feePayer" field must be defined for signing with feePayer!');
       }

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -232,11 +232,8 @@ Accounts.prototype.signTransaction = function signTransaction() {
     // For handling when callback is undefined.
     callback = callback || function () {}
 
-    // Validate tx object
-    if (!tx.senderRawTransaction) {
-      const error = helpers.validateFunction.validateParams(tx)
-      if (error) return handleError(error)
-    } else if (!tx.feePayer) { return handleError('To sign with fee payer, senderRawTransaction and feePayer must be defined in the transaction object.') }
+    let error = helpers.validateFunction.validateParams(tx)
+    if (error) return handleError(error)
 
     // When privateKey is undefined, find Account from Wallet.
     if (privateKey === undefined) {
@@ -367,9 +364,7 @@ Accounts.prototype.signTransactionWithSignature = function signTransactionWithSi
     }
 
     function signed(tx) {
-      if (!tx.senderRawTransaction) {
-        error = helpers.validateFunction.validateParams(tx)
-      }
+      error = helpers.validateFunction.validateParams(tx)
       if (error) {
         callback(error)
         return Promise.reject(error)
@@ -1106,7 +1101,7 @@ Wallet.prototype.getAccount = function (input) {
     return this[input]
   }
 
-  if (!_.isString(input)) throw new Error(`Accounts in the Wallet can be searched by only index or address.`)
+  if (!_.isString(input)) throw new Error(`Accounts in the Wallet can be searched by only index or address. :${input}`)
 
   if (!utils.isAddress(input)) throw new Error(`Failed to getAccount from Wallet: invalid address(${input})`)
 

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -429,7 +429,7 @@ describe('caver.klay.accounts.signTransaction', () => {
         senderRawTransaction: senderSigned.rawTransaction,
       }
 
-      const errorMessage = 'To sign with fee payer, senderRawTransaction and feePayer must be defined in the transaction object.'
+      const errorMessage = `Invalid fee payer: ${feePayerTransaction.feePayer}`
       await expect(caver.klay.accounts.signTransaction(feePayerTransaction)).to.be.rejectedWith(errorMessage)
     })
   })

--- a/test/transactionType/accountUpdate.js
+++ b/test/transactionType/accountUpdate.js
@@ -1574,4 +1574,42 @@ describe('ACCOUNT_UPDATE transaction', () => {
     // Throw error from formatter validation
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('The key parameter to be used for ACCOUNT_UPDATE is duplicated.')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-588: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-588: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-589: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey, feePayerSignatures: [['0x01', '0x', '0x']]}, accountUpdateObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-589: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({publicKey, feePayerSignatures: [['0x01', '0x', '0x']]}, accountUpdateObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/cancelTransaction.js
+++ b/test/transactionType/cancelTransaction.js
@@ -144,7 +144,7 @@ describe('CANCEL transaction', () => {
   it('CAVERJS-UNIT-TX-516 : If transaction object has unnecessary feePayer field, sendTransaction should throw error', () => {
     const tx = Object.assign({feePayer : testAccount.address}, cancelObject)
 
-    expect(()=> caver.klay.sendTransaction(tx)).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws('"feePayer" cannot be used with CANCEL transaction')
   }).timeout(200000)
 
   // UnnecessaryFeeRatio
@@ -316,5 +316,43 @@ describe('CANCEL transaction', () => {
     const tx = Object.assign({legacyKey: true}, cancelObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with CANCEL transaction')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-590: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-590: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, cancelObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-591: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, cancelObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-591: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, cancelObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/contractDeploy.js
+++ b/test/transactionType/contractDeploy.js
@@ -157,7 +157,7 @@ describe('SMART_CONTRACT_DEPLOY transaction', () => {
     const tx = Object.assign({feePayer: testAccount.address}, deployObject)
 
     // This error return from formatter. Because in formatter discriminate fee delegation through feePayer and senderRawTransaction
-    expect(()=> caver.klay.sendTransaction(tx)).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws('"feePayer" cannot be used with SMART_CONTRACT_DEPLOY transaction')
   }).timeout(200000)
 
   // UnnecessaryFeeRatio
@@ -348,5 +348,43 @@ describe('SMART_CONTRACT_DEPLOY transaction', () => {
     const receipt = await caver.klay.sendTransaction(deployObject)
 
     expect(receipt.status).to.be.true
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-592: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-592: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, deployObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-593: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, deployObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-593: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, deployObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/contractExecution.js
+++ b/test/transactionType/contractExecution.js
@@ -146,7 +146,7 @@ describe('SMART_CONTRACT_EXECUTION transaction', () => {
     const tx = Object.assign({feePayer: testAccount.address}, executionObject)
 
     // This error return from formatter. Because in formatter discriminate fee delegation through feePayer and senderRawTransaction
-    expect(()=> caver.klay.sendTransaction(tx)).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws('"feePayer" cannot be used with SMART_CONTRACT_EXECUTION transaction')
   }).timeout(200000)
 
   // UnnecessaryFeeRatio
@@ -318,5 +318,65 @@ describe('SMART_CONTRACT_EXECUTION transaction', () => {
     const tx = Object.assign({legacyKey: true}, executionObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with SMART_CONTRACT_EXECUTION transaction')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-594: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-594: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, executionObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-595: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, executionObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-595: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, executionObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-596: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, executionObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-596: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, executionObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedAccountUpdate.js
+++ b/test/transactionType/feeDelegatedAccountUpdate.js
@@ -1247,11 +1247,6 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE transaction', () => {
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
 
-  // Error senderRawTransaction missing (A check on the senderRawTransaction is performed when the feePayer attempts to sign the rawTransaction after sender signed.)
-  it('CAVERJS-UNIT-TX-334 : If transaction object missing senderRawTransaction, signTransaction should throw error', async () => {
-    expect(()=>caver.klay.sendTransaction({feePayer: payerAddress})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
-
   // UnnecessaryFeeRatio
   it('CAVERJS-UNIT-TX-335 : If transaction object has feeRatio, signTransaction should throw error', async () => {
     const tx = Object.assign({feeRatio: 20, publicKey}, accountUpdateObject)
@@ -1392,5 +1387,125 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE transaction', () => {
 
     // Throw error from formatter validation
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('The key parameter to be used for FEE_DELEGATED_ACCOUNT_UPDATE is duplicated.')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-597: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-597: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-598: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-598: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-599: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-599: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-600: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-600: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-601: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-601: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
+++ b/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
@@ -1251,12 +1251,7 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO transaction', () => {
     const ret = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
-
-  // Error senderRawTransaction missing (A check on the senderRawTransaction is performed when the feePayer attempts to sign the rawTransaction after sender signed.)
-  it('CAVERJS-UNIT-TX-413 : If transaction object missing senderRawTransaction, signTransaction should throw error', async () => {
-    expect(()=>caver.klay.sendTransaction({feePayer: payerAddress})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
-
+  
   // MissingFeeRatio
   it('CAVERJS-UNIT-TX-414 : If transaction object has feeRatio, signTransaction should throw error', async () => {
     const tx = Object.assign({publicKey}, accountUpdateObject)
@@ -1399,5 +1394,125 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO transaction', () => {
 
     // Throw error from formatter validation
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('The key parameter to be used for FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO is duplicated.')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-602: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-602: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-603: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-603: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-604: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-604: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, publicKey, feePayerSignatures}, accountUpdateObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-605: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-605: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-606: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-606: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({publicKey}, accountUpdateObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedCancelTransaction.js
+++ b/test/transactionType/feeDelegatedCancelTransaction.js
@@ -139,11 +139,6 @@ describe('FEE_DELEGATED_CANCEL transaction', () => {
     const ret = await caver.klay.accounts.signTransaction(tx, senderPrvKey)
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
-  
-  // MissingSenderRawTransaction
-  it('CAVERJS-UNIT-TX-532 : If transaction object missing senderRawTransaction field, should throw error', async() => {
-    expect(()=>caver.klay.sendTransaction({feePayer: testAccount.address})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
 
   // UnnecessaryFeeRatio
   it('CAVERJS-UNIT-TX-533 : If transaction object has unnecessary feeRatio field, signTransaction should throw error', async() => {
@@ -314,5 +309,127 @@ describe('FEE_DELEGATED_CANCEL transaction', () => {
     const tx = Object.assign({legacyKey: true}, cancelObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_CANCEL transaction')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-607: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-607: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, cancelObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-608: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, cancelObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-608: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, cancelObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-609: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, cancelObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-609: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, cancelObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-610: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-610: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-611: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-611: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
+++ b/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
@@ -140,11 +140,6 @@ describe('FEE_DELEGATED_CANCEL_WITH_RATIO transaction', () => {
     const ret = await caver.klay.accounts.signTransaction(tx, senderPrvKey)
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
-  
-  // MissingSenderRawTransaction
-  it('CAVERJS-UNIT-TX-548 : If transaction object missing senderRawTransaction field, should throw error', async() => {
-    expect(()=>caver.klay.sendTransaction({feePayer: testAccount.address})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
 
   // MissingFeeRatio
   it('CAVERJS-UNIT-TX-549 : If transaction object missing feeRatio, signTransaction should throw error', async() => {
@@ -317,5 +312,125 @@ describe('FEE_DELEGATED_CANCEL_WITH_RATIO transaction', () => {
     const tx = Object.assign({legacyKey: true}, cancelObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_CANCEL_WITH_RATIO transaction')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-612: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-612: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, cancelObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-613: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, cancelObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-613: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, cancelObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-614: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, cancelObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-614: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, cancelObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-615: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-615: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-616: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-616: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, cancelObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedContractDeploy.js
+++ b/test/transactionType/feeDelegatedContractDeploy.js
@@ -157,11 +157,6 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction', () => {
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
 
-  // MissingSenderRawTransaction
-  it('CAVERJS-UNIT-TX-443 : If transaction object missing senderRawTransaction field, should throw error', async() => {
-    expect(()=>caver.klay.sendTransaction({feePayer: testAccount.address})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
-
   // UnnecessaryFeeRatio
   it('CAVERJS-UNIT-TX-444 : If transaction object has unnecessary feeRatio field, signTransaction should throw error', async() => {
     const tx = Object.assign({feeRatio: 10}, deployObject)
@@ -345,5 +340,125 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction', () => {
     })
 
     expect(receipt.status).to.be.true
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-617: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-617: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, deployObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-618: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, deployObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-618: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, deployObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-619: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, deployObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-619: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, deployObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-620: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-620: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-621: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-621: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedContractDeployWithRatio.js
+++ b/test/transactionType/feeDelegatedContractDeployWithRatio.js
@@ -158,11 +158,6 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY_WITH_RATIO transaction', () => {
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
 
-  // MissingSenderRawTransaction
-  it('CAVERJS-UNIT-TX-458 : If transaction object missing senderRawTransaction field, should throw error', async() => {
-    expect(()=>caver.klay.sendTransaction({feePayer: testAccount.address})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
-
   // MissingFeeRatio
   it('CAVERJS-UNIT-TX-459 : If transaction object missing feeRatio field, signTransaction should throw error', async() => {
     const tx = Object.assign(deployObject)
@@ -348,5 +343,125 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY_WITH_RATIO transaction', () => {
     })
 
     expect(receipt.status).to.be.true
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-622: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-622: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, deployObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-623: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, deployObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-623: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, deployObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-624: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, deployObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-624: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, deployObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-625: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-625: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-626: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-626: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, deployObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedContractExecution.js
+++ b/test/transactionType/feeDelegatedContractExecution.js
@@ -140,11 +140,6 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION transaction', () => {
     const ret = await caver.klay.accounts.signTransaction(tx, senderPrvKey)
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
-  
-  // MissingSenderRawTransaction
-  it('CAVERJS-UNIT-TX-486 : If transaction object missing senderRawTransaction field, should throw error', async() => {
-    expect(()=>caver.klay.sendTransaction({feePayer: testAccount.address})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
 
   // UnnecessaryFeeRatio
   it('CAVERJS-UNIT-TX-487 : If transaction object has unnecessary feeRatio field, signTransaction should throw error', async() => {
@@ -315,5 +310,147 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION transaction', () => {
     const tx = Object.assign({legacyKey: true}, executionObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_SMART_CONTRACT_EXECUTION transaction')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-627: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-627: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, executionObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-628: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, executionObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-628: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, executionObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-629: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, executionObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-629: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, executionObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-630: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, executionObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-630: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, executionObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-631: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-631: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-632: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-632: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedContractExecutionWithRatio.js
+++ b/test/transactionType/feeDelegatedContractExecutionWithRatio.js
@@ -141,11 +141,6 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO transaction', () => 
     const ret = await caver.klay.accounts.signTransaction(tx, senderPrvKey)
     expect(()=>caver.klay.sendTransaction({senderRawTransaction: ret.rawTransaction})).to.throws('The "feePayer" field must be defined for signing with feePayer!')
   }).timeout(200000)
-  
-  // MissingSenderRawTransaction
-  it('CAVERJS-UNIT-TX-501 : If transaction object missing senderRawTransaction field, should throw error', async() => {
-    expect(()=>caver.klay.sendTransaction({feePayer: testAccount.address})).to.throws('The "senderRawTransaction" field must be defined for signing with feePayer!')
-  }).timeout(200000)
 
   // MissingFeeRatio
   it('CAVERJS-UNIT-TX-502 : If transaction object missing feeRatio, signTransaction should throw error', async() => {
@@ -318,5 +313,147 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO transaction', () => 
     const tx = Object.assign({legacyKey: true}, executionObject)
 
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO transaction')
+  }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-633: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-633: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, executionObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-634: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, executionObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-634: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, executionObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-635: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, executionObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-635: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, executionObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-636: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, executionObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-636: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, executionObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-637: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-637: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-638: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-638: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, executionObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
   }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedValueTransfer.js
+++ b/test/transactionType/feeDelegatedValueTransfer.js
@@ -389,4 +389,146 @@ describe('FEE_DELEGATED_VALUE_TRANSFER transaction', () => {
     
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_VALUE_TRANSFER transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-639: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-639: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-640: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-640: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-641: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-641: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-642: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-642: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-643: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-643: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-644: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-644: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedValueTransferMemo.js
+++ b/test/transactionType/feeDelegatedValueTransferMemo.js
@@ -402,4 +402,147 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO transaction', () => {
     
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_VALUE_TRANSFER_MEMO transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-651: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-651: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-652: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferMemoObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-652: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferMemoObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-653: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferMemoObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-653: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferMemoObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-654: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-654: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-655: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-655: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-656: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-656: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
@@ -405,4 +405,147 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO_WITH_RATIO transaction', () => {
     
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_VALUE_TRANSFER_MEMO_WITH_RATIO transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-657: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-657: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-658: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferMemoWithRatioObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-658: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferMemoWithRatioObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-659: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferMemoWithRatioObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-659: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferMemoWithRatioObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-660: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-660: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-661: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-661: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-662: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-662: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/feeDelegatedValueTransferWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferWithRatio.js
@@ -405,4 +405,147 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_WITH_RATIO transaction', () => {
     
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with FEE_DELEGATED_VALUE_TRANSFER_WITH_RATIO transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-645: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-645: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-646: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferWithRatioObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-646: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const tx = Object.assign({feePayerSignatures}, feeDelegatedValueTransferWithRatioObject)
+
+    const expectedError = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error with invalid feePayer missing when feePayerSignatures is defined in transaction object
+  it('CAVERJS-UNIT-TX-647: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferWithRatioObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-647: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const feePayerSignatures = [['0x26', '0x984e9d43c496ef39ef2d496c8e1aee695f871e4f6cfae7f205ddda1589ca5c9e', '0x46647d1ce8755cd664f5fb4eba3082dd1a13817488029f3869662986b7b1a5ae']]
+    const invalidFeePayer = 'feePayer'
+    const tx = Object.assign({feePayer: invalidFeePayer, feePayerSignatures}, feeDelegatedValueTransferWithRatioObject)
+
+    const expectedError = `Invalid address of fee payer: ${invalidFeePayer}`
+
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-648: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-648: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is not defined with fee payer transaction format
+  it('CAVERJS-UNIT-TX-649: If transaction object missing feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    const expectedError = `Invalid fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-649: If transaction object missing feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: '0x',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // Error when feePayer is invalid with fee payer transaction format
+  it('CAVERJS-UNIT-TX-650: If transaction object has invalid feePayer, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    const expectedError = `Invalid address of fee payer: ${feePayerTx.feePayer}`
+
+    await expect(caver.klay.accounts.signTransaction(feePayerTx, payerPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-650: If transaction object has invalid feePayer, sendTransaction should throw error', async () => {
+    const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+    const { rawTransaction } = await caver.klay.accounts.signTransaction(tx, testAccount.privateKey)
+    
+    const feePayerTx = {
+      senderRawTransaction: rawTransaction,
+      feePayer: 'invalid',
+    }
+
+    // when sendTransaction, get account from wallet before calling signTransaction
+    const expectedError = `Provided address "${feePayerTx.feePayer}" is invalid, the capitalization checksum test failed.`
+
+    expect(()=> caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/legacyTransaction.js
+++ b/test/transactionType/legacyTransaction.js
@@ -353,4 +353,64 @@ describe('LEGACY transaction', () => {
     // Throw error from formatter validation
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with LEGACY transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-663: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, legacyObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-663: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, legacyObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-664: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, legacyObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with LEGACY transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-664: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, legacyObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with LEGACY transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-665: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, legacyObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-665: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, legacyObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/valueTransfer.js
+++ b/test/transactionType/valueTransfer.js
@@ -378,4 +378,64 @@ describe('VALUE_TRANSFER transaction', () => {
     
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with VALUE_TRANSFER transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-666: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, valueTransferObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-666: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, valueTransferObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-667: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, valueTransferObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-667: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, valueTransferObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-668: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, valueTransferObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-668: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, valueTransferObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
 })

--- a/test/transactionType/valueTransferWithMemo.js
+++ b/test/transactionType/valueTransferWithMemo.js
@@ -378,4 +378,64 @@ describe('VALUE_TRANSFER_MEMO transaction', () => {
     
     expect(()=> caver.klay.sendTransaction(tx)).to.throws('"legacyKey" cannot be used with VALUE_TRANSFER_MEMO transaction')
   }).timeout(200000)
+
+  // Invalid from address
+  it('CAVERJS-UNIT-TX-669: If transaction object has invalid from, signTransaction should throw error', async () => {
+    const tx = Object.assign({}, valueTransferMemoObject)
+    tx.from = 'invalidAddress'
+
+    const expectedError = `Invalid address of from: ${tx.from}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-669: If transaction object has invalid from, sendTransaction should throw error', () => {
+    const tx = Object.assign({}, valueTransferMemoObject)
+    tx.from = 'invalidAddress'
+    
+    const expectedError = `Provided address "${tx.from}" is invalid, the capitalization checksum test failed`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // UnnecessaryFeePayerSignatures
+  it('CAVERJS-UNIT-TX-670: If transaction object has unnecessary feePayerSignatures, signTransaction should throw error', async () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, valueTransferMemoObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    await expect(caver.klay.accounts.signTransaction(tx, testAccount.privateKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-670: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const tx = Object.assign({feePayerSignatures: [['0x01', '0x', '0x']]}, valueTransferMemoObject)
+
+    const expectedError = `"feePayerSignatures" cannot be used with ${tx.type} transaction`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
+
+  // InvalidTo
+  it('CAVERJS-UNIT-TX-671: If transaction object has invalid to address, signTransaction should throw error', async () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, valueTransferMemoObject)
+    tx.to = invalidTo
+
+    const expectedError = `Invalid address of to: ${tx.to}`
+
+    await expect(caver.klay.accounts.signTransaction(tx, senderPrvKey)).to.be.rejectedWith(expectedError)
+  }).timeout(200000)
+
+  it('CAVERJS-UNIT-TX-671: If transaction object has unnecessary feePayerSignatures, sendTransaction should throw error', () => {
+    const invalidTo = 'invalid'
+    const tx = Object.assign({}, valueTransferMemoObject)
+    tx.to = invalidTo
+
+    const expectedError = `Provided address "${tx.to}" is invalid, the capitalization checksum test failed.`
+
+    // Throw error from formatter validation
+    expect(()=> caver.klay.sendTransaction(tx)).to.throws(expectedError)
+  }).timeout(200000)
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces modification logic of validateParams.

- Added validation check logic inside of validateParams function.
 : Originally, validateParams checks validation with not fee payer format transaction. So before calling validateParams function, tx should be checked fee payer format or not. 

- Added logic to check validation of address(from or to). 
: ‘to’ address can be ‘0x’ from decodeTransaction when transaction is for smart contract deploy, so check validation to address logic is added to each essential check function. 

- Added case to validateCodeFormat for handling result of decodeTransaction .
: codeFormat can be ‘0x’ from decodeTransaction. 

- Added logic to check existence of feePayer, if feePayerSignatures is defined inside of transaction object. 
: For making RLP encoded transaction string, if feePayerSignatures is defined, feePayer also is needed. 

- Added validation logic related with ‘key’ field for account update.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

Changes to remove the syntax to check whether the fee payer format transaction before calling validateParams will be reflected in later PRs.
