### PR TITLE
Modified xyPointFromPublicKey to handle compressed publicKey

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -700,7 +700,10 @@ const rlpEncode = data => RLP.encode(data)
 
 const rlpDecode = encodedData => RLP.decode(encodedData)
 
-const xyPointFromPublicKey = publicKey => {
+const xyPointFromPublicKey = pub => {
+    let publicKey = pub
+    if (isCompressedPublicKey(publicKey)) publicKey = decompressPublicKey(pub)
+
     publicKey = publicKey.replace('0x', '')
     if (publicKey.length !== 128) throw Error('Invalid public key') // + 2 means '0x'
 

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -1154,6 +1154,30 @@ describe('caver.utils.xyPointFromPublicKey', () => {
         expect(xyPoint4[0]).to.equals('0x5b3b58259770871a1cc18534f2d438935fa2dcdb04116cbfbde8adfe858c23e')
         expect(xyPoint4[1]).to.equals('0x50047c5aea3c2f55de7de04203f8fe8ccc3b491029338d038a7ef6d6903b302e')
     })
+
+    it('CAVERJS-UNIT-ETC-209: caver.utils.xyPointFromPublicKey should return x, y point with compressed public key', () => {
+        const publicKey1 = '0x03046241c7524030e5b44fff78021e35227d708c8630757b35090d56527b615f60'
+        const publicKey2 = '0x02ba7135b75cae89b958e7bb78009bda52f6a348150757cc078e3e5e5d25519c50'
+        const publicKey3 = '0x0212b97e6756861ac0257a240d985d761cee9ca7719a29c233c644cfcc42188500'
+        const publicKey4 = '0x0205b3b58259770871a1cc18534f2d438935fa2dcdb04116cbfbde8adfe858c23e'
+
+        const xyPoint1 = caver.utils.xyPointFromPublicKey(publicKey1)
+        const xyPoint2 = caver.utils.xyPointFromPublicKey(publicKey2)
+        const xyPoint3 = caver.utils.xyPointFromPublicKey(publicKey3)
+        const xyPoint4 = caver.utils.xyPointFromPublicKey(publicKey4)
+
+        expect(xyPoint1[0]).to.equals('0x46241c7524030e5b44fff78021e35227d708c8630757b35090d56527b615f60')
+        expect(xyPoint1[1]).to.equals('0x5b8d366782c86dee49356be574e1172f75ef5ce5d03b6e8c17dbf10f3fa2d9a3')
+
+        expect(xyPoint2[0]).to.equals('0xba7135b75cae89b958e7bb78009bda52f6a348150757cc078e3e5e5d25519c50')
+        expect(xyPoint2[1]).to.equals('0xed4ccec1f78ba4e1c21c7b1e57751cec4cf42e3997a476e3ecbf360ad095336')
+
+        expect(xyPoint3[0]).to.equals('0x12b97e6756861ac0257a240d985d761cee9ca7719a29c233c644cfcc42188500')
+        expect(xyPoint3[1]).to.equals('0xc8e4c69cdb71665377b9e8ffb702355ca53917e66c7444619049c3dd0252ab6')
+
+        expect(xyPoint4[0]).to.equals('0x5b3b58259770871a1cc18534f2d438935fa2dcdb04116cbfbde8adfe858c23e')
+        expect(xyPoint4[1]).to.equals('0x50047c5aea3c2f55de7de04203f8fe8ccc3b491029338d038a7ef6d6903b302e')
+    })
 })
 
 describe('caver.utils.isValidPublicKey', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of 'xyPointfromPubicKey' function to handle compressed pubic key string.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/265

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
