### PR TITLE
Fixed error message and duplicate rejection

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -348,7 +348,7 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                 // Signing to transaction using wallet in Node supports only LEGACY transaction, so if transaction is not LEGACY, return error.
                 if (tx.feePayer !== undefined || (tx.type !== undefined && tx.type !== 'LEGACY')) {
                     error = new Error(
-                        `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${addressToUse}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+                        `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${addressToUse} to the caver-js wallet.`
                     )
                     sendTxCallback(error)
                     return

--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -348,7 +348,7 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                 // Signing to transaction using wallet in Node supports only LEGACY transaction, so if transaction is not LEGACY, return error.
                 if (tx.feePayer !== undefined || (tx.type !== undefined && tx.type !== 'LEGACY')) {
                     error = new Error(
-                        `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${addressToUse} to the caver-js wallet.`
+                        `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${addressToUse} to the caver-js wallet.`
                     )
                     sendTxCallback(error)
                     return

--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -300,9 +300,8 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
 
                 let error
                 if (!_.isObject(tx)) {
-                    error = new Error('The transaction must be defined as an object.')
-                    sendTxCallback(error)
-                    return Promise.reject(error)
+                    sendTxCallback(new Error('The transaction must be defined as an object.'))
+                    return
                 }
 
                 let addressToUse = tx.from
@@ -321,7 +320,7 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                     wallet = method.accounts.wallet.getAccount(addressToUse)
                 } catch (e) {
                     sendTxCallback(e)
-                    return Promise.reject(e)
+                    return
                 }
 
                 if (wallet && wallet.privateKey) {
@@ -348,15 +347,17 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                 // If wallet was not found in caver-js wallet, then it has to use wallet in Node.
                 // Signing to transaction using wallet in Node supports only LEGACY transaction, so if transaction is not LEGACY, return error.
                 if (tx.feePayer !== undefined || (tx.type !== undefined && tx.type !== 'LEGACY')) {
-                    error = new Error('Only Legacy transactions can be signed on a Klaytn node!')
+                    error = new Error(
+                        `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${addressToUse}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+                    )
                     sendTxCallback(error)
-                    return Promise.reject(error)
+                    return
                 }
 
                 error = validateParams(tx)
                 if (error) {
                     sendTxCallback(error)
-                    return Promise.reject(error)
+                    return
                 }
                 break
             }

