### PR TITLE
Implemented bufferToHex in utils

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -405,44 +405,6 @@ const stripHexPrefix = function(str) {
     return isHexPrefixed(str) ? str.slice(2) : str
 }
 
-/**
- * Convert a input into a Buffer.
- *
- * @method toBuffer
- * @param {Buffer|Array|String|Number|BN|Object} input
- * @return {Buffer}
- */
-const toBuffer = function(input) {
-    if (Buffer.isBuffer(input)) return input
-    if (input === null || input === undefined) return Buffer.alloc(0)
-    if (Array.isArray(input)) return Buffer.from(input)
-    if (utils.isBN(input)) return input.toArrayLike(Buffer)
-    if (_.isObject(input)) {
-        if (input.toArray && _.isFunction(input.toArray)) return Buffer.from(input.toArray())
-        throw new Error('To convert an object to a buffer, the toArray function must be implemented inside the object')
-    }
-
-    switch (typeof input) {
-        case 'string':
-            if (isHexParameter(input)) return Buffer.from(stripHexPrefix(utils.makeEven(input)), 'hex')
-            throw new Error("Failed to convert string to Buffer. 'toBuffer' function only supports 0x-prefixed hex string")
-        case 'number':
-            return numberToBuffer(input)
-    }
-    throw new Error(`Not supported type with ${input}`)
-}
-
-/**
- * Convert a number to a Buffer.
- *
- * @method numberToBuffer
- * @param {Number|String|BN} num
- * @return {Buffer}
- */
-const numberToBuffer = function(num) {
-    return Buffer.from(stripHexPrefix(utils.makeEven(utils.numberToHex(num))), 'hex')
-}
-
 module.exports = {
     _fireError: _fireError,
     _jsonInterfaceMethodToString: _jsonInterfaceMethodToString,
@@ -479,8 +441,9 @@ module.exports = {
     toHex: utils.toHex,
     toBN: utils.toBN,
 
-    toBuffer: toBuffer,
-    numberToBuffer: numberToBuffer,
+    toBuffer: utils.toBuffer,
+    numberToBuffer: utils.numberToBuffer,
+    bufferToHex: utils.bufferToHex,
 
     bytesToHex: utils.bytesToHex,
     hexToBytes: utils.hexToBytes,

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -334,6 +334,14 @@ describe('CAVERJS-UNIT-ETC-117: caver.utils.toHex', () => {
             expected:
                 '0x0300000035c3a8c386c3954c5d127cc29dc38ec2bec29e1a37c2abc29b05321128c390c297590a3c100000000000006521c39f642fc3b1c3b5c3ac0c3a7ac2a6c38ec2a6c2b1c3a7c2b7c3b7c38dc2a2c38bc39f07362ac28508c28ec297c3b1c29ec3b94331c38955c380c3a9321ac393c28642c28c',
         },
+        {
+            value: Buffer.from('5b9ac8', 'hex'),
+            expected: '0x5b9ac8',
+        },
+        {
+            value: Buffer.alloc(0),
+            expected: '0x',
+        },
     ]
 
     it.each(tests, 'should return hexstring', test => {
@@ -1155,5 +1163,19 @@ describe('caver.utils.isEmptySig', () => {
         const expectedError = 'Invalid signatures length: 6'
         expect(() => caver.utils.isEmptySig(['0x01', '0x', '0x', '0x01', '0x', '0x'])).to.throws(expectedError)
         expect(() => caver.utils.isEmptySig([['0x01', '0x', '0x', '0x01', '0x', '0x']])).to.throws(expectedError)
+    })
+})
+
+describe('caver.utils.bufferToHex', () => {
+    it('CAVERJS-UNIT-ETC-181: caver.utils.bufferToHex should convert buffer to Hex', () => {
+        const buf = Buffer.from('5b9ac8', 'hex')
+        const ret = caver.utils.bufferToHex(buf)
+        expect(ret).to.equals('0x5b9ac8')
+    })
+
+    it('CAVERJS-UNIT-ETC-182: caver.utils.bufferToHex should convert empty buffer to Hex', () => {
+        const buf = Buffer.alloc(0)
+        const ret = caver.utils.bufferToHex(buf)
+        expect(ret).to.equals('0x')
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces new util function named bufferToHex.

Also originally toBuffer and numberToBuffer functions are existed in caver-utils/index.js file.
But those functions are related with toHex and bufferToHex functions in caver-utils/utils.js.
So moved function location to utils.js file.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close #198 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
