### PR TITLE
Fixed caver.utils.isBigNumber to accept genuine BigNumber instances only

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -26,6 +26,7 @@
 
 const _ = require('lodash')
 const BN = require('bn.js')
+const BigNumber = require('bignumber.js')
 const numberToBN = require('number-to-bn')
 const utf8 = require('utf8')
 const Hash = require('eth-lib/lib/hash')
@@ -78,7 +79,9 @@ const isBN = function(object) {
  * @param {Object} object
  * @return {Boolean}
  */
-const isBigNumber = object => object && object.constructor && object.constructor.name === 'BigNumber'
+const isBigNumber = function(num) {
+    return BigNumber.isBigNumber(num)
+}
 
 /**
  * Takes an input and transforms it into an BN

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -114,6 +114,15 @@ describe('caver.utils.isBigNumber', () => {
             expect(caver.utils.isBigNumber(test.value)).to.be.equal(test.expected)
         })
     })
+
+    context('CAVERJS-UNIT-ETC-202: input: An object whose type is BigNumber but not of type BigNumber', () => {
+        it('caver.utils.isBigNumber should return false', () => {
+            const notBigNumber = {}
+            notBigNumber.constructor = {}
+            notBigNumber.constructor.name = 'BigNumber'
+            expect(caver.utils.isBigNumber(notBigNumber)).to.be.equal(false)
+        })
+    })
 })
 
 describe('caver.utils.sha3', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of caver.utils.isBigNumber.

The original code uses object's constructor name to check whether the parameter is a type of BigNumber.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

This will be included in caver-js v1.3.2 release