--- a/test/transactionType/accountUpdate.js
+++ b/test/transactionType/accountUpdate.js
@@ -2080,4 +2080,25 @@ describe('ACCOUNT_UPDATE transaction', () => {
 
         expect(() => caver.klay.signTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-711: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+        const updator = caver.klay.accounts.createAccountForUpdateWithLegacyKey(acctInNode.address)
+
+        const tx = Object.assign({ key: updator }, accountUpdateObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/accountUpdate.js
+++ b/test/transactionType/accountUpdate.js
@@ -2088,7 +2088,7 @@ describe('ACCOUNT_UPDATE transaction', () => {
         const tx = Object.assign({ key: updator }, accountUpdateObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/accountUpdate.js
+++ b/test/transactionType/accountUpdate.js
@@ -2088,7 +2088,7 @@ describe('ACCOUNT_UPDATE transaction', () => {
         const tx = Object.assign({ key: updator }, accountUpdateObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/cancelTransaction.js
+++ b/test/transactionType/cancelTransaction.js
@@ -421,4 +421,24 @@ describe('CANCEL transaction', () => {
         // Throw error from formatter validation
         expect(() => caver.klay.sendTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-712: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, cancelObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/cancelTransaction.js
+++ b/test/transactionType/cancelTransaction.js
@@ -428,7 +428,7 @@ describe('CANCEL transaction', () => {
         const tx = Object.assign({}, cancelObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/cancelTransaction.js
+++ b/test/transactionType/cancelTransaction.js
@@ -428,7 +428,7 @@ describe('CANCEL transaction', () => {
         const tx = Object.assign({}, cancelObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/contractDeploy.js
+++ b/test/transactionType/contractDeploy.js
@@ -463,7 +463,7 @@ describe('SMART_CONTRACT_DEPLOY transaction', () => {
         const tx = Object.assign({}, deployObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/contractDeploy.js
+++ b/test/transactionType/contractDeploy.js
@@ -463,7 +463,7 @@ describe('SMART_CONTRACT_DEPLOY transaction', () => {
         const tx = Object.assign({}, deployObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/contractDeploy.js
+++ b/test/transactionType/contractDeploy.js
@@ -456,4 +456,24 @@ describe('SMART_CONTRACT_DEPLOY transaction', () => {
         // Throw error from formatter validation
         expect(() => caver.klay.sendTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-713: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, deployObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/contractExecution.js
+++ b/test/transactionType/contractExecution.js
@@ -449,4 +449,24 @@ describe('SMART_CONTRACT_EXECUTION transaction', () => {
         // Throw error from formatter validation
         expect(() => caver.klay.sendTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-714: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, executionObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/contractExecution.js
+++ b/test/transactionType/contractExecution.js
@@ -456,7 +456,7 @@ describe('SMART_CONTRACT_EXECUTION transaction', () => {
         const tx = Object.assign({}, executionObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/contractExecution.js
+++ b/test/transactionType/contractExecution.js
@@ -456,7 +456,7 @@ describe('SMART_CONTRACT_EXECUTION transaction', () => {
         const tx = Object.assign({}, executionObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedAccountUpdate.js
+++ b/test/transactionType/feeDelegatedAccountUpdate.js
@@ -2131,4 +2131,25 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE transaction', () => {
 
         expect(() => caver.klay.signTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-715: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+        const updator = caver.klay.accounts.createAccountForUpdateWithLegacyKey(acctInNode.address)
+
+        const tx = Object.assign({ key: updator }, accountUpdateObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedAccountUpdate.js
+++ b/test/transactionType/feeDelegatedAccountUpdate.js
@@ -2139,7 +2139,7 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE transaction', () => {
         const tx = Object.assign({ key: updator }, accountUpdateObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedAccountUpdate.js
+++ b/test/transactionType/feeDelegatedAccountUpdate.js
@@ -2139,7 +2139,7 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE transaction', () => {
         const tx = Object.assign({ key: updator }, accountUpdateObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
+++ b/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
@@ -2272,7 +2272,7 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO transaction', () => {
         const tx = Object.assign({ key: updator }, accountUpdateObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
+++ b/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
@@ -2272,7 +2272,7 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO transaction', () => {
         const tx = Object.assign({ key: updator }, accountUpdateObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
+++ b/test/transactionType/feeDelegatedAccountUpdateWithRatio.js
@@ -2264,4 +2264,25 @@ describe('FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO transaction', () => {
 
         expect(() => caver.klay.signTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-716: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+        const updator = caver.klay.accounts.createAccountForUpdateWithLegacyKey(acctInNode.address)
+
+        const tx = Object.assign({ key: updator }, accountUpdateObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedCancelTransaction.js
+++ b/test/transactionType/feeDelegatedCancelTransaction.js
@@ -531,4 +531,24 @@ describe('FEE_DELEGATED_CANCEL transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-717: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, cancelObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedCancelTransaction.js
+++ b/test/transactionType/feeDelegatedCancelTransaction.js
@@ -538,7 +538,7 @@ describe('FEE_DELEGATED_CANCEL transaction', () => {
         const tx = Object.assign({}, cancelObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedCancelTransaction.js
+++ b/test/transactionType/feeDelegatedCancelTransaction.js
@@ -538,7 +538,7 @@ describe('FEE_DELEGATED_CANCEL transaction', () => {
         const tx = Object.assign({}, cancelObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
+++ b/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
@@ -553,7 +553,7 @@ describe('FEE_DELEGATED_CANCEL_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, cancelObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
+++ b/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
@@ -546,4 +546,24 @@ describe('FEE_DELEGATED_CANCEL_WITH_RATIO transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-718: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, cancelObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
+++ b/test/transactionType/feeDelegatedCancelTransactionWithRatio.js
@@ -553,7 +553,7 @@ describe('FEE_DELEGATED_CANCEL_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, cancelObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractDeploy.js
+++ b/test/transactionType/feeDelegatedContractDeploy.js
@@ -578,4 +578,24 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-719: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, deployObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedContractDeploy.js
+++ b/test/transactionType/feeDelegatedContractDeploy.js
@@ -585,7 +585,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction', () => {
         const tx = Object.assign({}, deployObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractDeploy.js
+++ b/test/transactionType/feeDelegatedContractDeploy.js
@@ -585,7 +585,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY transaction', () => {
         const tx = Object.assign({}, deployObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractDeployWithRatio.js
+++ b/test/transactionType/feeDelegatedContractDeployWithRatio.js
@@ -604,7 +604,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, deployObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractDeployWithRatio.js
+++ b/test/transactionType/feeDelegatedContractDeployWithRatio.js
@@ -604,7 +604,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, deployObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractDeployWithRatio.js
+++ b/test/transactionType/feeDelegatedContractDeployWithRatio.js
@@ -597,4 +597,24 @@ describe('FEE_DELEGATED_SMART_CONTRACT_DEPLOY_WITH_RATIO transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-720: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, deployObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedContractExecution.js
+++ b/test/transactionType/feeDelegatedContractExecution.js
@@ -588,4 +588,24 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-721: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, executionObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedContractExecution.js
+++ b/test/transactionType/feeDelegatedContractExecution.js
@@ -595,7 +595,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION transaction', () => {
         const tx = Object.assign({}, executionObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractExecution.js
+++ b/test/transactionType/feeDelegatedContractExecution.js
@@ -595,7 +595,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION transaction', () => {
         const tx = Object.assign({}, executionObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractExecutionWithRatio.js
+++ b/test/transactionType/feeDelegatedContractExecutionWithRatio.js
@@ -608,7 +608,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO transaction', () => 
         const tx = Object.assign({}, executionObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractExecutionWithRatio.js
+++ b/test/transactionType/feeDelegatedContractExecutionWithRatio.js
@@ -608,7 +608,7 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO transaction', () => 
         const tx = Object.assign({}, executionObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedContractExecutionWithRatio.js
+++ b/test/transactionType/feeDelegatedContractExecutionWithRatio.js
@@ -601,4 +601,24 @@ describe('FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO transaction', () => 
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-722: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, executionObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedValueTransfer.js
+++ b/test/transactionType/feeDelegatedValueTransfer.js
@@ -637,7 +637,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransfer.js
+++ b/test/transactionType/feeDelegatedValueTransfer.js
@@ -637,7 +637,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransfer.js
+++ b/test/transactionType/feeDelegatedValueTransfer.js
@@ -630,4 +630,24 @@ describe('FEE_DELEGATED_VALUE_TRANSFER transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-723: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, feeDelegatedValueTransferObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedValueTransferMemo.js
+++ b/test/transactionType/feeDelegatedValueTransferMemo.js
@@ -651,7 +651,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransferMemo.js
+++ b/test/transactionType/feeDelegatedValueTransferMemo.js
@@ -644,4 +644,24 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-724: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedValueTransferMemo.js
+++ b/test/transactionType/feeDelegatedValueTransferMemo.js
@@ -651,7 +651,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferMemoObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
@@ -656,7 +656,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
@@ -656,7 +656,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferMemoWithRatio.js
@@ -649,4 +649,24 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_MEMO_WITH_RATIO transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-725: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, feeDelegatedValueTransferMemoWithRatioObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/feeDelegatedValueTransferWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferWithRatio.js
@@ -657,7 +657,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransferWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferWithRatio.js
@@ -657,7 +657,7 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_WITH_RATIO transaction', () => {
         const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/feeDelegatedValueTransferWithRatio.js
+++ b/test/transactionType/feeDelegatedValueTransferWithRatio.js
@@ -650,4 +650,24 @@ describe('FEE_DELEGATED_VALUE_TRANSFER_WITH_RATIO transaction', () => {
 
         expect(() => caver.klay.sendTransaction(feePayerTx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-726: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, feeDelegatedValueTransferWithRatioObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/valueTransfer.js
+++ b/test/transactionType/valueTransfer.js
@@ -514,7 +514,7 @@ describe('VALUE_TRANSFER transaction', () => {
         const tx = Object.assign({}, valueTransferObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/valueTransfer.js
+++ b/test/transactionType/valueTransfer.js
@@ -507,4 +507,24 @@ describe('VALUE_TRANSFER transaction', () => {
         // Throw error from formatter validation
         expect(() => caver.klay.sendTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-727: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, valueTransferObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/valueTransfer.js
+++ b/test/transactionType/valueTransfer.js
@@ -514,7 +514,7 @@ describe('VALUE_TRANSFER transaction', () => {
         const tx = Object.assign({}, valueTransferObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/valueTransferWithMemo.js
+++ b/test/transactionType/valueTransferWithMemo.js
@@ -505,4 +505,24 @@ describe('VALUE_TRANSFER_MEMO transaction', () => {
         // Throw error from formatter validation
         expect(() => caver.klay.sendTransaction(tx)).to.throws(expectedError)
     }).timeout(200000)
+
+    it('CAVERJS-UNIT-TX-728: sendTransaction should throw error when try to use an account in Node with not LEGACY transaction', async () => {
+        const acctInNode = caver.klay.accounts.create()
+
+        const tx = Object.assign({}, valueTransferMemoObject)
+        tx.from = acctInNode.address
+
+        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+
+        try {
+            await caver.klay.sendTransaction(tx, (error, result) => {
+                expect(error).not.to.be.null
+                expect(result).to.be.undefined
+                expect(error.message).to.equals(expectedError)
+            })
+            assert(false)
+        } catch (error) {
+            expect(error.message).to.equals(expectedError)
+        }
+    }).timeout(100000)
 })

--- a/test/transactionType/valueTransferWithMemo.js
+++ b/test/transactionType/valueTransferWithMemo.js
@@ -512,7 +512,7 @@ describe('VALUE_TRANSFER_MEMO transaction', () => {
         const tx = Object.assign({}, valueTransferMemoObject)
         tx.from = acctInNode.address
 
-        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
+        const expectedError = `No private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {

--- a/test/transactionType/valueTransferWithMemo.js
+++ b/test/transactionType/valueTransferWithMemo.js
@@ -512,7 +512,7 @@ describe('VALUE_TRANSFER_MEMO transaction', () => {
         const tx = Object.assign({}, valueTransferMemoObject)
         tx.from = acctInNode.address
 
-        const expectedError = `Failed to send transaction: Only Legacy transactions can be signed on a Klaytn node. Please add an account(${acctInNode.address.toLowerCase()}) with caver.klay.accounts.wallet.add, or use a 'LEGACY' transaction.`
+        const expectedError = `no private key found in the caver-js wallet. Trying to use the Klaytn node's wallet, but it only supports legacy transactions. Please add private key of ${acctInNode.address.toLowerCase()} to the caver-js wallet.`
 
         try {
             await caver.klay.sendTransaction(tx, (error, result) => {


### PR DESCRIPTION
## Proposed changes

This PR introduces fixing error message(Error: Only Legacy transactions can be signed on a Klaytn node!) to help developers to figure out cause of problem.

And also duplicate Promise reject is removed.
'sendTxCallback' will reject when error, so Promise.reject doesn't need to be call again after that.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close #147 

## Further comments

If there is a better opinion of the error message, i will reflect it.
