### PR TITLE
remove never used dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "gulp-replace": "^1.0.0",
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^3.0.1",
-    "gulp-util": "^3.0.8",
     "jshint": "^2.9.7",
     "nock": "^10.0.6",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "any-promise": "1.3.0",
-    "bignumber": "^1.1.0",
     "bignumber.js": "^8.0.2",
     "bn.js": "4.11.6",
     "chai": "^4.1.2",
@@ -82,11 +81,8 @@
     "babel-eslint": "^8.2.6",
     "babel-plugin-external-helpers": "^6.22.0",
     "babelrc-rollup": "^3.0.0",
-    "bower": "^1.8.8",
-    "bowser": "^2.0.0-alpha.3",
     "browserify": "^16.2.2",
     "chai-as-promised": "^7.1.1",
-    "chance": "^1.0.18",
     "del": "^3.0.0",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^17.0.0",
@@ -120,9 +116,6 @@
     "rollup-plugin-progress": "^0.4.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-uglify": "^6.0.0",
-    "root-path": "^0.2.1",
-    "rxjs": "^6.4.0",
-    "vinyl-source-stream": "^2.0.0",
-    "webpack-stream": "^5.2.1"
+    "vinyl-source-stream": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Proposed changes
- npm warn following message
- deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- remove devDependency of gulp-util
- remove never used dependencies

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- N/A

## Further comments

- N/A

