### PR TITLE
Return null when receipt is null

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -260,7 +260,9 @@ const outputTransactionFormatter = function(tx) {
  * @returns {Object}
  */
 const outputTransactionReceiptFormatter = function(receipt) {
-    if (typeof receipt !== 'object' || receipt === null) {
+    if (!receipt) return null
+
+    if (typeof receipt !== 'object') {
         throw new Error(`Received receipt is invalid: ${receipt}`)
     }
 


### PR DESCRIPTION
## Proposed changes

This PR introduces return null when receipt is null.

caver.klay.getTransaction will return null when fail to find tx.
But now caver.klay.getTransactionReceipt will throw error when fail to find transaction receipt.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
