### PR TITLE
Set nonce with pending tag

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -772,7 +772,7 @@ Accounts.prototype.signTransaction = function signTransaction() {
     return Promise.all([
         isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._klaytnCall.getGasPrice() : tx.gasPrice,
-        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from) : tx.nonce,
+        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from, 'pending') : tx.nonce,
     ]).then(function(args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2])) {
             throw new Error(`One of the values "chainId", "gasPrice", or "nonce" couldn't be fetched: ${JSON.stringify(args)}`)
@@ -851,7 +851,7 @@ Accounts.prototype.feePayerSignTransaction = function feePayerSignTransaction() 
     return Promise.all([
         isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._klaytnCall.getGasPrice() : tx.gasPrice,
-        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from) : tx.nonce,
+        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from, 'pending') : tx.nonce,
     ]).then(function(args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2])) {
             throw new Error(`One of the values "chainId", "gasPrice", or "nonce" couldn't be fetched: ${JSON.stringify(args)}`)
@@ -969,7 +969,7 @@ Accounts.prototype.getRawTransactionWithSignatures = function getRawTransactionW
     return Promise.all([
         isNot(tx.chainId) ? _this._klaytnCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._klaytnCall.getGasPrice() : tx.gasPrice,
-        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from) : tx.nonce,
+        isNot(tx.nonce) ? _this._klaytnCall.getTransactionCount(tx.from, 'pending') : tx.nonce,
     ]).then(function(args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2])) {
             throw new Error(`One of the values "chainId", "gasPrice", or "nonce" couldn't be fetched: ${JSON.stringify(args)}`)

--- a/test/accounts.signTransaction.js
+++ b/test/accounts.signTransaction.js
@@ -16,22 +16,95 @@
     along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
 */
 
+const assert = require('assert')
 const { expect } = require('./extendedChai')
 
 const Caver = require('../index.js')
 const testRPCURL = require('./testrpc')
 
+const caver = new Caver(testRPCURL)
+
+let sender
+let payer
+let testAccount
+
+before(() => {
+    const senderPrvKey =
+        process.env.privateKey && String(process.env.privateKey).indexOf('0x') === -1
+            ? `0x${process.env.privateKey}`
+            : process.env.privateKey
+    const payerPrvKey =
+        process.env.privateKey2 && String(process.env.privateKey2).indexOf('0x') === -1
+            ? `0x${process.env.privateKey2}`
+            : process.env.privateKey2
+
+    sender = caver.klay.accounts.wallet.add(senderPrvKey)
+    payer = caver.klay.accounts.wallet.add(payerPrvKey)
+
+    testAccount = caver.klay.accounts.wallet.add(caver.klay.accounts.create())
+})
+
 describe('caver.klay.accounts.signTransaction', () => {
     it('CAVERJS-UNIT-TX-001 : should be rejected when data field is missing for contract creation tx', () => {
-        const caver = new Caver(testRPCURL)
-
-        const { privateKey } = caver.klay.accounts.create()
-
         const tx = {
             value: '1000000000',
             gas: 2000000,
         }
 
-        expect(caver.klay.accounts.signTransaction(tx, privateKey)).to.eventually.rejected
+        expect(caver.klay.accounts.signTransaction(tx, testAccount.transactionKey)).to.eventually.rejected
     })
+
+    it('CAVERJS-UNIT-WALLET-396: should set nonce with pending block tag', done => {
+        let doneCount = 0
+        let blockNumber = -1
+        function countDone(num) {
+            doneCount++
+            if (blockNumber === -1) blockNumber = num
+            if (doneCount >= 2) {
+                if (blockNumber !== num) return compareNonce()
+                done()
+            }
+        }
+
+        compareNonce()
+
+        function compareNonce() {
+            caver.klay.getTransactionCount(sender.address).then(baseNonce => {
+                caver.klay
+                    .sendTransaction({
+                        from: sender.address,
+                        to: testAccount.address,
+                        value: '1',
+                        gas: 30000,
+                    })
+                    .on('transactionHash', hash1 => {
+                        caver.klay
+                            .sendTransaction({
+                                from: sender.address,
+                                to: testAccount.address,
+                                value: '1',
+                                gas: 30000,
+                            })
+                            .on('receipt', r2 => {
+                                const nonceInReceipt = caver.utils.hexToNumber(r2.nonce)
+                                expect(nonceInReceipt).to.equals(baseNonce + 1)
+                                countDone(r2.blockNumber)
+                            })
+                            .on('error', e => {
+                                assert(false)
+                                done()
+                            })
+                    })
+                    .on('receipt', r1 => {
+                        const nonceInReceipt = caver.utils.hexToNumber(r1.nonce)
+                        expect(nonceInReceipt).to.equals(baseNonce)
+                        countDone(r1.blockNumber)
+                    })
+                    .on('error', e => {
+                        assert(false)
+                        done()
+                    })
+            })
+        }
+    }).timeout(200000)
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces set nonce automation with 'pending' block tag in Accounts pacakge.

When sign to transaction, if there is no nonce in transaction object, caver will request getTransactionCount to network, and then set nonce to it.

For now when getTransactionCount, caver is using 'latest' block tag.
So if you send tx before previous tranasaction is not processed yet, node will throw "there is another tx which has the same nonce in the tx pool" error.

For resolving this, set nonce with 'pending' block tag.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
