### PR TITLE
remove devDependency of gulp-util #168

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "gulp-replace": "^1.0.0",
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^3.0.1",
-    "gulp-util": "^3.0.8",
     "jshint": "^2.9.7",
     "nock": "^10.0.6",
     "path": "^0.12.7",


### PR DESCRIPTION
## Proposed changes
- npm warn following message
- deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- remove devDependency of gulp-util

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- N/A

## Further comments

- N/A

