### PR TITLE
Modified signTransaction logic and implemented feePayerSignTransaction

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -76,7 +76,9 @@ var _txInputFormatter = function (options){
     if (options.to) {
       options.humanReadable = options.humanReadable !== undefined? options.humanReadable : false
       if (options.humanReadable) throw new Error('HumanReadableAddress is not supported yet.')
-      options.to = inputAddressFormatter(options.to)
+      if (!utils.isContractDeployment(options) || options.to !== '0x') {
+        options.to = inputAddressFormatter(options.to)
+      }
     }
 
     if (options.data && options.input) {

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -540,6 +540,8 @@ Accounts.prototype.getLegacyAccount = function getLegacyAccount(key) {
 
 /**
  * signTransaction signs to transaction with private key.
+ * If there are signatures(feePayerSignatures if the fee payer signs) in tx entered as a parameter, 
+ * the signatures(feePayerSignatures if the fee payer signs) are appended.
  *
  * @method signTransaction
  * @param {String|Object} tx The transaction to sign.
@@ -716,6 +718,7 @@ Accounts.prototype.signTransaction = function signTransaction() {
 
 /**
 * feePayerSignTransaction calls signTransaction, creating a format for feePayer to sign the transaction.
+* If there are feePayerSignatures in tx entered as a parameter, the signatures for fee payer are appended.
 *
 * @method feePayerSignTransaction
 * @param {Object|String} tx The transaction to sign.

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -68,6 +68,13 @@ function coverInitialTxValue(tx) {
   return tx
 }
 
+/**
+ * resolveArgsForSignTransaction parse arguments for signTransaction.
+ *
+ * @method resolveArgsForSignTransaction
+ * @param {Object} args Parameters of signTransaction.
+ * @return {Object}
+ */
 function resolveArgsForSignTransaction(args) {
   if (args.length === 0 || args.length > 3) throw new Error('Invalid parameter: The number of parameters is invalid.')
   
@@ -99,6 +106,13 @@ function resolveArgsForSignTransaction(args) {
   return { tx, privateKey, callback }
 }
 
+/**
+ * resolveArgsForFeePayerSignTransaction parse arguments for feePayerSignTransaction.
+ *
+ * @method resolveArgsForFeePayerSignTransaction
+ * @param {Object} args Parameters of feePayerSignTransaction.
+ * @return {Object}
+ */
 function resolveArgsForFeePayerSignTransaction(args) {
   if (args.length === 0 || args.length > 4) throw new Error('Invalid parameter: The number of parameters is invalid.')
   


### PR DESCRIPTION
## Proposed changes

This PR introduces modification signing logic and newly implemented functions.

1. signTransaction is modified for handling RLP encoded raw transaction and appending.

2. feePayerSignTransaction is implemented for fee payer.

3. signTransaction and feePayerSignTransaction function remove duplication of signatures.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
