### PR TITLE
Added solc version checking logic in intTest

### DIFF
--- a/test/intTest.js
+++ b/test/intTest.js
@@ -39,6 +39,7 @@ const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 const Caver = require('../index.js')
 const testEnv = require('./klaytn-integration-tests/env.json')
+const testProfile = require('./klaytn-integration-tests/testProfile.json')
 const { expect } = require('./extendedChai')
 
 const { overwriteSignature, getSenderTxHash } = require('../packages/caver-klay/caver-klay-accounts/src/makeRawTransaction')
@@ -481,15 +482,15 @@ before(() => {
     }
 })
 
-it('solc check', async () => {
+async function checkSolidityVersion() {
     const { stdout, stderr } = await exec('solc --version')
     const regex = /Version: ([0-9]+.[0-9]+.[0-9]+)/
     const found = stdout.match(regex)
     expect(found).to.not.null
 
     const version = found[1]
-    expect(version).to.equal('0.5.0')
-})
+    expect(version).to.equal(testProfile.solidity)
+}
 
 describe('Integration tests', () => {
     const directoryPath = path.join(__dirname, 'klaytn-integration-tests')
@@ -497,6 +498,11 @@ describe('Integration tests', () => {
     intFiles.forEach(function(intf) {
         if (intf.isDirectory() === false) return
         describe(`testing ${intf.name}`, () => {
+            before(function(done) {
+                // Check version of solidity compiler before INT-SOL integration test
+                if (intf.name === 'INT-SOL') checkSolidityVersion().then(done)
+            })
+
             const dir = path.join(__dirname, 'klaytn-integration-tests/', intf.name)
             const files = fs.readdirSync(dir)
             files.forEach(function(file) {

--- a/test/intTest.js
+++ b/test/intTest.js
@@ -39,7 +39,7 @@ const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 const Caver = require('../index.js')
 const testEnv = require('./klaytn-integration-tests/env.json')
-const testProfile = require('./klaytn-integration-tests/testProfile.json')
+const conf = require('./klaytn-integration-tests/conf.json')
 const { expect } = require('./extendedChai')
 
 const { overwriteSignature, getSenderTxHash } = require('../packages/caver-klay/caver-klay-accounts/src/makeRawTransaction')
@@ -489,7 +489,7 @@ async function checkSolidityVersion() {
     expect(found).to.not.null
 
     const version = found[1]
-    expect(version).to.equal(testProfile.solidity)
+    expect(version).to.equal(conf.solidity)
 }
 
 describe('Integration tests', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces checking solc version when intTest with INT-SOL.
solc version will be described in conf.json file.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

This PR related with https://github.com/klaytn/klaytn-integration-tests/pull/6
And this also can be edited along with that, and should be merged after that.
