### PR TITLE
Handled undefined options with AccountKeyWeightedMutliSig

### DIFF
--- a/packages/caver-account/src/accountKey/accountKeyHelper.js
+++ b/packages/caver-account/src/accountKey/accountKeyHelper.js
@@ -37,7 +37,7 @@ const ACCOUNT_KEY_TAG = {
  * @param {WeightedMultiSigOptions|object} [options] An instance of WeightedMultiSigOptions or an object that defines 'threshold' and 'weight'.
  * @return {WeightedMultiSigOptions}
  */
-const formatOptionsForMultiSig = (lengthOfKeys, options) => {
+const fillWeightedMultiSigOptionsForMultiSig = (lengthOfKeys, options) => {
     if (_.isArray(options))
         throw new Error(`For AccountKeyWeightedMultiSig, options cannot be defined as an array of WeightedMultiSigOptions.`)
 
@@ -56,7 +56,7 @@ const formatOptionsForMultiSig = (lengthOfKeys, options) => {
  * @param {Array.<WeightedMultiSigOptions>|Array.<object>} [options] An array of WeightedMultiSigOptions or object that defines 'threshold' and 'weight'.
  * @return {Array.<WeightedMultiSigOptions>}
  */
-const formatOptionsForRoleBased = (lengthOfKeys, options = []) => {
+const fillWeightedMultiSigOptionsForRoleBased = (lengthOfKeys, options = []) => {
     if (!_.isArray(options)) throw new Error(`For AccountKeyRoleBased, options should be an array of WeightedMultiSigOptions.`)
 
     for (let i = 0; i < lengthOfKeys.length; i++) {
@@ -87,6 +87,6 @@ const formatOptionsForRoleBased = (lengthOfKeys, options = []) => {
 
 module.exports = {
     ACCOUNT_KEY_TAG,
-    formatOptionsForMultiSig,
-    formatOptionsForRoleBased,
+    fillWeightedMultiSigOptionsForMultiSig,
+    fillWeightedMultiSigOptionsForRoleBased,
 }

--- a/packages/caver-account/src/accountKey/accountKeyWeightedMultiSig.js
+++ b/packages/caver-account/src/accountKey/accountKeyWeightedMultiSig.js
@@ -20,8 +20,7 @@ const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const WeightedPublicKey = require('./weightedPublicKey')
 const utils = require('../../../caver-utils')
-const { ACCOUNT_KEY_TAG } = require('./accountKeyHelper')
-const WeightedMultiSigOptions = require('./weightedMultiSigOptions')
+const { ACCOUNT_KEY_TAG, formatOptionsForMultiSig } = require('./accountKeyHelper')
 
 /**
  * Representing an AccountKeyWeightedMultiSig.
@@ -54,11 +53,7 @@ class AccountKeyWeightedMultiSig {
      * @return {AccountKeyWeightedMultiSig}
      */
     static fromPublicKeysAndOptions(publicKeyArray, options) {
-        if (options === undefined) {
-            throw new Error(`Invalid options object. For AccountKeyWeightedMultiSig, the second parameter 'options' should be defined.`)
-        }
-        if (!(options instanceof WeightedMultiSigOptions)) options = WeightedMultiSigOptions.fromObject(options)
-
+        options = formatOptionsForMultiSig(publicKeyArray.length, options)
         if (publicKeyArray.length !== options.weights.length) {
             throw new Error(`The length of public keys is not equal to the length of weight array.`)
         }

--- a/packages/caver-account/src/accountKey/accountKeyWeightedMultiSig.js
+++ b/packages/caver-account/src/accountKey/accountKeyWeightedMultiSig.js
@@ -20,7 +20,7 @@ const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const WeightedPublicKey = require('./weightedPublicKey')
 const utils = require('../../../caver-utils')
-const { ACCOUNT_KEY_TAG, formatOptionsForMultiSig } = require('./accountKeyHelper')
+const { ACCOUNT_KEY_TAG, fillWeightedMultiSigOptionsForMultiSig } = require('./accountKeyHelper')
 
 /**
  * Representing an AccountKeyWeightedMultiSig.
@@ -53,7 +53,7 @@ class AccountKeyWeightedMultiSig {
      * @return {AccountKeyWeightedMultiSig}
      */
     static fromPublicKeysAndOptions(publicKeyArray, options) {
-        options = formatOptionsForMultiSig(publicKeyArray.length, options)
+        options = fillWeightedMultiSigOptionsForMultiSig(publicKeyArray.length, options)
         if (publicKeyArray.length !== options.weights.length) {
             throw new Error(`The length of public keys is not equal to the length of weight array.`)
         }

--- a/packages/caver-account/src/index.js
+++ b/packages/caver-account/src/index.js
@@ -123,14 +123,10 @@ class Account {
      *
      * @param {string} address The address of Account.
      * @param {Array} publicKeyArray The array that includes multiple public key strings.
-     * @param {Object} options The object that includes threshold and weight array.
+     * @param {Object} [options] The object that includes threshold and weight array.
      * @return {Account}
      */
     static createWithAccountKeyWeightedMultiSig(address, publicKeyArray, options) {
-        if (options === undefined)
-            throw new Error(
-                `The variable 'options' is undefined. To create an Account instance with AccountKeyWeightedMultiSig, 'options' should be defined.`
-            )
         return new Account(address, AccountKeyWeightedMultiSig.fromPublicKeysAndOptions(publicKeyArray, options))
     }
 
@@ -139,14 +135,10 @@ class Account {
      *
      * @param {string} address The address of Account.
      * @param {Array} roledBasedPublicKeyArray A two-dimensional array containing arrays of public key strings for each role.
-     * @param {Array} options An array that contains objects with threshold and weight array defined for each role.
+     * @param {Array} [options] An array that contains objects with threshold and weight array defined for each role.
      * @return {Account}
      */
     static createWithAccountKeyRoleBased(address, roledBasedPublicKeyArray, options) {
-        if (options === undefined)
-            throw new Error(
-                `The variable 'options' is undefined. To create an Account instance with AccountKeyRoleBased, 'options' should be defined.`
-            )
         return new Account(address, AccountKeyRoleBased.fromRoleBasedPublicKeysAndOptions(roledBasedPublicKeyArray, options))
     }
 

--- a/packages/caver-wallet/src/keyring/keyring.js
+++ b/packages/caver-wallet/src/keyring/keyring.js
@@ -26,7 +26,10 @@ const utils = require('../../../caver-utils')
 const PrivateKey = require('./privateKey')
 const { KEY_ROLE, MAXIMUM_KEY_NUM, isMultipleKeysFormat, isRoleBasedKeysFormat } = require('./keyringHelper')
 const Account = require('../../../caver-account')
-const { formatOptionsForMultiSig, formatOptionsForRoleBased } = require('../../../caver-account/src/accountKey/accountKeyHelper')
+const {
+    fillWeightedMultiSigOptionsForMultiSig,
+    fillWeightedMultiSigOptionsForRoleBased,
+} = require('../../../caver-account/src/accountKey/accountKeyHelper')
 
 /**
  * representing a Keyring which includes `address` and `private keys` by roles.
@@ -524,9 +527,9 @@ class Keyring {
         if (isRoleBased) {
             const lengths = []
             for (const k of this.keys) lengths.push(k.length)
-            options = formatOptionsForRoleBased(lengths, options)
+            options = fillWeightedMultiSigOptionsForRoleBased(lengths, options)
         }
-        if (isWeightedMultiSig) options = formatOptionsForMultiSig(this.keys[0].length, options)
+        if (isWeightedMultiSig) options = fillWeightedMultiSigOptionsForMultiSig(this.keys[0].length, options)
 
         if (isRoleBased) {
             // AccountKeyRoleBased with AccountKeyPublic

--- a/packages/caver-wallet/src/keyring/keyring.js
+++ b/packages/caver-wallet/src/keyring/keyring.js
@@ -26,7 +26,7 @@ const utils = require('../../../caver-utils')
 const PrivateKey = require('./privateKey')
 const { KEY_ROLE, MAXIMUM_KEY_NUM, isMultipleKeysFormat, isRoleBasedKeysFormat } = require('./keyringHelper')
 const Account = require('../../../caver-account')
-const WeightedMultiSigOptions = require('../../../caver-account/src/accountKey/weightedMultiSigOptions')
+const { formatOptionsForMultiSig, formatOptionsForRoleBased } = require('../../../caver-account/src/accountKey/accountKeyHelper')
 
 /**
  * representing a Keyring which includes `address` and `private keys` by roles.
@@ -521,8 +521,12 @@ class Keyring {
         if (isRoleBased && options !== undefined && !_.isArray(options))
             throw new Error(`options for an account should define threshold and weight for each roles in an array format`)
 
-        // _validateOptionsForUpdate returns WeightedMultiSigOptions with 1 threshold and 1 weight for each key when options is not defined.
-        if (isRoleBased || isWeightedMultiSig) options = this._validateOptionsForUpdate(options)
+        if (isRoleBased) {
+            const lengths = []
+            for (const k of this.keys) lengths.push(k.length)
+            options = formatOptionsForRoleBased(lengths, options)
+        }
+        if (isWeightedMultiSig) options = formatOptionsForMultiSig(this.keys[0].length, options)
 
         if (isRoleBased) {
             // AccountKeyRoleBased with AccountKeyPublic
@@ -533,9 +537,6 @@ class Keyring {
             return Account.createWithAccountKeyRoleBased(this.address, publicKeysByRole, options)
         }
         if (isWeightedMultiSig) {
-            // options = [ {threshold: 1, weights: [1,2] }, {}, {} ]
-            options = options[0]
-
             const publicKeys = this.getPublicKey()[0]
             return Account.createWithAccountKeyWeightedMultiSig(this.address, publicKeys, options)
         }
@@ -620,36 +621,6 @@ class Keyring {
 
         const derived = this.keys[0][0].getDerivedAddress()
         return this.address.toLowerCase() !== derived.toLowerCase()
-    }
-
-    _validateOptionsForUpdate(options = []) {
-        // { threshold: 1, weights: [1, 1] } => [{ threshold: 1, weights: [1, 1] }]
-        if (!_.isArray(options)) options = [options]
-
-        for (let i = 0; i < this._keys.length; i++) {
-            // Validation for options obejct will be operated in AccountKeyWeightedMultiSig class.
-            if (options[i] && Object.keys(options[i]).length > 0) {
-                if (!(options[i] instanceof WeightedMultiSigOptions))
-                    options[i] = new WeightedMultiSigOptions(options[i].threshold, options[i].weights)
-                if (!options[i].isEmpty()) continue
-            }
-
-            let optionToAdd
-            if (this._keys[i].length > 1) {
-                // default option when option is not set
-                optionToAdd = new WeightedMultiSigOptions(1, Array(this._keys[i].length).fill(1))
-            } else {
-                // AccountKeyPublic does not need option
-                optionToAdd = new WeightedMultiSigOptions()
-            }
-
-            if (options[i]) {
-                options[i] = optionToAdd
-            } else {
-                options.push(optionToAdd)
-            }
-        }
-        return options
     }
 }
 

--- a/test/packages/caver.account.accountKey.js
+++ b/test/packages/caver.account.accountKey.js
@@ -312,14 +312,9 @@ describe('caver.account.accountKey.accountKeyWeightedMultiSig', () => {
                 '0xc10b598a1a3ba252acc21349d61c2fbd9bc8c15c50a5599f420cccc3291f9bf9803a1898f45b2770eda7abce70e8503b5e82b748ec0ce557ac9f4f4796965e4e',
                 '0x1769a9196f523c419be50c26419ebbec34d3d6aa8b59da834212f13dbec9a9c12a4d0eeb91d7bd5d592653d43dd0593cfe24cb20a5dbef05832932e7c7191bf6',
             ]
-            let options
-            let expectedError = `Invalid options object. For AccountKeyWeightedMultiSig, the second parameter 'options' should be defined.`
-            expect(() => caver.account.accountKey.accountKeyWeightedMultiSig.fromPublicKeysAndOptions(publicArray, options)).to.throw(
-                expectedError
-            )
 
-            options = { weights: [1, 1] }
-            expectedError = `Invalid object for creating WeightedMultiSigOptions. 'threshold' and 'weights' should be defined.`
+            let options = { weights: [1, 1] }
+            let expectedError = `Invalid object for creating WeightedMultiSigOptions. 'threshold' and 'weights' should be defined.`
             expect(() => caver.account.accountKey.accountKeyWeightedMultiSig.fromPublicKeysAndOptions(publicArray, options)).to.throw(
                 expectedError
             )
@@ -354,6 +349,19 @@ describe('caver.account.accountKey.accountKeyWeightedMultiSig', () => {
             expect(() => caver.account.accountKey.accountKeyWeightedMultiSig.fromPublicKeysAndOptions(publicArray, options)).to.throw(
                 expectedError
             )
+        })
+    })
+
+    context('CAVERJS-UNIT-ACCOUNT-062: caver.account.accountKey.accountKeyWeightedMultiSig.fromPublicKeysAndOptions', () => {
+        it('should create an instance with default options', () => {
+            const publicArray = [
+                '0xc10b598a1a3ba252acc21349d61c2fbd9bc8c15c50a5599f420cccc3291f9bf9803a1898f45b2770eda7abce70e8503b5e82b748ec0ce557ac9f4f4796965e4e',
+                '0x1769a9196f523c419be50c26419ebbec34d3d6aa8b59da834212f13dbec9a9c12a4d0eeb91d7bd5d592653d43dd0593cfe24cb20a5dbef05832932e7c7191bf6',
+            ]
+            const options = { threshold: 1, weights: [1, 1] }
+            const accountKey = caver.account.accountKey.accountKeyWeightedMultiSig.fromPublicKeysAndOptions(publicArray)
+
+            testAccountKey(accountKey, 'AccountKeyWeightedMultiSig', { expectedAccountKey: publicArray, exepectedOptions: options })
         })
     })
 
@@ -680,6 +688,33 @@ describe('caver.account.accountKey.accountKeyRoleBased', () => {
             expect(() => caver.account.accountKey.accountKeyRoleBased.fromRoleBasedPublicKeysAndOptions(pubs, options)).to.throw(
                 expectedError
             )
+        })
+    })
+
+    context('CAVERJS-UNIT-ACCOUNT-063: caver.account.accountKey.accountKeyRoleBased.fromRoleBasedPublicKeysAndOptions', () => {
+        it('should create an instance with default options', () => {
+            const publicArray = [
+                [
+                    '0x91245244462b3eee6436d3dc0ba3f69ef413fe2296c729733eff891a55f70c02f2b0870653417943e795e7c8694c4f8be8af865b7a0224d1dec0bf8a1bf1b5a6',
+                ],
+                [
+                    '0xd3bb14320d87eed081ae44740b5abbc52bac2c7ccf85b6281a0fc69f3ba4c171cc4bd2ba7f0c969cd72bfa49c854d8ac2cf3d0edea7f0ce0fd31cf080374935d',
+                    '0xcfa4d1bee51e59e6842b136ff95b9d01385f94bed13c4be8996c6d20cb732c3ee47cd2b6bbb917658c5fd3d02b0ddf1242b1603d1acbde7812a7d9d684ed37a9',
+                ],
+                [
+                    '0x91245244462b3eee6436d3dc0ba3f69ef413fe2296c729733eff891a55f70c02f2b0870653417943e795e7c8694c4f8be8af865b7a0224d1dec0bf8a1bf1b5a6',
+                    '0x77e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f3570b1a104b67d1cd169bbf61dd557f15ab5ee8b661326096954caddadf34ae6ac8',
+                    '0xd3bb14320d87eed081ae44740b5abbc52bac2c7ccf85b6281a0fc69f3ba4c171cc4bd2ba7f0c969cd72bfa49c854d8ac2cf3d0edea7f0ce0fd31cf080374935d',
+                ],
+            ]
+            const options = [
+                new caver.account.weightedMultiSigOptions(),
+                new caver.account.weightedMultiSigOptions(1, [1, 1]),
+                new caver.account.weightedMultiSigOptions(1, [1, 1, 1]),
+            ]
+            const accountKey = caver.account.accountKey.accountKeyRoleBased.fromRoleBasedPublicKeysAndOptions(publicArray)
+
+            testAccountKey(accountKey, 'AccountKeyRoleBased', { expectedAccountKey: publicArray, exepectedOptions: options })
         })
     })
 

--- a/test/packages/caver.account.js
+++ b/test/packages/caver.account.js
@@ -173,6 +173,32 @@ describe('caver.account.create', () => {
                 exepectedOptions: options,
             })
             expect(createWithAccountKeyWeightedMultiSigSpy).to.have.been.calledOnce
+            createWithAccountKeyWeightedMultiSigSpy.restore()
+        })
+    })
+
+    context('CAVERJS-UNIT-ACCOUNT-064: address: valid address / accountKey: uncompressed public key strings', () => {
+        it('should generate account instances with AccountKeyWeightedMultiSig with default options', () => {
+            const createWithAccountKeyWeightedMultiSigSpy = sinon.spy(caver.account, 'createWithAccountKeyWeightedMultiSig')
+            const address = '0xab9825316619a0720ad891135e92adb84fd74fc1'
+            const pubs = [
+                '0x91245244462b3eee6436d3dc0ba3f69ef413fe2296c729733eff891a55f70c02f2b0870653417943e795e7c8694c4f8be8af865b7a0224d1dec0bf8a1bf1b5a6',
+                '0x77e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f3570b1a104b67d1cd169bbf61dd557f15ab5ee8b661326096954caddadf34ae6ac8',
+                '0xd3bb14320d87eed081ae44740b5abbc52bac2c7ccf85b6281a0fc69f3ba4c171cc4bd2ba7f0c969cd72bfa49c854d8ac2cf3d0edea7f0ce0fd31cf080374935d',
+                '0xcfa4d1bee51e59e6842b136ff95b9d01385f94bed13c4be8996c6d20cb732c3ee47cd2b6bbb917658c5fd3d02b0ddf1242b1603d1acbde7812a7d9d684ed37a9',
+            ]
+            const options = new caver.account.weightedMultiSigOptions(1, [1, 1, 1, 1])
+
+            const account = caver.account.create(address, pubs)
+
+            testAccount(account, {
+                expectedAddress: address,
+                expectedAccountKeyType: 'AccountKeyWeightedMultiSig',
+                expectedAccountKey: pubs,
+                exepectedOptions: options,
+            })
+            expect(createWithAccountKeyWeightedMultiSigSpy).to.have.been.calledOnce
+            createWithAccountKeyWeightedMultiSigSpy.restore()
         })
     })
 
@@ -234,6 +260,46 @@ describe('caver.account.create', () => {
                 exepectedOptions: options,
             })
             expect(createWithAccountKeyRoleBasedSpy).to.have.been.calledOnce
+            createWithAccountKeyRoleBasedSpy.restore()
+        })
+    })
+
+    context('CAVERJS-UNIT-ACCOUNT-065: address: valid address / accountKey: role based uncompressed public key strings', () => {
+        it('should generate account instances with AccountKeyRoleBased with default options', () => {
+            const createWithAccountKeyRoleBasedSpy = sinon.spy(caver.account, 'createWithAccountKeyRoleBased')
+            const address = '0xab9825316619a0720ad891135e92adb84fd74fc1'
+            const pubs = [
+                [
+                    '0xb86b2787e8c7accd7d2d82678c9bef047a0aafd72a6e690817506684e8513c9af36becba90c8de06fd06da16492263267a63720985f94fc5a027d0a26d25e6ae',
+                ],
+                [
+                    '0x1a909c4d7dbb5281b1d1b55e79a1b2568111bd2830246c3173ce824000eb8716afe39b6106fb9db360fb5779e2d346c8328698174831941586b11bdc3e755905',
+                    '0x1427ac6351bbfc15811e8e5389a674b01d7a2c253e69a6ed30a33583864368f65f63b92fd60be61c5d176ae1771e7738e6a043af814b9af5d81137df29ee95f2',
+                    '0x90fe4bb78bc981a40874ebcff2f9de4eba1e59ecd7a271a37814413720a3a5ea5fa9bd7d8bc5c66a9a08d77563458b004bbd1d594a3a12ef108cdc7c04c525a6',
+                ],
+                [
+                    '0x91245244462b3eee6436d3dc0ba3f69ef413fe2296c729733eff891a55f70c02f2b0870653417943e795e7c8694c4f8be8af865b7a0224d1dec0bf8a1bf1b5a6',
+                    '0x77e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f3570b1a104b67d1cd169bbf61dd557f15ab5ee8b661326096954caddadf34ae6ac8',
+                    '0xd3bb14320d87eed081ae44740b5abbc52bac2c7ccf85b6281a0fc69f3ba4c171cc4bd2ba7f0c969cd72bfa49c854d8ac2cf3d0edea7f0ce0fd31cf080374935d',
+                    '0xcfa4d1bee51e59e6842b136ff95b9d01385f94bed13c4be8996c6d20cb732c3ee47cd2b6bbb917658c5fd3d02b0ddf1242b1603d1acbde7812a7d9d684ed37a9',
+                ],
+            ]
+            const options = [
+                new caver.account.weightedMultiSigOptions(),
+                new caver.account.weightedMultiSigOptions(1, [1, 1, 1]),
+                new caver.account.weightedMultiSigOptions(1, [1, 1, 1, 1]),
+            ]
+
+            const account = caver.account.create(address, pubs)
+
+            testAccount(account, {
+                expectedAddress: address,
+                expectedAccountKeyType: 'AccountKeyRoleBased',
+                expectedAccountKey: pubs,
+                exepectedOptions: options,
+            })
+            expect(createWithAccountKeyRoleBasedSpy).to.have.been.calledOnce
+            createWithAccountKeyRoleBasedSpy.restore()
         })
     })
 
@@ -484,8 +550,16 @@ describe('caver.account.createWithAccountKeyWeightedMultiSig', () => {
                 '0x77e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f3570b1a104b67d1cd169bbf61dd557f15ab5ee8b661326096954caddadf34ae6ac8',
             ]
 
-            const expectedError = `The variable 'options' is undefined. To create an Account instance with AccountKeyWeightedMultiSig, 'options' should be defined.`
-            expect(() => caver.account.createWithAccountKeyWeightedMultiSig(address, pubs)).to.throw(expectedError)
+            const options = new caver.account.weightedMultiSigOptions(1, [1, 1])
+
+            const account = caver.account.createWithAccountKeyWeightedMultiSig(address, pubs)
+
+            testAccount(account, {
+                expectedAddress: address,
+                expectedAccountKeyType: 'AccountKeyWeightedMultiSig',
+                expectedAccountKey: pubs,
+                exepectedOptions: options,
+            })
         })
     })
 })
@@ -537,14 +611,27 @@ describe('caver.account.createWithAccountKeyRoleBased', () => {
                 ],
                 [
                     '0x1a909c4d7dbb5281b1d1b55e79a1b2568111bd2830246c3173ce824000eb8716afe39b6106fb9db360fb5779e2d346c8328698174831941586b11bdc3e755905',
+                    '0x1a909c4d7dbb5281b1d1b55e79a1b2568111bd2830246c3173ce824000eb8716afe39b6106fb9db360fb5779e2d346c8328698174831941586b11bdc3e755905',
                 ],
                 [
                     '0x91245244462b3eee6436d3dc0ba3f69ef413fe2296c729733eff891a55f70c02f2b0870653417943e795e7c8694c4f8be8af865b7a0224d1dec0bf8a1bf1b5a6',
                 ],
             ]
 
-            const expectedError = `The variable 'options' is undefined. To create an Account instance with AccountKeyRoleBased, 'options' should be defined.`
-            expect(() => caver.account.createWithAccountKeyRoleBased(address, pubs)).to.throw(expectedError)
+            const options = [
+                new caver.account.weightedMultiSigOptions(),
+                new caver.account.weightedMultiSigOptions(1, [1, 1]),
+                new caver.account.weightedMultiSigOptions(),
+            ]
+
+            const account = caver.account.createWithAccountKeyRoleBased(address, pubs)
+
+            testAccount(account, {
+                expectedAddress: address,
+                expectedAccountKeyType: 'AccountKeyRoleBased',
+                expectedAccountKey: pubs,
+                exepectedOptions: options,
+            })
         })
     })
 })

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -1891,18 +1891,17 @@ describe('keyring.toAccount', () => {
     context('CAVERJS-UNIT-KEYRING-121: keyring type: multiSig / options: defined(empty array format)', () => {
         it('return account instance which has AccountKeyWeightedMultiSig', () => {
             const options = []
-            const exepectedOptions = new caver.account.weightedMultiSigOptions(1, [1, 1, 1])
-            const account = multiSig.toAccount(options)
-            validateAccount(account, { keyring: multiSig, expectedAccountKey: 'AccountKeyWeightedMultiSig', exepectedOptions })
+
+            const expectedError = `For AccountKeyWeightedMultiSig, options cannot be defined as an array of WeightedMultiSigOptions.`
+            expect(() => multiSig.toAccount(options)).to.throw(expectedError)
         })
     })
 
     context('CAVERJS-UNIT-KEYRING-122: keyring type: multiSig / options: defined(array of empty object format)', () => {
         it('return account instance which has AccountKeyWeightedMultiSig', () => {
             const options = [{}, {}, {}]
-            const exepectedOptions = new caver.account.weightedMultiSigOptions(1, [1, 1, 1])
-            const account = multiSig.toAccount(options)
-            validateAccount(account, { keyring: multiSig, expectedAccountKey: 'AccountKeyWeightedMultiSig', exepectedOptions })
+            const expectedError = `For AccountKeyWeightedMultiSig, options cannot be defined as an array of WeightedMultiSigOptions.`
+            expect(() => multiSig.toAccount(options)).to.throw(expectedError)
         })
     })
 
@@ -1913,8 +1912,8 @@ describe('keyring.toAccount', () => {
                 new caver.account.weightedMultiSigOptions(),
                 new caver.account.weightedMultiSigOptions(),
             ]
-            const account = multiSig.toAccount(options)
-            validateAccount(account, { keyring: multiSig, expectedAccountKey: 'AccountKeyWeightedMultiSig', exepectedOptions: options[0] })
+            const expectedError = `For AccountKeyWeightedMultiSig, options cannot be defined as an array of WeightedMultiSigOptions.`
+            expect(() => multiSig.toAccount(options)).to.throw(expectedError)
         })
     })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces handling undefined options with AccountKeyWeightedMultiSig.

The existing logic was implemented to default the handling of undefined options only when calling the toAccount method on the Keyring instance.

However, in this PR, the logic is changed to treat the undefined options in the static method of Account, AccountKeyWeightedMultiSig and AccountKeyRoleBased.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
