### PR TITLE
Modified isBN function to use BN.isBN

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -68,7 +68,7 @@ const TRANSACTION_HASH_LENGTH = 66
  * @return {Boolean}
  */
 const isBN = function(object) {
-    return object instanceof BN || (object && object.constructor && object.constructor.name === 'BN')
+    return BN.isBN(object)
 }
 
 /**

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -74,6 +74,15 @@ describe('caver.utils.isBN', () => {
             expect(caver.utils.isBN(test.value)).to.be.equal(test.expected)
         })
     })
+
+    context('CAVERJS-UNIT-ETC-192: input: An object whose type is BN but not of type BN', () => {
+        it('caver.utils should return false', () => {
+            const notBn = {}
+            notBn.constructor = {}
+            notBn.constructor.name = 'BN'
+            expect(caver.utils.isBN(notBn)).to.be.equal(false)
+        })
+    })
 })
 
 describe('caver.utils.isBigNumber', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of utils.isBN.

Currently utils.isBN checks the constructor name to determine if the object parameter is BN type.
This method will return true if the object's constructor name is BN even though it is not actually a BN type.

So instead of checking constructor name, i changed to use the BN.isBN function.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close #205 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
