### PR TITLE
Added getRLPEncoding function in abstractTrasnaction and modified function name

### DIFF
--- a/packages/caver-transaction/src/transactionHasher/transactionHasher.js
+++ b/packages/caver-transaction/src/transactionHasher/transactionHasher.js
@@ -20,12 +20,12 @@ const Hash = require('eth-lib/lib/hash')
 
 class TransactionHasher {
     static getHashForSigning(transaction) {
-        const rlpEncoded = transaction.getRLPEncodingForSigning()
+        const rlpEncoded = transaction.getRLPEncodingForSignature()
         return Hash.keccak256(rlpEncoded)
     }
 
     static getHashForFeePayerSigning(transaction) {
-        const rlpEncoded = transaction.getRLPEncodingForFeePayerSigning()
+        const rlpEncoded = transaction.getRLPEncodingForFeePayerSignature()
         return Hash.keccak256(rlpEncoded)
     }
 }

--- a/packages/caver-transaction/src/transactionTypes/abstractFeeDelegatedTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractFeeDelegatedTransaction.js
@@ -210,12 +210,12 @@ class AbstractFeeDelegatedTransaction extends AbstractTransaction {
     }
 
     /**
-     * Returns an RLP-encoded transaction string for signing as a fee payer
+     * Returns an RLP-encoded transaction string for making signature as a fee payer
      *
      * @return {string}
      */
-    getRLPEncodingForFeePayerSigning() {
-        return RLP.encode([this.getCommonRLPForSigning(), this.feePayer, Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
+    getRLPEncodingForFeePayerSignature() {
+        return RLP.encode([this.getCommonRLPEncodingForSignature(), this.feePayer, Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -282,16 +282,35 @@ class AbstractTransaction {
     }
 
     /**
-     * Returns an RLP-encoded transaction string for signing
+     * Returns an RLP-encoded transaction string
      *
      * @return {string}
      */
-    getRLPEncodingForSigning() {
-        if (this.gasPrice === undefined) throw new Error(`gasPrice is undefined. Use 'transaction.fillTransaction' to fill values.`)
-        if (this.nonce === undefined) throw new Error(`nonce is undefined. Use 'transaction.fillTransaction' to fill values.`)
-        if (this.chainId === undefined) throw new Error(`chainId is undefined. Use 'transaction.fillTransaction' to fill values.`)
+    getRLPEncoding() {
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define variable in transaction or use 'transaction.fillTransaction' to fill values.`)
+        if (this.nonce === undefined)
+            throw new Error(`nonce is undefined. Define variable in transaction or use 'transaction.fillTransaction' to fill values.`)
+        if (this.chainId === undefined)
+            throw new Error(`chainId is undefined. Define variable in transaction or use 'transaction.fillTransaction' to fill values.`)
 
-        return RLP.encode([this.getCommonRLPForSigning(), Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
+        return this.getRLPEncodingForTransactionHash()
+    }
+
+    /**
+     * Returns an RLP-encoded transaction string for making signature
+     *
+     * @return {string}
+     */
+    getRLPEncodingForSignature() {
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define variable in transaction or use 'transaction.fillTransaction' to fill values.`)
+        if (this.nonce === undefined)
+            throw new Error(`nonce is undefined. Define variable in transaction or use 'transaction.fillTransaction' to fill values.`)
+        if (this.chainId === undefined)
+            throw new Error(`chainId is undefined. Define variable in transaction or use 'transaction.fillTransaction' to fill values.`)
+
+        return RLP.encode([this.getCommonRLPEncodingForSignature(), Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
     }
 
     /**

--- a/packages/caver-wallet/src/keyringContainer.js
+++ b/packages/caver-wallet/src/keyringContainer.js
@@ -198,7 +198,7 @@ class KeyringContainer {
 
         // User parameter input cases
         // (address transaction) / (address transaction index) / (address transaction index hasher)
-        if (_.isFunction(index)) throw new Error(`In order to send a custom hasher as a parameter, the index must be defined first.`)
+        if (_.isFunction(index)) throw new Error(`In order to pass a custom hasher, use the third parameter.`)
 
         await transaction.fillTransaction()
         const hash = hasher(transaction)
@@ -253,7 +253,7 @@ class KeyringContainer {
     async signFeePayerWithKey(address, transaction, index = 0, hasher = TransactionHasher.getHashForFeePayerSigning) {
         // User parameter input cases
         // (address transaction) / (address transaction index) / (address transaction index hasher)
-        if (_.isFunction(index)) throw new Error(`In order to send a custom hasher as a parameter, the index must be defined first.`)
+        if (_.isFunction(index)) throw new Error(`In order to pass a custom hasher, use the third parameter.`)
 
         if (!transaction.feePayer || transaction.feePayer === '0x') transaction.feePayer = address
 

--- a/test/packages/caver.wallet.js
+++ b/test/packages/caver.wallet.js
@@ -433,7 +433,7 @@ describe('wallet.signWithKey', () => {
 
             const txHash = '0xd4aab6590bdb708d1d3eafe95a967dafcd2d7cde197e512f3f0b8158e7b65fd1'
 
-            const expectedError = `In order to send a custom hasher as a parameter, the index must be defined first.`
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
             await expect(caver.wallet.signWithKey(keyring.address, vt, () => txHash)).to.be.rejectedWith(expectedError)
         })
     })
@@ -683,7 +683,7 @@ describe('wallet.signFeePayerWithKey', () => {
 
             const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
 
-            const expectedError = `In order to send a custom hasher as a parameter, the index must be defined first.`
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
             await expect(caver.wallet.signFeePayerWithKey(keyring.address, vt, () => txHash)).to.be.rejectedWith(expectedError)
         })
     })
@@ -829,7 +829,7 @@ class mockValueTransfer {
         this.gasPrice = '0x5d21dba00'
         this.signatures = []
 
-        this.getRLPEncodingForSigning = () => '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+        this.getRLPEncodingForSignature = () => '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
         this.fillTransaction = () => {}
         this.appendSignatures = () => {}
     }
@@ -845,7 +845,7 @@ class mockAccountUpdate {
         this.nonce = '0x0'
         this.gasPrice = '0x5d21dba00'
 
-        this.getRLPEncodingForSigning = () => '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+        this.getRLPEncodingForSignature = () => '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
         this.fillTransaction = () => {}
         this.appendSignatures = () => {}
     }
@@ -856,7 +856,7 @@ class mockFeeDelegatedValueTransfer extends mockValueTransfer {
         super(keyring)
         this.type = 'FEE_DELEGATED_VALUE_TRANSFER'
 
-        this.getRLPEncodingForFeePayerSigning = () => '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+        this.getRLPEncodingForFeePayerSignature = () => '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
         this.appendFeePayerSignatures = () => {}
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces below changes:
- Implement `getRLPEncoding` function in AbstractTransaction to check optional values.
Each transaction will implement `getRLPEncodingForTransactionHash`, and `getRLPEncoding` will use `getRLPEncodingForTransactionHash`

- Changed function name from `getRLPEncodingForSigning` to `getRLPEncodingForSignature`

- Changed function name from `getRLPEncodingForFeePayerSigning ` to `getRLPEncodingForFeePayerSignature `

- Modified error message in KeyringContainer to apply review in https://github.com/klaytn/caver-js/pull/264 for same case.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
