### PR TITLE
Added linting check process in test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,15 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: npm install
-      - run: npm test
+      - run: 
+          name: "Install caver-js for testing"
+          command: npm install
+      - run:
+          name: "Lint check"
+          command: npm run lint
+      - run: 
+          name: "Run test code"
+          command: npm test
 
   tag_verify:
     <<: *defaults

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,5 +47,6 @@ module.exports = {
         'prefer-const': 1,
         'no-multi-assign': 1,
         'class-methods-use-this': 1,
+        'import/no-unresolved': 1,
     },
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces adding lint check process in test job.

Run 'npm run lint' on Circle Ci's test job, and If there is an error, the ci process fails.

Originally, I tried to give a guide to the flow after checking the number of errors in the config.yml file, but since the logic did not work properly, I changed the ci to simply run npm run lint.

It would be nice to add something to the CONTRIBUTING.md file that mentions the case of linting check fail.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
