### PR TITLE
Implemented getRawTransactionWithSignatures and combineSignatures

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -927,11 +927,15 @@ Accounts.prototype.combineSignatures = function combineSignatures(rawTransaction
         // feePayer field can be '0x' when after sender signs to trasnaction.
         // For handling this, if feePayer is '0x', don't compare with other transaction
         if (key === 'feePayer') {
-          if (decodedTx[key] === '0x') {
-            decodedTx[key] = decodedTransaction[key]
-            feePayer = decodedTx[key]
-          } else if (decodedTransaction[key] === '0x') {
+          if (decodedTransaction[key] === '0x') {
             continue
+          } else {
+            // set feePayer variable with valid feePayer address(not '0x')
+            feePayer = decodedTransaction[key]
+            if (decodedTx[key] === '0x') {
+              // set feePayer field to decodedTx for comparing feePayer address with other transactions
+              decodedTx[key] = decodedTransaction[key]
+            }
           }
         }
 
@@ -948,13 +952,14 @@ Accounts.prototype.combineSignatures = function combineSignatures(rawTransaction
 
 
   const parsedTxObject = decodeFromRawTransaction(rawTransactions[0])
-  if (feePayer) parsedTxObject.feePayer = feePayer
-  
   parsedTxObject.signatures = senders
-  if (parsedTxObject.feePayer && parsedTxObject.feePayer !== '0x' && parsedTxObject.feePayerSignatures) {
-    parsedTxObject.feePayerSignatures = feePayers
-  }
 
+  if (feePayer) {
+    parsedTxObject.feePayer = feePayer
+    if (feePayers.length > 0) {
+      parsedTxObject.feePayerSignatures = feePayers
+    }
+  }
   return this.getRawTransactionWithSignatures(parsedTxObject)
 }
 

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -922,6 +922,8 @@ Accounts.prototype.combineSignatures = function combineSignatures(rawTransaction
           continue
         }
 
+        // feePayer field can be '0x' when after sender signs to trasnaction.
+        // For handling this, if feePayer is '0x', don't compare with other transaction
         if (key === 'feePayer') {
           if (decodedTx[key] === '0x') {
             decodedTx[key] = decodedTransaction[key]

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -894,10 +894,10 @@ Accounts.prototype.getRawTransactionWithSignatures = function getRawTransactionW
 
 /**
  * combineSignatures combines RLP encoded raw transaction strings.
+ * combineSignatures compares transaction before combining, and if values in field are not same(except default value), this throws error.
  *
  * @method combineSignatures
  * @param {Array} rawTransactions The array of raw transaction string to combine.
- * @param {Function} callback The callback function to call.
  * @return {Object}
  */
 Accounts.prototype.combineSignatures = function combineSignatures(rawTransactions) {

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -793,33 +793,50 @@ Accounts.prototype.feePayerSignTransaction = function feePayerSignTransaction() 
     })
 }
 
-Accounts.prototype.signTransactionWithSignature = function signTransactionWithSignature(tx, callback) {
+/**
+ * getRawTransactionWithSignatures returns object which contains rawTransaction.
+ *
+ * @method getRawTransactionWithSignatures
+ * @param {Object} tx The transaction object which contains signatures or feePayerSignatures.
+ * @param {Function} callback The callback function to call.
+ * @return {Object}
+ */
+Accounts.prototype.getRawTransactionWithSignatures = function getRawTransactionWithSignatures(tx, callback) {
     var _this = this,
-        error = false,
         result
 
     callback = callback || function () {}
 
-    if (!tx) {
-      error = new Error('No transaction object given!')
-
-      callback(error)
-      return Promise.reject(error)
+    let handleError = (e) => {
+      e = e instanceof Error? e : new Error(e)
+      if (callback) callback(e)
+      return Promise.reject(e)
     }
 
-    if (!tx.signature) {
-      error = new Error('No tx signature given!')
+    if (!tx || !_.isObject(tx)) return handleError('Invalid parameter: The transaction must be defined as an object')
+    if (!tx.signatures && !tx.feePayerSignatures) return handleError('There are no signatures or feePayerSignatures defined in the transaction object.')
 
-      callback(error)
-      return Promise.reject(error)
+    let error = helpers.validateFunction.validateParams(tx)
+    if (error) return handleError(error)
+
+    if (tx.senderRawTransaction) {
+      tx.feePayerSignatures = tx.feePayerSignatures || [['0x01', '0x', '0x']]
+
+      const decoded = decodeFromRawTransaction(tx.senderRawTransaction)
+      // feePayer !== '0x' means that in senderRawTransaction there are feePayerSignatures
+      if (decoded.feePayer !== '0x' && !utils.isEmptySig(decoded.feePayerSignatures)) {
+        if (decoded.feePayer.toLowerCase() !== tx.feePayer.toLowerCase()) return handleError('Invalid feePayer')
+        tx.feePayerSignatures = tx.feePayerSignatures.concat(decoded.feePayerSignatures)
+      }
+
+      decoded.feePayer = tx.feePayer
+      decoded.feePayerSignatures = tx.feePayerSignatures
+
+      if (tx.signatures) decoded.signatures = decoded.signatures.concat(tx.signatures)
+      tx = decoded
     }
 
     function signed(tx) {
-      error = helpers.validateFunction.validateParams(tx)
-      if (error) {
-        callback(error)
-        return Promise.reject(error)
-      }
 
       try {
         // Guarantee all property in transaction is hex.
@@ -829,23 +846,24 @@ Accounts.prototype.signTransactionWithSignature = function signTransactionWithSi
 
         const rlpEncoded = encodeRLPByTxType(transaction)
 
-        const messageHash = Hash.keccak256(rlpEncoded)
+        let sigs = transaction.signatures? transaction.signatures : ['0x01', '0x', '0x']
 
-        let sig
-        if (_.isArray(transaction.signature)) {
-          sig = transaction.signature.map((_sig) => utils.resolveSignature(_sig))
-        } else {
-          sig = utils.resolveSignature(transaction.signature)
-        }
+        if (!_.isArray(sigs[0])) sigs = [sigs]
 
-        const rawTransaction = makeRawTransaction(rlpEncoded, sig, transaction)
+        const { rawTransaction, signatures, feePayerSignatures } = makeRawTransaction(rlpEncoded, sigs, transaction)
 
         result = {
-            messageHash: messageHash,
-            signature: sig,
-            rawTransaction: rawTransaction,
-            txHash: Hash.keccak256(rawTransaction),
-            senderTxHash: getSenderTxHash(rawTransaction),
+          rawTransaction: rawTransaction,
+          txHash: Hash.keccak256(rawTransaction),
+          senderTxHash: getSenderTxHash(rawTransaction),
+        }
+
+        if (signatures && !utils.isEmptySig(signatures)) {
+          result.signatures = signatures
+        }
+
+        if (feePayerSignatures && !utils.isEmptySig(feePayerSignatures)) {
+          result.feePayerSignatures = feePayerSignatures
         }
         
       } catch(e) {
@@ -861,12 +879,11 @@ Accounts.prototype.signTransactionWithSignature = function signTransactionWithSi
         return Promise.resolve(signed(tx));
     }
 
-
     // Otherwise, get the missing info from the Klaytn Node
     return Promise.all([
         isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._klaytnCall.getGasPrice() : tx.gasPrice,
-        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.feePayer || tx.from) : tx.nonce
+        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from) : tx.nonce
     ]).then(function (args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2])) {
             throw new Error('One of the values "chainId", "gasPrice", or "nonce" couldn\'t be fetched: '+ JSON.stringify(args));
@@ -874,6 +891,68 @@ Accounts.prototype.signTransactionWithSignature = function signTransactionWithSi
         return signed(_.extend(tx, {chainId: args[0], gasPrice: args[1], nonce: args[2]}));
     });
 };
+
+/**
+ * combineSignatures combines RLP encoded raw transaction strings.
+ *
+ * @method combineSignatures
+ * @param {Array} rawTransactions The array of raw transaction string to combine.
+ * @param {Function} callback The callback function to call.
+ * @return {Object}
+ */
+Accounts.prototype.combineSignatures = function combineSignatures(rawTransactions) {
+  let decodedTx
+  let senders = []
+  let feePayers = []
+  let feePayer
+
+  if (!_.isArray(rawTransactions)) throw new Error(`The parameter of the combineSignatures function must be an array of RLP encoded transaction strings.`)
+  
+  for (const raw of rawTransactions) {
+    const { senderSignatures, feePayerSignatures, decodedTransaction } = extractSignatures(raw)
+
+    senders = senders.concat(senderSignatures)
+    feePayers = feePayers.concat(feePayerSignatures)
+    
+    if (decodedTx) {
+      let isSame = true
+      const keys = Object.keys(decodedTx)
+      for (const key of keys) {
+        if (key === 'v' || key === 'r' || key === 's' || key === 'signatures' || key === 'payerV' || key === 'payerR' || key === 'payerS' || key === 'feePayerSignatures') {
+          continue
+        }
+
+        if (key === 'feePayer') {
+          if (decodedTx[key] === '0x') {
+            decodedTx[key] = decodedTransaction[key]
+            feePayer = decodedTx[key]
+          } else if (decodedTransaction[key] === '0x') {
+            continue
+          }
+        }
+
+        if (decodedTransaction[key] === undefined || decodedTx[key] !== decodedTransaction[key]) {
+          isSame = false
+          break
+        }
+      }
+      if (!isSame) throw new Error(`Failed to combineSignatures: Signatures that sign to different transaction cannot be combined.`)
+    } else {
+      decodedTx = decodedTransaction
+    }
+  }
+
+
+  const parsedTxObject = decodeFromRawTransaction(rawTransactions[0])
+  if (feePayer) parsedTxObject.feePayer = feePayer
+  
+  parsedTxObject.signatures = senders
+  if (parsedTxObject.feePayer && parsedTxObject.feePayer !== '0x' && parsedTxObject.feePayerSignatures) {
+    parsedTxObject.feePayerSignatures = feePayers
+  }
+
+  return this.getRawTransactionWithSignatures(parsedTxObject)
+}
 
 /**
  * cav.klay.accounts.recoverTransaction('0xf86180808401ef364594f0109fc8df283027b6285cc889f5aa624eac1f5580801ca031573280d608f75137e33fc14655f097867d691d5c4c44ebe5ae186070ac3d5ea0524410802cdc025034daefcdfa08e7d2ee3f0b9d9ae184b2001fe0aff07603d9');

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -894,8 +894,10 @@ Accounts.prototype.getRawTransactionWithSignatures = function getRawTransactionW
 
 /**
  * combineSignatures combines RLP encoded raw transaction strings.
- * combineSignatures compares transaction before combining, and if values in field are not same(except default value), this throws error.
- *
+ * combineSignatures compares transaction before combining, and if values in field are not same, this throws error.
+ * The result of deocdeTransaction, feePayer can be '0x'(default value) when there is not fee payer's information(address of feePayer and feePayerSignatures)
+ * In this case, feePayer field doesn't have to be compared with other transaction.
+ * 
  * @method combineSignatures
  * @param {Array} rawTransactions The array of raw transaction string to combine.
  * @return {Object}

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -895,7 +895,7 @@ Accounts.prototype.getRawTransactionWithSignatures = function getRawTransactionW
 /**
  * combineSignatures combines RLP encoded raw transaction strings.
  * combineSignatures compares transaction before combining, and if values in field are not same, this throws error.
- * The result of deocdeTransaction, feePayer can be '0x'(default value) when there is not fee payer's information(address of feePayer and feePayerSignatures)
+ * The comparison allows that the address of the fee payer is '0x'(default value) for some transactions while the other transactions have a specific fee payer. This is for the use case that some transactions do not have the fee payer's information.
  * In this case, feePayer field doesn't have to be compared with other transaction.
  * 
  * @method combineSignatures

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -1441,7 +1441,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       expect(Object.getOwnPropertyNames(result)).to.deep.equal(keys)
 
       expect(signResult.rawTransaction).to.equals(result.rawTransaction)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-308: input: fee delegated value transfer tx object with signatures', () => {
@@ -1455,7 +1455,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       expect(Object.getOwnPropertyNames(result)).to.deep.equal(keys)
 
       expect(signResult.rawTransaction).to.equals(result.rawTransaction)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-309: input: fee delegated value transfer tx object with feePayerSignatures', () => {
@@ -1476,7 +1476,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(caver.utils.isEmptySig(decoded.signatures)).to.be.true
       expect(decoded.feePayerSignatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-310: input: fee delegated value transfer tx object with signatures and feePayerSignatures', () => {
@@ -1501,7 +1501,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
       expect(decoded.feePayerSignatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-311: input: fee payer tx format(includes signatures) object with signatures', () => {
@@ -1522,7 +1522,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
 
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-312: input: fee payer tx format(includes signatures and feePayerSignatures) object with signatures', () => {
@@ -1546,7 +1546,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
       expect(decoded.feePayerSignatures.length).to.equals(1)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-313: input: fee payer tx format(includes signatures and feePayerSignatures) object with signatures and feePayerSignatures', () => {
@@ -1572,7 +1572,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
       expect(decoded.feePayerSignatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-314: input: fee delegated value transfer tx object without signatures and feePayerSignatures', () => {
@@ -1580,7 +1580,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const errorMessage = `There are no signatures or feePayerSignatures defined in the transaction object.`
       
       await expect(caver.klay.accounts.getRawTransactionWithSignatures(feeDelegatedTx)).to.be.rejectedWith(errorMessage)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-315: input: fee delegated value transfer tx object without feePayerSignatures only(no feePayer)', () => {
@@ -1592,7 +1592,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const errorMessage = `"feePayer" is missing: feePayer must be defined with feePayerSignatures.`
       
       await expect(caver.klay.accounts.getRawTransactionWithSignatures(tx)).to.be.rejectedWith(errorMessage)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-316: input: value transfer tx object with feePayer', () => {
@@ -1604,7 +1604,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const errorMessage = `"feePayer" cannot be used with ${vtTx.type} transaction`
       
       await expect(caver.klay.accounts.getRawTransactionWithSignatures(vtTx)).to.be.rejectedWith(errorMessage)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-317: input: value transfer tx object with feePayerSignatures', () => {
@@ -1615,7 +1615,7 @@ describe('caver.klay.accounts.getRawTransactionWithSignatures', () => {
       const errorMessage = `"feePayerSignatures" cannot be used with ${vtTx.type} transaction`
       
       await expect(caver.klay.accounts.getRawTransactionWithSignatures(vtTx)).to.be.rejectedWith(errorMessage)
-    })
+    }).timeout(200000)
   })
 })
 
@@ -1656,7 +1656,7 @@ describe('caver.klay.accounts.combineSignatures', () => {
 
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-319: input: RLP encoded raw transaction string(includes signatures of fee payer only)', () => {
@@ -1673,7 +1673,7 @@ describe('caver.klay.accounts.combineSignatures', () => {
 
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.feePayerSignatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-320: input: RLP encoded raw transaction string(includes signatures of sender and fee payer)', () => {
@@ -1691,7 +1691,7 @@ describe('caver.klay.accounts.combineSignatures', () => {
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
       expect(decoded.feePayerSignatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 
   context('CAVERJS-UNIT-WALLET-321: input: RLP encoded raw transaction string(includes duplicated signatures of sender and fee payer)', () => {
@@ -1726,7 +1726,7 @@ describe('caver.klay.accounts.combineSignatures', () => {
       const decoded = caver.klay.decodeTransaction(result.rawTransaction)
       expect(decoded.signatures.length).to.equals(3)
       expect(decoded.feePayerSignatures.length).to.equals(3)
-    })
+    }).timeout(200000)
   })
 })
 

--- a/test/packages/caver.klay.accounts.js
+++ b/test/packages/caver.klay.accounts.js
@@ -1728,6 +1728,30 @@ describe('caver.klay.accounts.combineSignatures', () => {
       expect(decoded.feePayerSignatures.length).to.equals(3)
     }).timeout(200000)
   })
+
+  context('CAVERJS-UNIT-WALLET-386: input: RLP encoded raw transaction string(includes signatures of sender only)', () => {
+    it('should remove duplicated signatures return valid rawTransaction', async () => {
+      let signResult = await caver.klay.accounts.signTransaction(feeDelegatedTx)
+      let signResult2 = await caver.klay.accounts.signTransaction(feeDelegatedTx, sender.transactionKey[0])
+      let signResult3 = await caver.klay.accounts.signTransaction(feeDelegatedTx, sender.transactionKey[1])
+      let signResult4 = await caver.klay.accounts.signTransaction(feeDelegatedTx, sender.transactionKey[2])
+
+      let rawArray = [
+        signResult.rawTransaction,
+        signResult2.rawTransaction,
+        signResult3.rawTransaction,
+        signResult4.rawTransaction,
+      ]
+      let result = await caver.klay.accounts.combineSignatures(rawArray)
+
+      const keys = ['rawTransaction', 'txHash', 'senderTxHash', 'signatures']
+      expect(Object.getOwnPropertyNames(result)).to.deep.equal(keys)
+      expect(result.signatures.length).to.equals(3)
+
+      const decoded = caver.klay.decodeTransaction(result.rawTransaction)
+      expect(decoded.signatures.length).to.equals(3)
+    }).timeout(200000)
+  })
 })
 
 describe('caver.klay.accounts.recoverTransaction', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces getRawTransactionWithSignatures and combineSignatures functions.

1. getRawTransactionWithSignatures
: This function is a change from the existing signTransactionWithSignature function.
Creates an RLP encoded transaction, taking as a parameter a transaction object containing signatures or feePayerSignatures.

2. combineSignatures
: The combineSignatures function combines multiple RLP encoded transactions into a single RLP encoded transaction.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #117 

## Further comments

Remain PR contents
1. sendSignedTransaction
2. test codes
