### PR TITLE
Added transaction test codes for basic

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "caver-js is a JavaScript API library that allows developers to interact with a Klaytn node",
   "main": "index.js",
   "scripts": {
-    "test": "npm run build && npm run transactionTest && mocha test/packages/caver.utils.js && mocha test/packages/caver.klay.net.js && npm run accountTest && npm run serTest && npm run walletTest",
+    "test": "npm run build && npm run transactionTest && npm run feeDelegatedTransactionTest && mocha test/packages/caver.utils.js && mocha test/packages/caver.klay.net.js && npm run accountTest && npm run serTest && npm run walletTest",
     "build-all": "gulp all",
     "build": "gulp default",
     "lint": "./node_modules/.bin/eslint './**/*.js'",
@@ -12,7 +12,8 @@
     "serTest": "mocha test/transactionType/serializationTest.js && mocha test/compressionPublicKey.js && mocha test/encodeContractDeploy.js && mocha test/parseAccountKey.js && mocha test/decodeTransaction.js",
     "accountTest": "mocha test/packages/caver.account.js && mocha test/packages/caver.account.accountKey.js",
     "walletTest": "mocha test/packages/caver.wallet.js && mocha test/packages/caver.wallet.keyring.js && mocha test/accountLib.js && mocha test/accounts.privateKeyToPublicKey.js && mocha test/accounts.recover.js && mocha test/packages/caver.klay.accounts.js && mocha test/isValidPrivateKey.js && mocha test/privateKeyToAccount.js",
-    "transactionTest": "mocha test/packages/caver.transaction/legacyTransaction.js && mocha test/packages/caver.transaction/valueTransfer.js",
+    "transactionTest": "mocha test/packages/caver.transaction/legacyTransaction.js && mocha test/packages/caver.transaction/valueTransfer.js && mocha test/packages/caver.transaction/valueTransferMemo.js && mocha test/packages/caver.transaction/accountUpdate.js && mocha test/packages/caver.transaction/smartContractDeploy.js && mocha test/packages/caver.transaction/smartContractExecution.js && mocha test/packages/caver.transaction/cancel.js",
+    "feeDelegatedTransactionTest": "mocha test/packages/caver.transaction/feeDelegatedValueTransfer.js && mocha test/packages/caver.transaction/feeDelegatedValueTransferMemo.js",
     "txTest": "mocha test/methodErrorHandling.js && mocha test/sendSignedTransaction.js && mocha test/estimateComputationCost.js && mocha test/getTransactionReceipt.js && mocha test/setNonceWithPendingTag.js && mocha test/getTransaction.js && mocha test/setContractOptions.js && mocha test/encodeContractDeploy.js && mocha test/accounts.signTransaction.js && mocha test/sendTransactionCallback.js && mocha test/signWithMultiSig.js && mocha test/transactionType/legacyTransaction.js && mocha test/transactionType/valueTransfer* && mocha test/transactionType/accountUpdate.js && mocha test/transactionType/contract* && mocha test/transactionType/cancelTransaction.js && mocha test/transactionType/feeDelegated*",
     "etcTest": "mocha test/packages/caver.utils.js && mocha test/confirmationListener.js && mocha test/hashMessage.js && mocha test/iban.* && mocha test/randomHex.js && mocha test/sha3.js && mocha test/toChecksumAddress.js && mocha test/unitMap.js && mocha test/default* && mocha test/getNodeInfo.js && mocha test/eventEmitter.js && mocha test/packages/caver.klay.net.js && mocha test/getNetworkType.js && mocha test/invalidResponse.js && mocha test/isContractDeployment.js && mocha test/personal.js && mocha test/multiProviderTest.js && mocha test/subscription.js && mocha test/supportsSubscriptions.js && mocha test/contract.once.js && mocha test/setProvider.js",
     "accountKeyTest": "mocha test/scenarioTest/accountKeyPublic.js && mocha test/scenarioTest/accountKeyMultiSig.js && mocha test/scenarioTest/accountKeyRoleBased.js",

--- a/test/packages/caver.transaction/accountUpdate.js
+++ b/test/packages/caver.transaction/accountUpdate.js
@@ -1,0 +1,1071 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, makeAccount, accountKeyTestCases, checkSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let roleBasedKeyring
+
+let txObjWithLegacy
+let txObjWithPublic
+let txObjWithFail
+let txObjWithMultiSig
+let txObjWithRoleBased
+
+const expectedValues = []
+let txsByAccountKeys = []
+
+const sandbox = sinon.createSandbox()
+
+function makeAccountUpdateObjectWithExpectedValues() {
+    {
+        const testAddress = '0xdca786ce39b074966e8a9eae16eac90783974d80'
+        const account = caver.account.createWithAccountKeyLegacy(testAddress)
+
+        const tx = {
+            from: testAddress,
+            gas: '0x30d40',
+            nonce: '0x0',
+            gasPrice: '0x5d21dba00',
+            signatures: [
+                [
+                    '0x0fea',
+                    '0x866f7cf552d4062a3c1a6055cabbe358a21ce779cfe2b81cee87b66024b993af',
+                    '0x2990dc2d9d36cc4de4b9a79c30aeab8d59e2d60631e0d90c8ac3c096b7a38852',
+                ],
+            ],
+            chainId: '0x7e3',
+            account,
+        }
+
+        expectedValues.push({})
+        expectedValues[accountKeyTestCases.LEGACY].tx = tx
+        expectedValues[accountKeyTestCases.LEGACY].rlpEncodingForSigning =
+            '0xeba5e420808505d21dba0083030d4094dca786ce39b074966e8a9eae16eac90783974d808201c08207e38080'
+        expectedValues[accountKeyTestCases.LEGACY].rlpEncodingCommon =
+            '0xe420808505d21dba0083030d4094dca786ce39b074966e8a9eae16eac90783974d808201c0'
+        expectedValues[accountKeyTestCases.LEGACY].senderTxHash = '0xeea281154fc4000f01b47a5a6f0c2caa1481cbc9ef935cc8c35a5f006f8d97a6'
+        expectedValues[accountKeyTestCases.LEGACY].transactionHash = '0xeea281154fc4000f01b47a5a6f0c2caa1481cbc9ef935cc8c35a5f006f8d97a6'
+        expectedValues[accountKeyTestCases.LEGACY].rlpEncoding =
+            '0x20f86c808505d21dba0083030d4094dca786ce39b074966e8a9eae16eac90783974d808201c0f847f845820feaa0866f7cf552d4062a3c1a6055cabbe358a21ce779cfe2b81cee87b66024b993afa02990dc2d9d36cc4de4b9a79c30aeab8d59e2d60631e0d90c8ac3c096b7a38852'
+    }
+    {
+        const testAddress = '0xffb52bc54635f840013e142ebe7c06c9c91c1625'
+        const pubKey =
+            '0xc93fcbdb2b9dbef8ee5c4748ffdce11f1f5b06d7ba71cc2b7699e38be7698d1edfa5c0486858a516e8a46c4834ac0ad10ed7dc7ec818a88a9f75fe5fabd20e90'
+        const account = caver.account.createWithAccountKeyPublic(testAddress, pubKey)
+
+        const tx = {
+            from: testAddress,
+            gas: '0x30d40',
+            nonce: '0x0',
+            gasPrice: '0x5d21dba00',
+            signatures: [
+                [
+                    '0x0fe9',
+                    '0x9c2ca281e94567846acbeef724b1a7a5f882d581aff9984755abd92272592b8e',
+                    '0x344fd23d7774ae9c227809bb579387dfcd69e74ae2fe3a788617f54a4001e5ab',
+                ],
+            ],
+            chainId: '0x7e3',
+            account,
+        }
+
+        expectedValues.push({})
+        expectedValues[accountKeyTestCases.PUBLIC].tx = tx
+        expectedValues[accountKeyTestCases.PUBLIC].rlpEncodingForSigning =
+            '0xf84eb847f84520808505d21dba0083030d4094ffb52bc54635f840013e142ebe7c06c9c91c1625a302a102c93fcbdb2b9dbef8ee5c4748ffdce11f1f5b06d7ba71cc2b7699e38be7698d1e8207e38080'
+
+        expectedValues[accountKeyTestCases.PUBLIC].rlpEncodingCommon =
+            '0xf84520808505d21dba0083030d4094ffb52bc54635f840013e142ebe7c06c9c91c1625a302a102c93fcbdb2b9dbef8ee5c4748ffdce11f1f5b06d7ba71cc2b7699e38be7698d1e'
+        expectedValues[accountKeyTestCases.PUBLIC].senderTxHash = '0x0c52c7e1d67da8221df26fa7ac01f33d87f46dc706844804f378cebe2e66c432'
+        expectedValues[accountKeyTestCases.PUBLIC].transactionHash = '0x0c52c7e1d67da8221df26fa7ac01f33d87f46dc706844804f378cebe2e66c432'
+        expectedValues[accountKeyTestCases.PUBLIC].rlpEncoding =
+            '0x20f88d808505d21dba0083030d4094ffb52bc54635f840013e142ebe7c06c9c91c1625a302a102c93fcbdb2b9dbef8ee5c4748ffdce11f1f5b06d7ba71cc2b7699e38be7698d1ef847f845820fe9a09c2ca281e94567846acbeef724b1a7a5f882d581aff9984755abd92272592b8ea0344fd23d7774ae9c227809bb579387dfcd69e74ae2fe3a788617f54a4001e5ab'
+    }
+    {
+        const testAddress = '0x26b05cce63f78ddf6a769fb2db39e54b9f2db620'
+        const account = caver.account.createWithAccountKeyFail(testAddress)
+
+        const tx = {
+            from: testAddress,
+            gas: '0x30d40',
+            nonce: '0x0',
+            gasPrice: '0x5d21dba00',
+            signatures: [
+                [
+                    '0x0fe9',
+                    '0x86361c43593859b6989794a6848c5ba1e5d8bd860522347cd167042acd6a7816',
+                    '0x773f5cc10f734b3b4486b9c5b7e5def156e06d9d9f4a3aaae6662f9a2126094c',
+                ],
+            ],
+            chainId: '0x7e3',
+            account,
+        }
+
+        expectedValues.push({})
+        expectedValues[accountKeyTestCases.FAIL].tx = tx
+        expectedValues[accountKeyTestCases.FAIL].rlpEncodingForSigning =
+            '0xeba5e420808505d21dba0083030d409426b05cce63f78ddf6a769fb2db39e54b9f2db6208203c08207e38080'
+        expectedValues[accountKeyTestCases.FAIL].rlpEncodingCommon =
+            '0xe420808505d21dba0083030d409426b05cce63f78ddf6a769fb2db39e54b9f2db6208203c0'
+        expectedValues[accountKeyTestCases.FAIL].senderTxHash = '0xfb6053ce6d0321eebcdbce2c123fd501bc38ab6bcf74a34001663a56d227cd92'
+        expectedValues[accountKeyTestCases.FAIL].transactionHash = '0xfb6053ce6d0321eebcdbce2c123fd501bc38ab6bcf74a34001663a56d227cd92'
+        expectedValues[accountKeyTestCases.FAIL].rlpEncoding =
+            '0x20f86c808505d21dba0083030d409426b05cce63f78ddf6a769fb2db39e54b9f2db6208203c0f847f845820fe9a086361c43593859b6989794a6848c5ba1e5d8bd860522347cd167042acd6a7816a0773f5cc10f734b3b4486b9c5b7e5def156e06d9d9f4a3aaae6662f9a2126094c'
+    }
+    {
+        const testAddress = '0x2dcd60f120bd64e35093a2945ce61c0bcb71dc93'
+        const pubArray = [
+            '0xe1c4bb4d01245ebdc62a88092f6c79b59d56e319ae694050e7a0c1cff93a0d9240bf159aa0ee59bacb41df2185cf0be1ca316c349d839e4edc04e1af77ec8c4e',
+            '0x13853532348457b4fb18526c6447a6cdff38a791dc2e778f19a843fc6b3a3e8d4cb21a4c331ccc967aa9127fb7e49ce52eaf69c967521d4066745371868b297b',
+            '0xe0f3c6f28dc933ac3cf7fc3143f0d38bc83aa9541ce7bb67c356cad5c9b020a3a0b24f48b17b1f7880ba027ad39095ae53888d788816658e47a58193c1b81720',
+        ]
+        const options = new caver.account.weightedMultiSigOptions(2, [1, 1, 1])
+        const account = caver.account.createWithAccountKeyWeightedMultiSig(testAddress, pubArray, options)
+
+        const tx = {
+            from: testAddress,
+            gas: '0x30d40',
+            nonce: '0x0',
+            gasPrice: '0x5d21dba00',
+            signatures: [
+                [
+                    '0x0fe9',
+                    '0x02aca4ec6773a26c71340c2500cb45886a61797bcd82790f7f01150ced48b0ac',
+                    '0x20502f22a1b3c95a5f260a03dc3de0eaa1f4a618b1d2a7d4da643507302e523c',
+                ],
+            ],
+            chainId: '0x7e3',
+            account,
+        }
+
+        expectedValues.push({})
+        expectedValues[accountKeyTestCases.MULTISIG].tx = tx
+        expectedValues[accountKeyTestCases.MULTISIG].rlpEncodingForSigning =
+            '0xf89eb897f89520808505d21dba0083030d40942dcd60f120bd64e35093a2945ce61c0bcb71dc93b87204f86f02f86ce301a102e1c4bb4d01245ebdc62a88092f6c79b59d56e319ae694050e7a0c1cff93a0d92e301a10313853532348457b4fb18526c6447a6cdff38a791dc2e778f19a843fc6b3a3e8de301a102e0f3c6f28dc933ac3cf7fc3143f0d38bc83aa9541ce7bb67c356cad5c9b020a38207e38080'
+        expectedValues[accountKeyTestCases.MULTISIG].rlpEncodingCommon =
+            '0xf89520808505d21dba0083030d40942dcd60f120bd64e35093a2945ce61c0bcb71dc93b87204f86f02f86ce301a102e1c4bb4d01245ebdc62a88092f6c79b59d56e319ae694050e7a0c1cff93a0d92e301a10313853532348457b4fb18526c6447a6cdff38a791dc2e778f19a843fc6b3a3e8de301a102e0f3c6f28dc933ac3cf7fc3143f0d38bc83aa9541ce7bb67c356cad5c9b020a3'
+        expectedValues[accountKeyTestCases.MULTISIG].senderTxHash = '0x6b67ca5e8f1ef46e009348541d0866dbb2902b75a4dccb3b7286d6987f556b44'
+        expectedValues[accountKeyTestCases.MULTISIG].transactionHash = '0x6b67ca5e8f1ef46e009348541d0866dbb2902b75a4dccb3b7286d6987f556b44'
+        expectedValues[accountKeyTestCases.MULTISIG].rlpEncoding =
+            '0x20f8dd808505d21dba0083030d40942dcd60f120bd64e35093a2945ce61c0bcb71dc93b87204f86f02f86ce301a102e1c4bb4d01245ebdc62a88092f6c79b59d56e319ae694050e7a0c1cff93a0d92e301a10313853532348457b4fb18526c6447a6cdff38a791dc2e778f19a843fc6b3a3e8de301a102e0f3c6f28dc933ac3cf7fc3143f0d38bc83aa9541ce7bb67c356cad5c9b020a3f847f845820fe9a002aca4ec6773a26c71340c2500cb45886a61797bcd82790f7f01150ced48b0aca020502f22a1b3c95a5f260a03dc3de0eaa1f4a618b1d2a7d4da643507302e523c'
+    }
+    {
+        const testAddress = '0xfb675bea5c3fa279fd21572161b6b6b2dbd84233'
+        const pubArray = [
+            [
+                '0xf7e7e03c328d39cee6201080ac2576919f904f0b8e47fcb7ea8869e7db0baf4470a0b29a1f6dd007e19a53da122d18bf6273cdddb2903ef0ad2b350b207ad67c',
+                '0xedacd9095274f292c702514f6443f58337e7d7c8311694f31c73e86f150ecf45820929c143da861f6009784e36a6ebd99f83b1baf93fd72e820b5df3cd00883b',
+                '0xb74fd682a6a805415e7711890bc91a283c268c78947ebf25a02a2e02625a68aa825b5213f3e9f03c34650da902a2a70915dcc1c7fe86333a7e40e638361335a4',
+            ],
+            [
+                '0xd0ae803893f344ee664378bbc9ebb35ca2d94f7d7ecea4e3e2f9f33817cdb04bb54cf4211eef21e9627a7d0ca6960e8f1135a35c751f526ce203c6e36b3f2230',
+            ],
+            [
+                '0x4b4cd35195aa4324184a64821e514a991b513cc354f5fa6d78fb99e23949bc59613d8be87ad3e1418ad11e1d5537233b697bc0c8c5d7335a6decf687cce700ba',
+                '0x3e65f4a76bca1488a1a046d6976778852aa41f07156d2c42e81c3da6621435d2350f8419fe8255dc87158c8ae30378b19b0d3d224eb410ca2de847a41caeb617',
+            ],
+        ]
+        const options = [
+            new caver.account.weightedMultiSigOptions(2, [1, 1, 1]),
+            new caver.account.weightedMultiSigOptions(),
+            new caver.account.weightedMultiSigOptions(1, [1, 1]),
+        ]
+        const account = caver.account.createWithAccountKeyRoleBased(testAddress, pubArray, options)
+
+        const transactionWithRolebased = {
+            from: testAddress,
+            gas: '0x30d40',
+            nonce: '0x0',
+            gasPrice: '0x5d21dba00',
+            signatures: [
+                [
+                    '0x0fe9',
+                    '0x66e28c27f16ba34325770e842874d07473180bcec22e86851a6882acbaeb56c3',
+                    '0x761e12fe11003aa4cb8fd9b44a41e5edebeb943cc366264b345d0f7e63853724',
+                ],
+            ],
+            chainId: '0x7e3',
+            account,
+        }
+
+        expectedValues.push({})
+        expectedValues[accountKeyTestCases.ROLEBAED].tx = transactionWithRolebased
+        expectedValues[accountKeyTestCases.ROLEBAED].rlpEncodingForSigning =
+            '0xf90119b90111f9010e20808505d21dba0083030d4094fb675bea5c3fa279fd21572161b6b6b2dbd84233b8eb05f8e8b87204f86f02f86ce301a102f7e7e03c328d39cee6201080ac2576919f904f0b8e47fcb7ea8869e7db0baf44e301a103edacd9095274f292c702514f6443f58337e7d7c8311694f31c73e86f150ecf45e301a102b74fd682a6a805415e7711890bc91a283c268c78947ebf25a02a2e02625a68aaa302a102d0ae803893f344ee664378bbc9ebb35ca2d94f7d7ecea4e3e2f9f33817cdb04bb84e04f84b01f848e301a1024b4cd35195aa4324184a64821e514a991b513cc354f5fa6d78fb99e23949bc59e301a1033e65f4a76bca1488a1a046d6976778852aa41f07156d2c42e81c3da6621435d28207e38080'
+        expectedValues[accountKeyTestCases.ROLEBAED].rlpEncodingCommon =
+            '0xf9010e20808505d21dba0083030d4094fb675bea5c3fa279fd21572161b6b6b2dbd84233b8eb05f8e8b87204f86f02f86ce301a102f7e7e03c328d39cee6201080ac2576919f904f0b8e47fcb7ea8869e7db0baf44e301a103edacd9095274f292c702514f6443f58337e7d7c8311694f31c73e86f150ecf45e301a102b74fd682a6a805415e7711890bc91a283c268c78947ebf25a02a2e02625a68aaa302a102d0ae803893f344ee664378bbc9ebb35ca2d94f7d7ecea4e3e2f9f33817cdb04bb84e04f84b01f848e301a1024b4cd35195aa4324184a64821e514a991b513cc354f5fa6d78fb99e23949bc59e301a1033e65f4a76bca1488a1a046d6976778852aa41f07156d2c42e81c3da6621435d2'
+        expectedValues[accountKeyTestCases.ROLEBAED].senderTxHash = '0x57cdfb7b92c16608b467c28e6519f66ef89923046fce37e086baa1f5775ef312'
+        expectedValues[accountKeyTestCases.ROLEBAED].transactionHash = '0x57cdfb7b92c16608b467c28e6519f66ef89923046fce37e086baa1f5775ef312'
+        expectedValues[accountKeyTestCases.ROLEBAED].rlpEncoding =
+            '0x20f90156808505d21dba0083030d4094fb675bea5c3fa279fd21572161b6b6b2dbd84233b8eb05f8e8b87204f86f02f86ce301a102f7e7e03c328d39cee6201080ac2576919f904f0b8e47fcb7ea8869e7db0baf44e301a103edacd9095274f292c702514f6443f58337e7d7c8311694f31c73e86f150ecf45e301a102b74fd682a6a805415e7711890bc91a283c268c78947ebf25a02a2e02625a68aaa302a102d0ae803893f344ee664378bbc9ebb35ca2d94f7d7ecea4e3e2f9f33817cdb04bb84e04f84b01f848e301a1024b4cd35195aa4324184a64821e514a991b513cc354f5fa6d78fb99e23949bc59e301a1033e65f4a76bca1488a1a046d6976778852aa41f07156d2c42e81c3da6621435d2f847f845820fe9a066e28c27f16ba34325770e842874d07473180bcec22e86851a6882acbaeb56c3a0761e12fe11003aa4cb8fd9b44a41e5edebeb943cc366264b345d0f7e63853724'
+    }
+}
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    const commonObj = {
+        from: sender.address,
+        gas: '0x3b9ac9ff',
+    }
+
+    txObjWithLegacy = Object.assign({ account: makeAccount(sender.address, accountKeyTestCases.LEGACY) }, commonObj)
+    txObjWithPublic = Object.assign({ account: makeAccount(sender.address, accountKeyTestCases.PUBLIC) }, commonObj)
+    txObjWithFail = Object.assign({ account: makeAccount(sender.address, accountKeyTestCases.FAIL) }, commonObj)
+    txObjWithMultiSig = Object.assign({ account: makeAccount(sender.address, accountKeyTestCases.MULTISIG) }, commonObj)
+    txObjWithRoleBased = Object.assign(
+        {
+            account: makeAccount(sender.address, accountKeyTestCases.ROLEBAED, [
+                { threshold: 2, weights: [1, 1, 1] },
+                {},
+                { threshold: 1, weights: [1, 1] },
+            ]),
+        },
+        commonObj
+    )
+
+    makeAccountUpdateObjectWithExpectedValues()
+})
+
+describe('TxTypeAccountUpdate', () => {
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+
+    beforeEach(() => {
+        txsByAccountKeys = []
+        txsByAccountKeys.push(new caver.transaction.accountUpdate(txObjWithLegacy))
+        txsByAccountKeys.push(new caver.transaction.accountUpdate(txObjWithPublic))
+        txsByAccountKeys.push(new caver.transaction.accountUpdate(txObjWithFail))
+        txsByAccountKeys.push(new caver.transaction.accountUpdate(txObjWithMultiSig))
+        txsByAccountKeys.push(new caver.transaction.accountUpdate(txObjWithRoleBased))
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create accountUpdate instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-152: If accountUpdate not define from, return error', () => {
+            const testUpdateObj = Object.assign({}, txObjWithPublic)
+            delete testUpdateObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.accountUpdate(testUpdateObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-153: If accountUpdate not define gas, return error', () => {
+            const testUpdateObj = Object.assign({}, txObjWithPublic)
+            delete testUpdateObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.accountUpdate(testUpdateObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-540: If accountUpdate not define gas, return error', () => {
+            const testUpdateObj = Object.assign({}, txObjWithPublic)
+            delete testUpdateObj.account
+
+            const expectedError = 'Missing account information with TxTypeAccountUpdate transaction'
+            expect(() => new caver.transaction.accountUpdate(testUpdateObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-154: If accountUpdate define from property with invalid address, return error', () => {
+            const testUpdateObj = Object.assign({}, txObjWithPublic)
+            testUpdateObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${testUpdateObj.from}`
+            expect(() => new caver.transaction.accountUpdate(testUpdateObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-155: If accountUpdate define unnecessary property, return error', () => {
+            const testUpdateObj = Object.assign({}, txObjWithPublic)
+
+            const unnecessaries = [
+                propertiesForUnnecessary.data,
+                propertiesForUnnecessary.input,
+                propertiesForUnnecessary.to,
+                propertiesForUnnecessary.value,
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feePayer,
+                propertiesForUnnecessary.feePayerSignatures,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+                propertiesForUnnecessary.humanReadable,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete testUpdateObj[unnecessaries[i - 1].name]
+                testUpdateObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeAccountUpdate} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.accountUpdate(testUpdateObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('accountUpdate.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-156: returns RLP-encoded string.', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+
+                expect(tx.getRLPEncoding()).to.equal(expectedValues[i].rlpEncoding)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-157: getRLPEncoding should throw error when nonce is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._nonce
+
+                const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-158: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._gasPrice
+
+                const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-159: getRLPEncoding should throw error when chainId is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._chainId
+
+                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('accountUpdate.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        const fillTransactionSpys = []
+        const appendSignaturesSpys = []
+
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let hasherSpy
+
+        beforeEach(() => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                fillTransactionSpys.push(sandbox.spy(txsByAccountKeys[i], 'fillTransaction'))
+                appendSignaturesSpys.push(sandbox.spy(txsByAccountKeys[i], 'appendSignatures'))
+            }
+
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(idx, customHasher = false) {
+            expect(fillTransactionSpys[idx]).to.have.been.calledOnce
+            expect(appendSignaturesSpys[idx]).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(txsByAccountKeys[idx])
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-160: input: keyring. should sign transaction.', async () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKey(sender)
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 1, 0)
+            }
+            expect(createFromPrivateKeySpy).not.to.have.been.called
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-161: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKey(sender.keys[0][0].privateKey)
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 1, 0)
+            }
+            expect(createFromPrivateKeySpy).to.have.been.callCount(Object.keys(txsByAccountKeys).length)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-162: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKey(sender.getKlaytnWalletKey())
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 1, 0)
+            }
+            expect(createFromPrivateKeySpy).to.have.been.callCount(Object.keys(txsByAccountKeys).length)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-163: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.from = roleBasedKeyring.address
+
+                await tx.signWithKey(roleBasedKeyring, 1)
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 1, 1)
+            }
+            expect(createFromPrivateKeySpy).not.to.have.been.called
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-164: input: keyring, custom hasher. should throw error.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                const expectedError = `In order to pass a custom hasher, use the third parameter.`
+                await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+            }
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-165: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.from = roleBasedKeyring.address
+
+                await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+                checkFunctionCall(i, true)
+                checkSignature(tx)
+                expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+                expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 1, 1)
+            }
+            expect(createFromPrivateKeySpy).not.to.have.been.called
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-166: input: keyring. should throw error when from is different.', async () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.from = roleBasedKeyring.address
+
+                const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+                await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+            }
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-167: input: rolebased keyring, index out of range. should throw error.', async () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.from = roleBasedKeyring.address
+
+                const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+                await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+            }
+        })
+    })
+
+    context('accountUpdate.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        const fillTransactionSpys = []
+        const appendSignaturesSpys = []
+
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let hasherSpy
+
+        beforeEach(() => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                fillTransactionSpys.push(sandbox.spy(txsByAccountKeys[i], 'fillTransaction'))
+                appendSignaturesSpys.push(sandbox.spy(txsByAccountKeys[i], 'appendSignatures'))
+            }
+
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(idx, customHasher = false) {
+            expect(fillTransactionSpys[idx]).to.have.been.calledOnce
+            expect(appendSignaturesSpys[idx]).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(txsByAccountKeys[idx])
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-168: input: keyring. should sign transaction.', async () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKeys(sender)
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 1)
+            }
+            expect(createFromPrivateKeySpy).not.to.have.been.called
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-169: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 1)
+            }
+            expect(createFromPrivateKeySpy).to.have.been.callCount(Object.keys(txsByAccountKeys).length)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-170: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+                checkFunctionCall(i)
+                checkSignature(tx)
+                expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 1)
+            }
+            expect(createFromPrivateKeySpy).to.have.been.callCount(Object.keys(txsByAccountKeys).length)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-171: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                await tx.signWithKeys(sender, customHasher)
+
+                checkFunctionCall(i, true)
+                checkSignature(tx)
+                expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 1)
+            }
+            expect(createFromPrivateKeySpy).not.to.have.been.called
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-172: input: keyring. should throw error when from is different.', async () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.from = roleBasedKeyring.address
+                const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+                await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+            }
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-173: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.from = roleBasedKeyring.address
+
+                await tx.signWithKeys(roleBasedKeyring)
+
+                checkFunctionCall(i, true)
+                checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+                expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+                expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 1)
+            }
+            expect(createFromPrivateKeySpy).not.to.have.been.called
+        }).timeout(200000)
+    })
+
+    context('accountUpdate.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-174: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+
+                const sig = [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ]
+                tx.appendSignatures(sig)
+                checkSignature(tx)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-175: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+
+                const sig = [
+                    [
+                        '0x0fea',
+                        '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                        '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                    ],
+                ]
+                tx.appendSignatures(sig)
+                checkSignature(tx)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-176: If signatures is not empty, appendSignatures should append signatures', () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+                tx.signatures = [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ]
+
+                const sig = [
+                    '0x0fea',
+                    '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                    '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+                ]
+
+                tx.appendSignatures(sig)
+                checkSignature(tx, { expectedLength: 2 })
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-177: appendSignatures should append multiple signatures', () => {
+            for (let i = 0; i < txsByAccountKeys.length; i++) {
+                const tx = txsByAccountKeys[i]
+
+                const sig = [
+                    [
+                        '0x0fea',
+                        '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                        '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                    ],
+                    [
+                        '0x0fea',
+                        '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                        '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                    ],
+                ]
+
+                tx.appendSignatures(sig)
+                checkSignature(tx, { expectedLength: 2 })
+            }
+        })
+    })
+
+    context('accountUpdate.combineSignatures', () => {
+        let combinedTarget
+        beforeEach(() => {
+            const testAddress = '0x40efcb7d744fdc881f698a8ec573999fe6383545'
+            combinedTarget = {
+                from: testAddress,
+                gas: '0x15f90',
+                nonce: '0x1',
+                gasPrice: '0x5d21dba00',
+                chainId: 2019,
+                account: caver.account.createWithAccountKeyLegacy(testAddress),
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-178: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.accountUpdate(combinedTarget)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x20f86c018505d21dba0083015f909440efcb7d744fdc881f698a8ec573999fe63835458201c0f847f845820fe9a0f2a83743da6931ce25a29d04f1c51cec8464f0d9d4dabb5acb059aa3fb8c345aa065879e06474669005e02e0b8ca06cba6f8943022305659f8936f1f6109147fdd'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0xf2a83743da6931ce25a29d04f1c51cec8464f0d9d4dabb5acb059aa3fb8c345a',
+                    '0x65879e06474669005e02e0b8ca06cba6f8943022305659f8936f1f6109147fdd',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-179: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            combinedTarget.signatures = [
+                [
+                    '0x0fe9',
+                    '0xf2a83743da6931ce25a29d04f1c51cec8464f0d9d4dabb5acb059aa3fb8c345a',
+                    '0x65879e06474669005e02e0b8ca06cba6f8943022305659f8936f1f6109147fdd',
+                ],
+            ]
+            const tx = new caver.transaction.accountUpdate(combinedTarget)
+
+            const rlpEncodedStrings = [
+                '0x20f86c018505d21dba0083015f909440efcb7d744fdc881f698a8ec573999fe63835458201c0f847f845820feaa0638f0d712b4b709cadab174dea6da50e5429ea59d78446e810af954af8d67981a0129ad4eb9222e161e9e52be9c2384e1b1ff7566c640bc5b30c054efd64b081e7',
+                '0x20f86c018505d21dba0083015f909440efcb7d744fdc881f698a8ec573999fe63835458201c0f847f845820fe9a0935584330d98f4a8a1cf83bf81ea7a18e33a962ad17b6a9eb8e04e3f5f95179da026804e07b5c105427497e8336300c1435d30ffa8d379dc27e5c1facd966c58db',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x20f8fa018505d21dba0083015f909440efcb7d744fdc881f698a8ec573999fe63835458201c0f8d5f845820fe9a0f2a83743da6931ce25a29d04f1c51cec8464f0d9d4dabb5acb059aa3fb8c345aa065879e06474669005e02e0b8ca06cba6f8943022305659f8936f1f6109147fddf845820feaa0638f0d712b4b709cadab174dea6da50e5429ea59d78446e810af954af8d67981a0129ad4eb9222e161e9e52be9c2384e1b1ff7566c640bc5b30c054efd64b081e7f845820fe9a0935584330d98f4a8a1cf83bf81ea7a18e33a962ad17b6a9eb8e04e3f5f95179da026804e07b5c105427497e8336300c1435d30ffa8d379dc27e5c1facd966c58db'
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0xf2a83743da6931ce25a29d04f1c51cec8464f0d9d4dabb5acb059aa3fb8c345a',
+                    '0x65879e06474669005e02e0b8ca06cba6f8943022305659f8936f1f6109147fdd',
+                ],
+                [
+                    '0x0fea',
+                    '0x638f0d712b4b709cadab174dea6da50e5429ea59d78446e810af954af8d67981',
+                    '0x129ad4eb9222e161e9e52be9c2384e1b1ff7566c640bc5b30c054efd64b081e7',
+                ],
+                [
+                    '0x0fe9',
+                    '0x935584330d98f4a8a1cf83bf81ea7a18e33a962ad17b6a9eb8e04e3f5f95179d',
+                    '0x26804e07b5c105427497e8336300c1435d30ffa8d379dc27e5c1facd966c58db',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-180: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.accountUpdate(combinedTarget)
+            tx.nonce = 1234
+
+            const rlpEncoded =
+                '0x20f86c018505d21dba0083015f909440efcb7d744fdc881f698a8ec573999fe63835458201c0f847f845820feaa0638f0d712b4b709cadab174dea6da50e5429ea59d78446e810af954af8d67981a0129ad4eb9222e161e9e52be9c2384e1b1ff7566c640bc5b30c054efd64b081e7'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('accountUpdate.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-181: getRawTransaction should call getRLPEncoding function', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+
+                const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+                const expected = expectedValues[i].rlpEncoding
+                const rawTransaction = tx.getRawTransaction()
+
+                expect(getRLPEncodingSpy).to.have.been.calledOnce
+                expect(rawTransaction).to.equal(expected)
+            }
+        })
+    })
+
+    context('accountUpdate.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-182: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+
+                const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+                const expected = expectedValues[i].transactionHash
+                const txHash = tx.getTransactionHash()
+
+                expect(getRLPEncodingSpy).to.have.been.calledOnce
+                expect(txHash).to.equal(expected)
+                expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-183: getTransactionHash should throw error when nonce is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._nonce
+
+                const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getTransactionHash()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-184: getTransactionHash should throw error when gasPrice is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._gasPrice
+
+                const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getTransactionHash()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-185: getTransactionHash should throw error when chainId is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._chainId
+
+                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getTransactionHash()).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('accountUpdate.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-186: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+
+                const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+                const expected = expectedValues[i].senderTxHash
+                const senderTxHash = tx.getSenderTxHash()
+
+                expect(getRLPEncodingSpy).to.have.been.calledOnce
+                expect(senderTxHash).to.equal(expected)
+                expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-187: getSenderTxHash should throw error when nonce is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._nonce
+
+                const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-188: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._gasPrice
+
+                const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-189: getSenderTxHash should throw error when chainId is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._chainId
+
+                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('accountUpdate.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-190: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+
+                const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+                const expected = expectedValues[i].rlpEncodingForSigning
+                const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+                expect(rlpEncodingForSign).to.equal(expected)
+                expect(commonRLPForSigningSpy).to.have.been.calledOnce
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-191: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._nonce
+
+                const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-192: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._gasPrice
+
+                const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+            }
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-193: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._chainId
+
+                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+                expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('accountUpdate.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-194: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+
+                const expected = expectedValues[i].rlpEncodingCommon
+                const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+
+                expect(commonRLPForSign).to.equal(expected)
+            }
+        })
+    })
+
+    context('accountUpdate.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-195: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._gasPrice
+
+                await tx.fillTransaction()
+                expect(getNonceSpy).not.to.have.been.calledOnce
+                expect(getChainIdSpy).not.to.have.been.calledOnce
+            }
+            expect(getGasPriceSpy).to.have.been.callCount(Object.values(expectedValues).length)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-196: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._nonce
+
+                await tx.fillTransaction()
+                expect(getGasPriceSpy).not.to.have.been.calledOnce
+                expect(getChainIdSpy).not.to.have.been.calledOnce
+            }
+            expect(getNonceSpy).to.have.been.callCount(Object.values(expectedValues).length)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-197: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            for (let i = 0; i < expectedValues.length; i++) {
+                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
+                delete tx._chainId
+
+                await tx.fillTransaction()
+                expect(getGasPriceSpy).not.to.have.been.calledOnce
+                expect(getNonceSpy).not.to.have.been.calledOnce
+            }
+            expect(getChainIdSpy).to.have.been.callCount(Object.values(expectedValues).length)
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/cancel.js
+++ b/test/packages/caver.transaction/cancel.js
@@ -1,0 +1,763 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let roleBasedKeyring
+
+const sandbox = sinon.createSandbox()
+
+const txWithExpectedValues = {}
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0x6b604e77c0fbebb5b2941bcde3ab5eb09d99ad24',
+        gas: '0xdbba0',
+        gasPrice: '0x5d21dba00',
+        chainId: '0x7e3',
+        signatures: [
+            [
+                '0x0fea',
+                '0xd9994ef507951a59380309f656ee8ed685becdc89b1d1a0eb1d2f72683ae14d3',
+                '0x7ad5d37a89781f294fab72b254ea9266e4d039ae163db4a4c4752f1fabff023b',
+            ],
+        ],
+        nonce: '0x6',
+    }
+
+    txWithExpectedValues.rlpEncodingForSigning = '0xe8a2e138068505d21dba00830dbba0946b604e77c0fbebb5b2941bcde3ab5eb09d99ad248207e38080'
+    txWithExpectedValues.rlpEncodingCommon = '0xe138068505d21dba00830dbba0946b604e77c0fbebb5b2941bcde3ab5eb09d99ad24'
+    txWithExpectedValues.senderTxHash = '0x65a45683117b76640328ad54ada9ac801fa7b0c4605cbac271f9ab543deeab1e'
+    txWithExpectedValues.transactionHash = '0x65a45683117b76640328ad54ada9ac801fa7b0c4605cbac271f9ab543deeab1e'
+    txWithExpectedValues.rlpEncoding =
+        '0x38f869068505d21dba00830dbba0946b604e77c0fbebb5b2941bcde3ab5eb09d99ad24f847f845820feaa0d9994ef507951a59380309f656ee8ed685becdc89b1d1a0eb1d2f72683ae14d3a07ad5d37a89781f294fab72b254ea9266e4d039ae163db4a4c4752f1fabff023b'
+})
+
+describe('TxTypeCancel', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            gas: '0xdbba0',
+            nonce: '0x6',
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create cancel instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-297: If cancel not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.cancel(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-298: If cancel not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.cancel(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-299: If cancel define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.cancel(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-300: If cancel define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.to,
+                propertiesForUnnecessary.value,
+                propertiesForUnnecessary.input,
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.humanReadable,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feePayer,
+                propertiesForUnnecessary.feePayerSignatures,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeCancel} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.cancel(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('cancel.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-301: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-302: getRLPEncoding should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-303: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-304: getRLPEncoding should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('cancel.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.cancel(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-305: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-306: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-307: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-308: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-309: input: keyring, custom hasher. should throw error.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-310: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-311: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.cancel(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-312: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.cancel(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('cancel.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.cancel(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-313: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-314: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-315: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-316: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-317: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.cancel(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-318: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('cancel.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-319: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.cancel(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-320: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.cancel(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-321: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.cancel(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-322: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.cancel(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('cancel.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0x504a835246e030d70ded9027f9f5a0aefcd45143',
+                gas: '0xdbba0',
+                gasPrice: '0x5d21dba00',
+                chainId: '0x7e3',
+                nonce: '0x1',
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-323: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.cancel(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x38f869018505d21dba00830dbba094504a835246e030d70ded9027f9f5a0aefcd45143f847f845820feaa00382dcd275a9657d8fc3c4dc1509ad975f083184e3d34779dc6bef10e0e973c8a059d5deb0f4c06a35a8024506159864ffc46dd08d91d5ac16fa69e92fb2d6b9ae'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x0382dcd275a9657d8fc3c4dc1509ad975f083184e3d34779dc6bef10e0e973c8',
+                    '0x59d5deb0f4c06a35a8024506159864ffc46dd08d91d5ac16fa69e92fb2d6b9ae',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-324: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fea',
+                    '0x0382dcd275a9657d8fc3c4dc1509ad975f083184e3d34779dc6bef10e0e973c8',
+                    '0x59d5deb0f4c06a35a8024506159864ffc46dd08d91d5ac16fa69e92fb2d6b9ae',
+                ],
+            ]
+            const tx = new caver.transaction.cancel(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x38f869018505d21dba00830dbba094504a835246e030d70ded9027f9f5a0aefcd45143f847f845820feaa05a3a7910ce495e316da1394f197cdadd95dbb6954d803052b9f62ce993c0ec3ca00934f8dda9666d759e511a5658de1db36faefb35e76a5e237d87ba8c3b9bb700',
+                '0x38f869018505d21dba00830dbba094504a835246e030d70ded9027f9f5a0aefcd45143f847f845820feaa0dccd060bd76582d221f6fe7e02e70877a25b65d80fed13b69b5c79d7c4520912a07572c5c68daf7094a17105eb6e5fed1b102bfe4ca737d62b51f921f7663fb2bd',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x38f8f7018505d21dba00830dbba094504a835246e030d70ded9027f9f5a0aefcd45143f8d5f845820feaa00382dcd275a9657d8fc3c4dc1509ad975f083184e3d34779dc6bef10e0e973c8a059d5deb0f4c06a35a8024506159864ffc46dd08d91d5ac16fa69e92fb2d6b9aef845820feaa05a3a7910ce495e316da1394f197cdadd95dbb6954d803052b9f62ce993c0ec3ca00934f8dda9666d759e511a5658de1db36faefb35e76a5e237d87ba8c3b9bb700f845820feaa0dccd060bd76582d221f6fe7e02e70877a25b65d80fed13b69b5c79d7c4520912a07572c5c68daf7094a17105eb6e5fed1b102bfe4ca737d62b51f921f7663fb2bd'
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x0382dcd275a9657d8fc3c4dc1509ad975f083184e3d34779dc6bef10e0e973c8',
+                    '0x59d5deb0f4c06a35a8024506159864ffc46dd08d91d5ac16fa69e92fb2d6b9ae',
+                ],
+                [
+                    '0x0fea',
+                    '0x5a3a7910ce495e316da1394f197cdadd95dbb6954d803052b9f62ce993c0ec3c',
+                    '0x0934f8dda9666d759e511a5658de1db36faefb35e76a5e237d87ba8c3b9bb700',
+                ],
+                [
+                    '0x0fea',
+                    '0xdccd060bd76582d221f6fe7e02e70877a25b65d80fed13b69b5c79d7c4520912',
+                    '0x7572c5c68daf7094a17105eb6e5fed1b102bfe4ca737d62b51f921f7663fb2bd',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-325: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.cancel(transactionObj)
+            tx.nonce = 1234
+
+            const rlpEncoded =
+                '0x38f869018505d21dba00830dbba094504a835246e030d70ded9027f9f5a0aefcd45143f847f845820feaa05a3a7910ce495e316da1394f197cdadd95dbb6954d803052b9f62ce993c0ec3ca00934f8dda9666d759e511a5658de1db36faefb35e76a5e237d87ba8c3b9bb700'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('cancel.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-326: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.rlpEncoding
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(expected)
+        })
+    })
+
+    context('cancel.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-327: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.transactionHash
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-328: getTransactionHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-329: getTransactionHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-330: getTransactionHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('cancel.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-331: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.senderTxHash
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-332: getSenderTxHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-334: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-334: getSenderTxHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('cancel.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-335: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+            const expected = txWithExpectedValues.rlpEncodingForSigning
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(expected)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-336: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-337: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-338: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('cancel.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-339: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+
+            expect(commonRLPForSign).to.equal(txWithExpectedValues.rlpEncodingCommon)
+        })
+    })
+
+    context('cancel.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-340: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-341: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-342: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/chainDataAnchoring.js
+++ b/test/packages/caver.transaction/chainDataAnchoring.js
@@ -1,0 +1,776 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+const RLP = require('eth-lib/lib/rlp')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let roleBasedKeyring
+
+const txWithExpectedValues = {}
+const input =
+    '0xf8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405'
+
+const sandbox = sinon.createSandbox()
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B',
+        gas: '0xf4240',
+        nonce: 1234,
+        gasPrice: '0x19',
+        signatures: [
+            [
+                '0x25',
+                '0xe58b9abf9f33a066b998fccaca711553fb4df425c9234bbb3577f9d9775bb124',
+                '0x2c409a6c5d92277c0a812dd0cc553d7fe1d652a807274c3786df3292cd473e09',
+            ],
+        ],
+        input,
+        chainId: 0x1,
+    }
+
+    txWithExpectedValues.rlpEncodingForSigning =
+        '0xf8cfb8caf8c8488204d219830f424094a94f5374fce5edbc8e2a8697c15331677e6ebf0bb8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405018080'
+    txWithExpectedValues.senderTxHash = '0x4aad85735e777795d24aa3eab51be959d8ebdf9683083d85b66f70b7170f2ea3'
+    txWithExpectedValues.transactionHash = '0x4aad85735e777795d24aa3eab51be959d8ebdf9683083d85b66f70b7170f2ea3'
+    txWithExpectedValues.rlpEncoding =
+        '0x48f9010e8204d219830f424094a94f5374fce5edbc8e2a8697c15331677e6ebf0bb8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405f845f84325a0e58b9abf9f33a066b998fccaca711553fb4df425c9234bbb3577f9d9775bb124a02c409a6c5d92277c0a812dd0cc553d7fe1d652a807274c3786df3292cd473e09'
+})
+
+describe('TxTypeChainDataAnchoring', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            gas: '0x3b9ac9ff',
+            input,
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create chainDataAnchoring instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-343: If chainDataAnchoring not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.chainDataAnchoring(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-344: If chainDataAnchoring not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.chainDataAnchoring(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-345: If chainDataAnchoring not define input, return error', () => {
+            delete transactionObj.input
+
+            const expectedError = '"input" is missing'
+            expect(() => new caver.transaction.chainDataAnchoring(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-346: If chainDataAnchoring define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.chainDataAnchoring(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-347: If chainDataAnchoring define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.to,
+                propertiesForUnnecessary.value,
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feePayer,
+                propertiesForUnnecessary.feePayerSignatures,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+                propertiesForUnnecessary.humanReadable,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeChainDataAnchoring} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.chainDataAnchoring(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('chainDataAnchoring.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-348: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-349: getRLPEncoding should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-350: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-351: getRLPEncoding should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('chainDataAnchoring.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-352: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-353: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-354: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-355: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-356: input: keyring, custom hasher. c.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-357: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-358: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-359: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('chainDataAnchoring.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-360: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-361: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-362: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-363: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-364: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-365: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('chainDataAnchoring.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-366: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-367: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-368: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-369: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('chainDataAnchoring.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0xb605c7550ad5fb15ddd9291a2d31a889db808152',
+                gas: '0xf4240',
+                gasPrice: '0x5d21dba00',
+                input,
+                chainId: '0x7e3',
+                nonce: '0x1',
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-370: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x48f90113018505d21dba00830f424094b605c7550ad5fb15ddd9291a2d31a889db808152b8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405f847f845820feaa091e77e86e76dc7f1edb1ef1c87fd4bcba1fd95cbc659db407e1f358ae0cc00eda008c2fc7ec8ee14e734701435d0ca2e001bc1e0742c0fe0d58bd131a582e4f10c'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x91e77e86e76dc7f1edb1ef1c87fd4bcba1fd95cbc659db407e1f358ae0cc00ed',
+                    '0x08c2fc7ec8ee14e734701435d0ca2e001bc1e0742c0fe0d58bd131a582e4f10c',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-371: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fea',
+                    '0x91e77e86e76dc7f1edb1ef1c87fd4bcba1fd95cbc659db407e1f358ae0cc00ed',
+                    '0x08c2fc7ec8ee14e734701435d0ca2e001bc1e0742c0fe0d58bd131a582e4f10c',
+                ],
+            ]
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x48f90113018505d21dba00830f424094b605c7550ad5fb15ddd9291a2d31a889db808152b8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405f847f845820feaa0c17c5ad8820b984da2bc816f881e1e283a9d7806ed5e3c703f58a7ed1f40edf1a049c4aa23508715aba0891ddad59bab4ff6abde777adffc1f39c79e51a78b786a',
+                '0x48f90113018505d21dba00830f424094b605c7550ad5fb15ddd9291a2d31a889db808152b8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405f847f845820fe9a0d2779b46862d5d10cb31d08ad5907eccf6343148e4264c730e048bb859cf1456a052570001d11eee29ee96c9f530be948a5f270167895705454596f6e61680718c',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x48f901a1018505d21dba00830f424094b605c7550ad5fb15ddd9291a2d31a889db808152b8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405f8d5f845820feaa091e77e86e76dc7f1edb1ef1c87fd4bcba1fd95cbc659db407e1f358ae0cc00eda008c2fc7ec8ee14e734701435d0ca2e001bc1e0742c0fe0d58bd131a582e4f10cf845820feaa0c17c5ad8820b984da2bc816f881e1e283a9d7806ed5e3c703f58a7ed1f40edf1a049c4aa23508715aba0891ddad59bab4ff6abde777adffc1f39c79e51a78b786af845820fe9a0d2779b46862d5d10cb31d08ad5907eccf6343148e4264c730e048bb859cf1456a052570001d11eee29ee96c9f530be948a5f270167895705454596f6e61680718c'
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x91e77e86e76dc7f1edb1ef1c87fd4bcba1fd95cbc659db407e1f358ae0cc00ed',
+                    '0x08c2fc7ec8ee14e734701435d0ca2e001bc1e0742c0fe0d58bd131a582e4f10c',
+                ],
+                [
+                    '0x0fea',
+                    '0xc17c5ad8820b984da2bc816f881e1e283a9d7806ed5e3c703f58a7ed1f40edf1',
+                    '0x49c4aa23508715aba0891ddad59bab4ff6abde777adffc1f39c79e51a78b786a',
+                ],
+                [
+                    '0x0fe9',
+                    '0xd2779b46862d5d10cb31d08ad5907eccf6343148e4264c730e048bb859cf1456',
+                    '0x52570001d11eee29ee96c9f530be948a5f270167895705454596f6e61680718c',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-372: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.chainDataAnchoring(transactionObj)
+            tx.input = '0x'
+
+            const rlpEncoded =
+                '0x48f901a1018505d21dba00830f424094b605c7550ad5fb15ddd9291a2d31a889db808152b8a8f8a6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000405f8d5f845820feaa091e77e86e76dc7f1edb1ef1c87fd4bcba1fd95cbc659db407e1f358ae0cc00eda008c2fc7ec8ee14e734701435d0ca2e001bc1e0742c0fe0d58bd131a582e4f10cf845820feaa0c17c5ad8820b984da2bc816f881e1e283a9d7806ed5e3c703f58a7ed1f40edf1a049c4aa23508715aba0891ddad59bab4ff6abde777adffc1f39c79e51a78b786af845820fe9a0d2779b46862d5d10cb31d08ad5907eccf6343148e4264c730e048bb859cf1456a052570001d11eee29ee96c9f530be948a5f270167895705454596f6e61680718c'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('chainDataAnchoring.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-373: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.rlpEncoding
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(expected)
+        })
+    })
+
+    context('chainDataAnchoring.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-374: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.transactionHash
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-375: getTransactionHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-376: getTransactionHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-377: getTransactionHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('chainDataAnchoring.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-378: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.senderTxHash
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-379: getSenderTxHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-380: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-381: getSenderTxHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('chainDataAnchoring.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-382: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+            const expected = txWithExpectedValues.rlpEncodingForSigning
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(expected)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-383: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-384: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-385: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('chainDataAnchoring.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-386: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+            const decoded = RLP.decode(txWithExpectedValues.rlpEncodingForSigning)
+
+            expect(commonRLPForSign).to.equal(decoded[0])
+        })
+    })
+
+    context('chainDataAnchoring.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-387: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-388: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-389: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/feeDelegatedValueTransfer.js
+++ b/test/packages/caver.transaction/feeDelegatedValueTransfer.js
@@ -1,0 +1,1266 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+const RLP = require('eth-lib/lib/rlp')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature, checkFeePayerSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let testKeyring
+let roleBasedKeyring
+
+const txWithExpectedValues = {}
+
+const sandbox = sinon.createSandbox()
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    testKeyring = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B',
+        to: '0x7b65B75d204aBed71587c9E519a89277766EE1d0',
+        value: '0xa',
+        gas: '0xf4240',
+        gasPrice: '0x19',
+        chainId: '0x1',
+        nonce: 1234,
+        signatures: [
+            [
+                '0x25',
+                '0x9f8e49e2ad84b0732984398749956e807e4b526c786af3c5f7416b293e638956',
+                '0x6bf88342092f6ff9fabe31739b2ebfa1409707ce54a54693e91a6b9bb77df0e7',
+            ],
+        ],
+        feePayer: '0x5A0043070275d9f6054307Ee7348bD660849D90f',
+        feePayerSignatures: [
+            [
+                '0x26',
+                '0xf45cf8d7f88c08e6b6ec0b3b562f34ca94283e4689021987abb6b0772ddfd80a',
+                '0x298fe2c5aeabb6a518f4cbb5ff39631a5d88be505d3923374f65fdcf63c2955b',
+            ],
+        ],
+    }
+    txWithExpectedValues.rlpEncodingForSigning =
+        '0xf839b5f4098204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b018080'
+    txWithExpectedValues.rlpEncodingForFeePayerSigning =
+        '0xf84eb5f4098204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b945a0043070275d9f6054307ee7348bd660849d90f018080'
+    txWithExpectedValues.senderTxHash = '0x40f8c94e01e07eb5353f6cd4cd3eabd5893215dd53a50ba4b8ff9a447ac51731'
+    txWithExpectedValues.transactionHash = '0xe1e07f9971153499fc8c7bafcdaf7abc20b37aa4c18fb1e53a9bfcc259e3644c'
+    txWithExpectedValues.rlpEncoding =
+        '0x09f8d68204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0bf845f84325a09f8e49e2ad84b0732984398749956e807e4b526c786af3c5f7416b293e638956a06bf88342092f6ff9fabe31739b2ebfa1409707ce54a54693e91a6b9bb77df0e7945a0043070275d9f6054307ee7348bd660849d90ff845f84326a0f45cf8d7f88c08e6b6ec0b3b562f34ca94283e4689021987abb6b0772ddfd80aa0298fe2c5aeabb6a518f4cbb5ff39631a5d88be505d3923374f65fdcf63c2955b'
+})
+
+describe('TxTypeFeeDelegatedValueTransfer', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            to: testKeyring.address,
+            value: 1,
+            gas: '0x3b9ac9ff',
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create feeDelegatedValueTransfer instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-390: If feeDelegatedValueTransfer not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-391: If feeDelegatedValueTransfer not define to, return error', () => {
+            delete transactionObj.to
+
+            const expectedError = '"to" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-392: If feeDelegatedValueTransfer not define value, return error', () => {
+            delete transactionObj.value
+
+            const expectedError = '"value" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-393: If feeDelegatedValueTransfer not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-394: If feeDelegatedValueTransfer define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-395: If feeDelegatedValueTransfer define feePayer property with invalid address, return error', () => {
+            transactionObj.feePayer = 'invalid'
+
+            const expectedError = `Invalid address of fee payer: ${transactionObj.feePayer}`
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-396: If feeDelegatedValueTransfer define to property with invalid address, return error', () => {
+            transactionObj.to = 'invalid address'
+
+            const expectedError = `Invalid address of to: ${transactionObj.to}`
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-397: If feeDelegatedValueTransfer define feePayerSignatures property without feePayer, return error', () => {
+            transactionObj.feePayerSignatures = [
+                [
+                    '0x26',
+                    '0xf45cf8d7f88c08e6b6ec0b3b562f34ca94283e4689021987abb6b0772ddfd80a',
+                    '0x298fe2c5aeabb6a518f4cbb5ff39631a5d88be505d3923374f65fdcf63c2955b',
+                ],
+            ]
+
+            const expectedError = '"feePayer" is missing: feePayer must be defined with feePayerSignatures.'
+            expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-398: If feeDelegatedValueTransfer define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.data,
+                propertiesForUnnecessary.input,
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+                propertiesForUnnecessary.humanReadable,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeFeeDelegatedValueTransfer} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.feeDelegatedValueTransfer(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('feeDelegatedValueTransfer.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-399: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-400: getRLPEncoding should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-401: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-402: getRLPEncoding should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransfer.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-403: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-404: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-405: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-406: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-407: input: keyring, custom hasher. should throw error.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-408: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-409: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-410: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransfer.signFeePayerWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+            tx.feePayer = sender.address
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForFeePayerSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-411: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
+            tx.feePayer = '0x'
+            await tx.signFeePayerWithKey(sender)
+
+            expect(tx.feePayer.toLowerCase()).to.equal(sender.address.toLowerCase())
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-412: input: keyring. should sign transaction.', async () => {
+            await tx.signFeePayerWithKey(sender)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-413: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signFeePayerWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-414: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signFeePayerWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-145: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.feePayer = roleBasedKeyring.address
+
+            await tx.signFeePayerWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-416: input: keyring, custom hasher. should throw error.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signFeePayerWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-417: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.feePayer = roleBasedKeyring.address
+
+            await tx.signFeePayerWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 2, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-418: input: keyring. should throw error when feePayer is different.', async () => {
+            tx.feePayer = roleBasedKeyring.address
+
+            const expectedError = `The feePayer address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signFeePayerWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-419: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signFeePayerWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransfer.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-420: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-421: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-422: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-423: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-424: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-425: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransfer.signFeePayerWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForFeePayerSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-426: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
+            tx.feePayer = '0x'
+            await tx.signFeePayerWithKeys(sender)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-427: input: keyring. should sign transaction.', async () => {
+            await tx.signFeePayerWithKeys(sender)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-428: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signFeePayerWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-429: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signFeePayerWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-430: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signFeePayerWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-431: input: keyring. should throw error when feePayer is different.', async () => {
+            tx.feePayer = roleBasedKeyring.address
+
+            const expectedError = `The feePayer address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signFeePayerWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-432: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.feePayer = roleBasedKeyring.address
+
+            await tx.signFeePayerWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkFeePayerSignature(tx, { expectedLength: roleBasedKeyring.keys[2].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransfer.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-433: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-434: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-435: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-436: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('feeDelegatedValueTransfer.appendFeePayerSignatures', () => {
+        beforeEach(() => {
+            transactionObj.feePayer = '0x90b3e9a3770481345a7f17f22f16d020bccfd33e'
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-437: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures in transaction', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-438: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-439: If feePayerSignatures is not empty, appendFeePayerSignatures should append feePayerSignatures', () => {
+            transactionObj.feePayerSignatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-440: appendFeePayerSignatures should append multiple feePayerSignatures', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('feeDelegatedValueTransfer.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0x04bb86a1b16113ebe8f57071f839b002cbcbf7d0',
+                to: '0x7b65b75d204abed71587c9e519a89277766ee1d0',
+                value: '0xa',
+                gas: '0xf4240',
+                nonce: '0x1',
+                gasPrice: '0x5d21dba00',
+                chainId: '0x7e3',
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-441: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x09f885018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0f847f845820feaa068e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492a068c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c280c4c3018080'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x68e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492',
+                    '0x68c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c2',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-442: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fea',
+                    '0x68e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492',
+                    '0x68c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c2',
+                ],
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x09f885018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0f847f845820feaa007337912a1855c1b3ca511eb44099350590e54aa611069058a9b739945ad97eaa037dfa221d29bc6d418ade23456de937993885b77cde5bc265739f278deebbc3980c4c3018080',
+                '0x09f885018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0f847f845820fe9a0799f833aa487296b11988650c9a63dc2a850715de4a29c8ab2b7c648718205a6a005a5fbad245cceccb4c08dd4a1cc6e26dc4fda06d0f49b248f83329623e3bee880c4c3018080',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x09f90113018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0f8d5f845820feaa068e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492a068c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c2f845820feaa007337912a1855c1b3ca511eb44099350590e54aa611069058a9b739945ad97eaa037dfa221d29bc6d418ade23456de937993885b77cde5bc265739f278deebbc39f845820fe9a0799f833aa487296b11988650c9a63dc2a850715de4a29c8ab2b7c648718205a6a005a5fbad245cceccb4c08dd4a1cc6e26dc4fda06d0f49b248f83329623e3bee880c4c3018080'
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x68e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492',
+                    '0x68c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c2',
+                ],
+                [
+                    '0x0fea',
+                    '0x07337912a1855c1b3ca511eb44099350590e54aa611069058a9b739945ad97ea',
+                    '0x37dfa221d29bc6d418ade23456de937993885b77cde5bc265739f278deebbc39',
+                ],
+                [
+                    '0x0fe9',
+                    '0x799f833aa487296b11988650c9a63dc2a850715de4a29c8ab2b7c648718205a6',
+                    '0x05a5fbad245cceccb4c08dd4a1cc6e26dc4fda06d0f49b248f83329623e3bee8',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-443: combineSignatures combines single feePayerSignature and sets feePayerSignatures in transaction', () => {
+            transactionObj.feePayer = '0xb85f01a3b0b6aaa2e487c9ed541e27b75b3eba95'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x09f899018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0c4c301808094b85f01a3b0b6aaa2e487c9ed541e27b75b3eba95f847f845820fe9a0388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dda065b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dd',
+                    '0x65b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkFeePayerSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-444: combineSignatures combines multiple feePayerSignatures and sets feePayerSignatures in transaction', () => {
+            transactionObj.feePayer = '0xb85f01a3b0b6aaa2e487c9ed541e27b75b3eba95'
+            transactionObj.feePayerSignatures = [
+                [
+                    '0x0fe9',
+                    '0x388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dd',
+                    '0x65b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2',
+                ],
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x09f899018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0c4c301808094b85f01a3b0b6aaa2e487c9ed541e27b75b3eba95f847f845820fe9a00585c73b60072ebb22bcc38b08e318dc88fc074435c3fa5d345219f1962098b7a06adcc5a1bc49d1c465412628bf8782aa8254af7fae8763d834a3f1711b22474a',
+                '0x09f899018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0c4c301808094b85f01a3b0b6aaa2e487c9ed541e27b75b3eba95f847f845820feaa0d432bdce799828530d89d14b4406ccb0446852a51f13e365123eac9375d7e629a04f73deb5343ff7d587a5affb14196a79c522b9a67c7d895762c6758258ac247b',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x09f90127018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0c4c301808094b85f01a3b0b6aaa2e487c9ed541e27b75b3eba95f8d5f845820fe9a0388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dda065b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2f845820fe9a00585c73b60072ebb22bcc38b08e318dc88fc074435c3fa5d345219f1962098b7a06adcc5a1bc49d1c465412628bf8782aa8254af7fae8763d834a3f1711b22474af845820feaa0d432bdce799828530d89d14b4406ccb0446852a51f13e365123eac9375d7e629a04f73deb5343ff7d587a5affb14196a79c522b9a67c7d895762c6758258ac247b'
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dd',
+                    '0x65b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2',
+                ],
+                [
+                    '0x0fe9',
+                    '0x0585c73b60072ebb22bcc38b08e318dc88fc074435c3fa5d345219f1962098b7',
+                    '0x6adcc5a1bc49d1c465412628bf8782aa8254af7fae8763d834a3f1711b22474a',
+                ],
+                [
+                    '0x0fea',
+                    '0xd432bdce799828530d89d14b4406ccb0446852a51f13e365123eac9375d7e629',
+                    '0x4f73deb5343ff7d587a5affb14196a79c522b9a67c7d895762c6758258ac247b',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkFeePayerSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-445: combineSignatures combines multiple signatures and feePayerSignatures', () => {
+            let tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            // RLP encoding with only signatures
+            const rlpEncodedStrings = [
+                '0x09f90113018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0f8d5f845820feaa068e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492a068c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c2f845820feaa007337912a1855c1b3ca511eb44099350590e54aa611069058a9b739945ad97eaa037dfa221d29bc6d418ade23456de937993885b77cde5bc265739f278deebbc39f845820fe9a0799f833aa487296b11988650c9a63dc2a850715de4a29c8ab2b7c648718205a6a005a5fbad245cceccb4c08dd4a1cc6e26dc4fda06d0f49b248f83329623e3bee880c4c3018080',
+            ]
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x68e56f3da7fbe7a86543eb4b244ddbcb13b2d1cb9adb3ee8a4c8b046821bc492',
+                    '0x68c29c057055f68a7860b54184bba7967bcf42b6aae12beaf9f30933e6e730c2',
+                ],
+                [
+                    '0x0fea',
+                    '0x07337912a1855c1b3ca511eb44099350590e54aa611069058a9b739945ad97ea',
+                    '0x37dfa221d29bc6d418ade23456de937993885b77cde5bc265739f278deebbc39',
+                ],
+                [
+                    '0x0fe9',
+                    '0x799f833aa487296b11988650c9a63dc2a850715de4a29c8ab2b7c648718205a6',
+                    '0x05a5fbad245cceccb4c08dd4a1cc6e26dc4fda06d0f49b248f83329623e3bee8',
+                ],
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            let combined = tx.combineSignatures(rlpEncodedStrings)
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+
+            const rlpEncodedStringsWithFeePayerSignatures = [
+                '0x09f90127018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0c4c301808094b85f01a3b0b6aaa2e487c9ed541e27b75b3eba95f8d5f845820fe9a0388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dda065b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2f845820fe9a00585c73b60072ebb22bcc38b08e318dc88fc074435c3fa5d345219f1962098b7a06adcc5a1bc49d1c465412628bf8782aa8254af7fae8763d834a3f1711b22474af845820feaa0d432bdce799828530d89d14b4406ccb0446852a51f13e365123eac9375d7e629a04f73deb5343ff7d587a5affb14196a79c522b9a67c7d895762c6758258ac247b',
+            ]
+            const expectedFeePayerSignatures = [
+                [
+                    '0x0fe9',
+                    '0x388a4beb8a27fe3c3631eb66278f0a756da13562af5fa1c33345eccf742555dd',
+                    '0x65b829314f8e91f2ee0266d4f4936d3f3bdc7ef1364a931a068742834c2519f2',
+                ],
+                [
+                    '0x0fe9',
+                    '0x0585c73b60072ebb22bcc38b08e318dc88fc074435c3fa5d345219f1962098b7',
+                    '0x6adcc5a1bc49d1c465412628bf8782aa8254af7fae8763d834a3f1711b22474a',
+                ],
+                [
+                    '0x0fea',
+                    '0xd432bdce799828530d89d14b4406ccb0446852a51f13e365123eac9375d7e629',
+                    '0x4f73deb5343ff7d587a5affb14196a79c522b9a67c7d895762c6758258ac247b',
+                ],
+            ]
+
+            const appendFeePayerSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            combined = tx.combineSignatures(rlpEncodedStrings)
+            expect(appendFeePayerSignaturesSpy).to.have.been.callCount(rlpEncodedStringsWithFeePayerSignatures.length)
+
+            // combine multiple signatures and feePayerSignatures
+            tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+            const combinedWithMultiple = tx.combineSignatures([combined])
+
+            expect(combined).to.equal(combinedWithMultiple)
+            checkSignature(tx, { expectedSignatures })
+            checkFeePayerSignature(tx, { expectedFeePayerSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-446: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+            tx.value = 10000
+
+            const rlpEncoded =
+                '0x09f899018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a9404bb86a1b16113ebe8f57071f839b002cbcbf7d0c4c301808094b85f01a3b0b6aaa2e487c9ed541e27b75b3eba95f847f845820feaa0d432bdce799828530d89d14b4406ccb0446852a51f13e365123eac9375d7e629a04f73deb5343ff7d587a5affb14196a79c522b9a67c7d895762c6758258ac247b'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransfer.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-447: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+    })
+
+    context('feeDelegatedValueTransfer.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-448: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(txWithExpectedValues.transactionHash)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-449: getTransactionHash should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-450: getTransactionHash should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-451: getTransactionHash should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransfer.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-452: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(txWithExpectedValues.senderTxHash)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-453: getSenderTxHash should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-454: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-455: getSenderTxHash should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransfer.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-456: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(txWithExpectedValues.rlpEncodingForSigning)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-457: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-458: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-459: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransfer.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-460: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransfer(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+            const decoded = RLP.decode(txWithExpectedValues.rlpEncodingForSigning)
+
+            expect(commonRLPForSign).to.equal(decoded[0])
+        })
+    })
+
+    context('feeDelegatedValueTransfer.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-461: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            transactionObj.nonce = '0x3a'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-462: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-463: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/feeDelegatedValueTransferMemo.js
+++ b/test/packages/caver.transaction/feeDelegatedValueTransferMemo.js
@@ -1,0 +1,1274 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+const RLP = require('eth-lib/lib/rlp')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature, checkFeePayerSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let testKeyring
+let roleBasedKeyring
+
+const txWithExpectedValues = {}
+
+const sandbox = sinon.createSandbox()
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    testKeyring = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B',
+        to: '0x7b65B75d204aBed71587c9E519a89277766EE1d0',
+        value: '0xa',
+        input: '0x68656c6c6f',
+        gas: '0xf4240',
+        gasPrice: '0x19',
+        chainId: '0x1',
+        nonce: 1234,
+        signatures: [
+            [
+                '0x26',
+                '0x64e213aef0167fbd853f8f9989ef5d8b912a77457395ccf13d7f37009edd5c5b',
+                '0x5d0c2e55e4d8734fe2516ed56ac628b74c0eb02aa3b6eda51e1e25a1396093e1',
+            ],
+        ],
+        feePayer: '0x5A0043070275d9f6054307Ee7348bD660849D90f',
+        feePayerSignatures: [
+            [
+                '0x26',
+                '0x87390ac14d3c34440b6ddb7b190d3ebde1a07d9a556e5a82ce7e501f24a060f9',
+                '0x37badbcb12cda1ed67b12b1831683a08a3adadee2ea760a07a46bdbb856fea44',
+            ],
+        ],
+    }
+    txWithExpectedValues.rlpEncodingForSigning =
+        '0xf841b83cf83a118204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b8568656c6c6f018080'
+    txWithExpectedValues.rlpEncodingForFeePayerSigning =
+        '0xf856b83cf83a118204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b8568656c6c6f945a0043070275d9f6054307ee7348bd660849d90f018080'
+    txWithExpectedValues.senderTxHash = '0xfffaa2b38d4e684ea70a89c78fc7b2659000d130c76ad721d68175cbfc77c550'
+    txWithExpectedValues.transactionHash = '0x8f68882f6192a53ba470aeca1e83ed9b9e519906a91256724b284dee778b21c9'
+    txWithExpectedValues.rlpEncoding =
+        '0x11f8dc8204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b8568656c6c6ff845f84326a064e213aef0167fbd853f8f9989ef5d8b912a77457395ccf13d7f37009edd5c5ba05d0c2e55e4d8734fe2516ed56ac628b74c0eb02aa3b6eda51e1e25a1396093e1945a0043070275d9f6054307ee7348bd660849d90ff845f84326a087390ac14d3c34440b6ddb7b190d3ebde1a07d9a556e5a82ce7e501f24a060f9a037badbcb12cda1ed67b12b1831683a08a3adadee2ea760a07a46bdbb856fea44'
+})
+
+describe('TxTypeFeeDelegatedValueTransferMemo', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            to: testKeyring.address,
+            value: 1,
+            input: '0x68656c6c6f',
+            gas: '0x3b9ac9ff',
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create feeDelegatedValueTransferMemo instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-464: If feeDelegatedValueTransferMemo not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-465: If feeDelegatedValueTransferMemo not define to, return error', () => {
+            delete transactionObj.to
+
+            const expectedError = '"to" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-466: If feeDelegatedValueTransferMemo not define value, return error', () => {
+            delete transactionObj.value
+
+            const expectedError = '"value" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-467: If feeDelegatedValueTransferMemo not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-468: If feeDelegatedValueTransferMemo not define input, return error', () => {
+            delete transactionObj.input
+
+            const expectedError = '"input" is missing'
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-469: If feeDelegatedValueTransferMemo define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-470: If feeDelegatedValueTransferMemo define feePayer property with invalid address, return error', () => {
+            transactionObj.feePayer = 'invalid'
+
+            const expectedError = `Invalid address of fee payer: ${transactionObj.feePayer}`
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-471: If feeDelegatedValueTransferMemo define to property with invalid address, return error', () => {
+            transactionObj.to = 'invalid address'
+
+            const expectedError = `Invalid address of to: ${transactionObj.to}`
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-472: If feeDelegatedValueTransferMemo define feePayerSignatures property without feePayer, return error', () => {
+            transactionObj.feePayerSignatures = [
+                [
+                    '0x26',
+                    '0xf45cf8d7f88c08e6b6ec0b3b562f34ca94283e4689021987abb6b0772ddfd80a',
+                    '0x298fe2c5aeabb6a518f4cbb5ff39631a5d88be505d3923374f65fdcf63c2955b',
+                ],
+            ]
+
+            const expectedError = '"feePayer" is missing: feePayer must be defined with feePayerSignatures.'
+            expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-473: If feeDelegatedValueTransferMemo define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+                propertiesForUnnecessary.humanReadable,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeFeeDelegatedValueTransferMemo} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-474: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-475: getRLPEncoding should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-476: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-477: getRLPEncoding should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-478: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-479: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-480: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-481: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-482: input: keyring, custom hasher. should throw error.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-483: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-484: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-485: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransferMemo.signFeePayerWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+            tx.feePayer = sender.address
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForFeePayerSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-486: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
+            tx.feePayer = '0x'
+            await tx.signFeePayerWithKey(sender)
+
+            expect(tx.feePayer.toLowerCase()).to.equal(sender.address.toLowerCase())
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-487: input: keyring. should sign transaction.', async () => {
+            await tx.signFeePayerWithKey(sender)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-488: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signFeePayerWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-489: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signFeePayerWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-490: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.feePayer = roleBasedKeyring.address
+
+            await tx.signFeePayerWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-491: input: keyring, custom hasher. should throw error.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signFeePayerWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-492: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.feePayer = roleBasedKeyring.address
+
+            await tx.signFeePayerWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 2, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-493: input: keyring. should throw error when feePayer is different.', async () => {
+            tx.feePayer = roleBasedKeyring.address
+
+            const expectedError = `The feePayer address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signFeePayerWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-494: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signFeePayerWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransferMemo.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-495: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-496: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-497: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-498: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-499: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-500: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransferMemo.signFeePayerWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForFeePayerSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-501: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
+            tx.feePayer = '0x'
+            await tx.signFeePayerWithKeys(sender)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-502: input: keyring. should sign transaction.', async () => {
+            await tx.signFeePayerWithKeys(sender)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-503: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signFeePayerWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-504: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signFeePayerWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-505: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signFeePayerWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkFeePayerSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 2)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-506: input: keyring. should throw error when feePayer is different.', async () => {
+            tx.feePayer = roleBasedKeyring.address
+
+            const expectedError = `The feePayer address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signFeePayerWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-507: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.feePayer = roleBasedKeyring.address
+
+            await tx.signFeePayerWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkFeePayerSignature(tx, { expectedLength: roleBasedKeyring.keys[2].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
+        }).timeout(200000)
+    })
+
+    context('feeDelegatedValueTransferMemo.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-508: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-509: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-510: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-511: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.appendFeePayerSignatures', () => {
+        beforeEach(() => {
+            transactionObj.feePayer = '0x90b3e9a3770481345a7f17f22f16d020bccfd33e'
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-512: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures in transaction', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-513: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-514: If feePayerSignatures is not empty, appendFeePayerSignatures should append feePayerSignatures', () => {
+            transactionObj.feePayerSignatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-515: appendFeePayerSignatures should append multiple feePayerSignatures', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendFeePayerSignatures(sig)
+            checkFeePayerSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0x1bc5339c6c55380d0da8aaa28e135164ecb86262',
+                to: '0x7b65b75d204abed71587c9e519a89277766ee1d0',
+                value: '0xa',
+                input: '0x68656c6c6f',
+                gas: '0xf4240',
+                nonce: '0x1',
+                gasPrice: '0x5d21dba00',
+                chainId: '0x7e3',
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-516: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x11f88b018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6ff847f845820feaa060a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aeaa001586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26e80c4c3018080'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x60a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aea',
+                    '0x01586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26e',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-517: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fea',
+                    '0x60a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aea',
+                    '0x01586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26e',
+                ],
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x11f88b018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6ff847f845820fe9a0b8f3ba052cd0ef34b683a3e8ad6f68f71a82d9416bf9732def4b66802967a055a07c241fa9b7d32b72fc8310e886c5b70de262457fd07711cbb2e17217d8c39b2680c4c3018080',
+                '0x11f88b018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6ff847f845820feaa06c301c61b6b8746f63baf57c477bd269ecdeb07d6200a719988bfcd0b7767bc1a016da23b63b4e54ffa16ce8668987e48a76b8e64ba7863359462efd1e8d9838a680c4c3018080',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x11f90119018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6ff8d5f845820feaa060a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aeaa001586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26ef845820fe9a0b8f3ba052cd0ef34b683a3e8ad6f68f71a82d9416bf9732def4b66802967a055a07c241fa9b7d32b72fc8310e886c5b70de262457fd07711cbb2e17217d8c39b26f845820feaa06c301c61b6b8746f63baf57c477bd269ecdeb07d6200a719988bfcd0b7767bc1a016da23b63b4e54ffa16ce8668987e48a76b8e64ba7863359462efd1e8d9838a680c4c3018080'
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x60a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aea',
+                    '0x01586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26e',
+                ],
+                [
+                    '0x0fe9',
+                    '0xb8f3ba052cd0ef34b683a3e8ad6f68f71a82d9416bf9732def4b66802967a055',
+                    '0x7c241fa9b7d32b72fc8310e886c5b70de262457fd07711cbb2e17217d8c39b26',
+                ],
+                [
+                    '0x0fea',
+                    '0x6c301c61b6b8746f63baf57c477bd269ecdeb07d6200a719988bfcd0b7767bc1',
+                    '0x16da23b63b4e54ffa16ce8668987e48a76b8e64ba7863359462efd1e8d9838a6',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-518: combineSignatures combines single feePayerSignature and sets feePayerSignatures in transaction', () => {
+            transactionObj.feePayer = '0x8d2f6e4986bc55e2d50611149e5725999a763d7c'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x11f89f018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6fc4c3018080948d2f6e4986bc55e2d50611149e5725999a763d7cf847f845820feaa0779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06a07d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06',
+                    '0x7d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkFeePayerSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-519: combineSignatures combines multiple feePayerSignatures and sets feePayerSignatures in transaction', () => {
+            transactionObj.feePayer = '0x8d2f6e4986bc55e2d50611149e5725999a763d7c'
+            transactionObj.feePayerSignatures = [
+                [
+                    '0x0fea',
+                    '0x779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06',
+                    '0x7d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392',
+                ],
+            ]
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x11f89f018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6fc4c3018080948d2f6e4986bc55e2d50611149e5725999a763d7cf847f845820fe9a0de14998f4aba6474b55b84e9a236daf159252b460915cea204a4361cf99c9dc9a0743a40d63646defba13c70581d85000836155dddb30bc8024c62dad76981abec',
+                '0x11f89f018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6fc4c3018080948d2f6e4986bc55e2d50611149e5725999a763d7cf847f845820fe9a034fa68120ce57d201f0c859308d32d74835e7969555960c4041a466c9e2f8788a05a996a8c67347f0eba83cd6b38fe030aff2e8356e4b5ec2af85549f040014e3d',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x11f9012d018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6fc4c3018080948d2f6e4986bc55e2d50611149e5725999a763d7cf8d5f845820feaa0779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06a07d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392f845820fe9a0de14998f4aba6474b55b84e9a236daf159252b460915cea204a4361cf99c9dc9a0743a40d63646defba13c70581d85000836155dddb30bc8024c62dad76981abecf845820fe9a034fa68120ce57d201f0c859308d32d74835e7969555960c4041a466c9e2f8788a05a996a8c67347f0eba83cd6b38fe030aff2e8356e4b5ec2af85549f040014e3d'
+
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06',
+                    '0x7d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392',
+                ],
+                [
+                    '0x0fe9',
+                    '0xde14998f4aba6474b55b84e9a236daf159252b460915cea204a4361cf99c9dc9',
+                    '0x743a40d63646defba13c70581d85000836155dddb30bc8024c62dad76981abec',
+                ],
+                [
+                    '0x0fe9',
+                    '0x34fa68120ce57d201f0c859308d32d74835e7969555960c4041a466c9e2f8788',
+                    '0x5a996a8c67347f0eba83cd6b38fe030aff2e8356e4b5ec2af85549f040014e3d',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkFeePayerSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-520: combineSignatures combines multiple signatures and feePayerSignatures', () => {
+            let tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            // RLP encoding with only signatures
+            const rlpEncodedStrings = [
+                '0x11f90119018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6ff8d5f845820feaa060a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aeaa001586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26ef845820fe9a0b8f3ba052cd0ef34b683a3e8ad6f68f71a82d9416bf9732def4b66802967a055a07c241fa9b7d32b72fc8310e886c5b70de262457fd07711cbb2e17217d8c39b26f845820feaa06c301c61b6b8746f63baf57c477bd269ecdeb07d6200a719988bfcd0b7767bc1a016da23b63b4e54ffa16ce8668987e48a76b8e64ba7863359462efd1e8d9838a680c4c3018080',
+            ]
+            const expectedSignatures = [
+                [
+                    '0x0fea',
+                    '0x60a20eed201a2b28bc452b65c699083a6399aaeff2a7572c5c8cf54056254aea',
+                    '0x01586e5321f51ed56da5241d6cc8365bdcade89c4b08d2615bc21231f5e2c26e',
+                ],
+                [
+                    '0x0fe9',
+                    '0xb8f3ba052cd0ef34b683a3e8ad6f68f71a82d9416bf9732def4b66802967a055',
+                    '0x7c241fa9b7d32b72fc8310e886c5b70de262457fd07711cbb2e17217d8c39b26',
+                ],
+                [
+                    '0x0fea',
+                    '0x6c301c61b6b8746f63baf57c477bd269ecdeb07d6200a719988bfcd0b7767bc1',
+                    '0x16da23b63b4e54ffa16ce8668987e48a76b8e64ba7863359462efd1e8d9838a6',
+                ],
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            let combined = tx.combineSignatures(rlpEncodedStrings)
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+
+            const rlpEncodedStringsWithFeePayerSignatures = [
+                '0x11f9012d018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6fc4c3018080948d2f6e4986bc55e2d50611149e5725999a763d7cf8d5f845820feaa0779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06a07d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392f845820fe9a0de14998f4aba6474b55b84e9a236daf159252b460915cea204a4361cf99c9dc9a0743a40d63646defba13c70581d85000836155dddb30bc8024c62dad76981abecf845820fe9a034fa68120ce57d201f0c859308d32d74835e7969555960c4041a466c9e2f8788a05a996a8c67347f0eba83cd6b38fe030aff2e8356e4b5ec2af85549f040014e3d',
+            ]
+            const expectedFeePayerSignatures = [
+                [
+                    '0x0fea',
+                    '0x779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06',
+                    '0x7d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392',
+                ],
+                [
+                    '0x0fe9',
+                    '0xde14998f4aba6474b55b84e9a236daf159252b460915cea204a4361cf99c9dc9',
+                    '0x743a40d63646defba13c70581d85000836155dddb30bc8024c62dad76981abec',
+                ],
+                [
+                    '0x0fe9',
+                    '0x34fa68120ce57d201f0c859308d32d74835e7969555960c4041a466c9e2f8788',
+                    '0x5a996a8c67347f0eba83cd6b38fe030aff2e8356e4b5ec2af85549f040014e3d',
+                ],
+            ]
+
+            const appendFeePayerSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
+            combined = tx.combineSignatures(rlpEncodedStrings)
+            expect(appendFeePayerSignaturesSpy).to.have.been.callCount(rlpEncodedStringsWithFeePayerSignatures.length)
+
+            // combine multiple signatures and feePayerSignatures
+            tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+            const combinedWithMultiple = tx.combineSignatures([combined])
+
+            expect(combined).to.equal(combinedWithMultiple)
+            checkSignature(tx, { expectedSignatures })
+            checkFeePayerSignature(tx, { expectedFeePayerSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-521: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+            tx.value = 10000
+
+            const rlpEncoded =
+                '0x11f9012d018505d21dba00830f4240947b65b75d204abed71587c9e519a89277766ee1d00a941bc5339c6c55380d0da8aaa28e135164ecb862628568656c6c6fc4c3018080948d2f6e4986bc55e2d50611149e5725999a763d7cf8d5f845820feaa0779d20a7958d3131e5ef6a423abb2337e8f120bd0798c47227aee51c70d23c06a07d3c36d5a33cb18e8fec7d1e1f2cfd9a0ec932adee9ad9a090fcd28fafd44392f845820fe9a0de14998f4aba6474b55b84e9a236daf159252b460915cea204a4361cf99c9dc9a0743a40d63646defba13c70581d85000836155dddb30bc8024c62dad76981abecf845820fe9a034fa68120ce57d201f0c859308d32d74835e7969555960c4041a466c9e2f8788a05a996a8c67347f0eba83cd6b38fe030aff2e8356e4b5ec2af85549f040014e3d'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-522: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-523: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(txWithExpectedValues.transactionHash)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-524: getTransactionHash should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-525: getTransactionHash should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-526: getTransactionHash should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-527: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(txWithExpectedValues.senderTxHash)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-528: getSenderTxHash should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-529: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-530: getSenderTxHash should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-531: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(txWithExpectedValues.rlpEncodingForSigning)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-532: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-533: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-534: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-535: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+            const decoded = RLP.decode(txWithExpectedValues.rlpEncodingForSigning)
+
+            expect(commonRLPForSign).to.equal(decoded[0])
+        })
+    })
+
+    context('feeDelegatedValueTransferMemo.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-536: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            transactionObj.nonce = '0x3a'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-537: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-538: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/smartContractDeploy.js
+++ b/test/packages/caver.transaction/smartContractDeploy.js
@@ -1,0 +1,801 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let roleBasedKeyring
+
+const sandbox = sinon.createSandbox()
+
+const byteCode =
+    '0x60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb0029'
+
+const txWithExpectedValues = {}
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0xd91aec35bea25d379e49cfe2dff5f5775cdac1a3',
+        value: '0x0',
+        gas: '0xdbba0',
+        gasPrice: '0x5d21dba00',
+        input: byteCode,
+        chainId: '0x7e3',
+        signatures: [
+            [
+                '0x0fe9',
+                '0x018a9f680a74e275f1f83a5c2c45e1313c52432df4595e944240b1511a4f4ba7',
+                '0x2d762c3417f91b81db4907db832cb28cc64df7dca3ea9be64899ab3f4812f016',
+            ],
+        ],
+        humanReadable: false,
+        codeFormat: 'EVM',
+        nonce: '0x1f',
+    }
+
+    txWithExpectedValues.rlpEncodingForSigning =
+        '0xf90241b90239f90236281f8505d21dba00830dbba0808094d91aec35bea25d379e49cfe2dff5f5775cdac1a3b9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb002980808207e38080'
+    txWithExpectedValues.rlpEncodingCommon =
+        '0xf90236281f8505d21dba00830dbba0808094d91aec35bea25d379e49cfe2dff5f5775cdac1a3b9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080'
+    txWithExpectedValues.senderTxHash = '0x523417d946221c4d12b58519580edca43662577df7e107f5ff92f115d4b3d210'
+    txWithExpectedValues.transactionHash = '0x523417d946221c4d12b58519580edca43662577df7e107f5ff92f115d4b3d210'
+    txWithExpectedValues.rlpEncoding =
+        '0x28f9027e1f8505d21dba00830dbba0808094d91aec35bea25d379e49cfe2dff5f5775cdac1a3b9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080f847f845820fe9a0018a9f680a74e275f1f83a5c2c45e1313c52432df4595e944240b1511a4f4ba7a02d762c3417f91b81db4907db832cb28cc64df7dca3ea9be64899ab3f4812f016'
+})
+
+describe('TxTypeSmartContractDeploy', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            value: 0,
+            gas: '0x15f90',
+            input: byteCode,
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create smartContractDeploy instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-198: If smartContractDeploy not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-199: If smartContractDeploy not define value, return error', () => {
+            delete transactionObj.value
+
+            const expectedError = '"value" is missing'
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-200: If smartContractDeploy not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-201: If smartContractDeploy not define input, return error', () => {
+            delete transactionObj.input
+
+            const expectedError = '"input" is missing'
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-202: If smartContractDeploy define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-203: If smartContractDeploy define codeFormat property with invalid codeFormat, return error', () => {
+            transactionObj.codeFormat = 'nonEVM'
+
+            const expectedError = `The codeFormat(${transactionObj.codeFormat}) is invalid.`
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-204: If smartContractDeploy define humanReadable property with true, return error', () => {
+            transactionObj.humanReadable = true
+
+            const expectedError = `HumanReadableAddress is not supported yet.`
+            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-205: If smartContractDeploy define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.to,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feePayer,
+                propertiesForUnnecessary.feePayerSignatures,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeSmartContractDeploy} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('smartContractDeploy.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-206: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-207: getRLPEncoding should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-208: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-209: getRLPEncoding should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractDeploy.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-210: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-211: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-212: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-213: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-214: input: keyring, custom hasher. c.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-215: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-216: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-217: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('smartContractDeploy.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-218: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-219: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-220: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-221: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-222: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-223: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('smartContractDeploy.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-224: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-225: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-226: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-227: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('smartContractDeploy.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0x47a4caa81fe2ed8cc834aafe5b1d7ee3ddedecfa',
+                value: 0,
+                gas: 900000,
+                input: byteCode,
+                gasPrice: '0x5d21dba00',
+                chainId: 2019,
+                codeFormat: 'EVM',
+                humanReadable: false,
+                nonce: '0x1',
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-228: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x28f9027e018505d21dba00830dbba080809447a4caa81fe2ed8cc834aafe5b1d7ee3ddedecfab9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080f847f845820fe9a04fbefaf9da3be278403c0b69861747a4f2f530958c5f3da0b7fed8898aa02a9da010b441518b74b9cb15d86403a4c59a562a4669bc9c878d77276f0205304c3d85'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x4fbefaf9da3be278403c0b69861747a4f2f530958c5f3da0b7fed8898aa02a9d',
+                    '0x10b441518b74b9cb15d86403a4c59a562a4669bc9c878d77276f0205304c3d85',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-229: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fe9',
+                    '0x4fbefaf9da3be278403c0b69861747a4f2f530958c5f3da0b7fed8898aa02a9d',
+                    '0x10b441518b74b9cb15d86403a4c59a562a4669bc9c878d77276f0205304c3d85',
+                ],
+            ]
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x28f9027e018505d21dba00830dbba080809447a4caa81fe2ed8cc834aafe5b1d7ee3ddedecfab9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080f847f845820fe9a06f59d699a5dd22a653b0ed1e39cbfc52ee468607eec95b195f302680ed7f9815a03b2f3f2a7a9482edfbcc9ee8e003e284b6c4a7ecbc8d361cc486562d4bdda389',
+                '0x28f9027e018505d21dba00830dbba080809447a4caa81fe2ed8cc834aafe5b1d7ee3ddedecfab9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080f847f845820feaa04a76af831891d1050d1a0c8e7656b4ab1952ef6a1059bff994edb29a6936a909a06affc6457e9c553c5efb138a7a56dbcbed681a5bae2dceff02848341a61ab9c4',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x28f9030c018505d21dba00830dbba080809447a4caa81fe2ed8cc834aafe5b1d7ee3ddedecfab9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080f8d5f845820fe9a04fbefaf9da3be278403c0b69861747a4f2f530958c5f3da0b7fed8898aa02a9da010b441518b74b9cb15d86403a4c59a562a4669bc9c878d77276f0205304c3d85f845820fe9a06f59d699a5dd22a653b0ed1e39cbfc52ee468607eec95b195f302680ed7f9815a03b2f3f2a7a9482edfbcc9ee8e003e284b6c4a7ecbc8d361cc486562d4bdda389f845820feaa04a76af831891d1050d1a0c8e7656b4ab1952ef6a1059bff994edb29a6936a909a06affc6457e9c553c5efb138a7a56dbcbed681a5bae2dceff02848341a61ab9c4'
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x4fbefaf9da3be278403c0b69861747a4f2f530958c5f3da0b7fed8898aa02a9d',
+                    '0x10b441518b74b9cb15d86403a4c59a562a4669bc9c878d77276f0205304c3d85',
+                ],
+                [
+                    '0x0fe9',
+                    '0x6f59d699a5dd22a653b0ed1e39cbfc52ee468607eec95b195f302680ed7f9815',
+                    '0x3b2f3f2a7a9482edfbcc9ee8e003e284b6c4a7ecbc8d361cc486562d4bdda389',
+                ],
+                [
+                    '0x0fea',
+                    '0x4a76af831891d1050d1a0c8e7656b4ab1952ef6a1059bff994edb29a6936a909',
+                    '0x6affc6457e9c553c5efb138a7a56dbcbed681a5bae2dceff02848341a61ab9c4',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-230: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.smartContractDeploy(transactionObj)
+            tx.value = 10000
+
+            const rlpEncoded =
+                '0x28f9027e018505d21dba00830dbba080809447a4caa81fe2ed8cc834aafe5b1d7ee3ddedecfab9020e60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb00298080f847f845820fe9a06f59d699a5dd22a653b0ed1e39cbfc52ee468607eec95b195f302680ed7f9815a03b2f3f2a7a9482edfbcc9ee8e003e284b6c4a7ecbc8d361cc486562d4bdda389'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractDeploy.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-231: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.rlpEncoding
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(expected)
+        })
+    })
+
+    context('smartContractDeploy.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-232: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.transactionHash
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-233: getTransactionHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-234: getTransactionHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-235: getTransactionHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractDeploy.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-236: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.senderTxHash
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-237: getSenderTxHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-238: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-239: getSenderTxHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractDeploy.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-240: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+            const expected = txWithExpectedValues.rlpEncodingForSigning
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(expected)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-241: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-242: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-243: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractDeploy.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-244: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+
+            expect(commonRLPForSign).to.equal(txWithExpectedValues.rlpEncodingCommon)
+        })
+    })
+
+    context('smartContractDeploy.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-245: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-246: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-247: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/smartContractExecution.js
+++ b/test/packages/caver.transaction/smartContractExecution.js
@@ -1,0 +1,794 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let roleBasedKeyring
+
+const sandbox = sinon.createSandbox()
+
+const input =
+    '0xa9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039'
+
+const txWithExpectedValues = {}
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0x6b604e77c0fbebb5b2941bcde3ab5eb09d99ad24',
+        to: '0xe3cd4e1cd287235cc0ea48c9fd02978533f5ec2b',
+        value: '0x0',
+        gas: '0xdbba0',
+        gasPrice: '0x5d21dba00',
+        input,
+        chainId: '0x7e3',
+        signatures: [
+            [
+                '0x0fea',
+                '0x66e1650b5779f152489633f343581c07938f8b2fc92c919d4dd7c7295d0beace',
+                '0x67b0b79383dbcd42a3aa8ebb1aa4bcb1fc0623ef9e97bc1e9b82d96fe37b5881',
+            ],
+        ],
+        nonce: '0x3',
+    }
+
+    txWithExpectedValues.rlpEncodingForSigning =
+        '0xf886b87ff87d30038505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80946b604e77c0fbebb5b2941bcde3ab5eb09d99ad24b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a00000000000000000000000000000000000000000000000000000000000030398207e38080'
+    txWithExpectedValues.rlpEncodingCommon =
+        '0xf87d30038505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80946b604e77c0fbebb5b2941bcde3ab5eb09d99ad24b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039'
+    txWithExpectedValues.senderTxHash = '0x75119321f4c5e93e486accb33fedc3d714de2610ffdc9655182ac50e4a5f3298'
+    txWithExpectedValues.transactionHash = '0x75119321f4c5e93e486accb33fedc3d714de2610ffdc9655182ac50e4a5f3298'
+    txWithExpectedValues.rlpEncoding =
+        '0x30f8c5038505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80946b604e77c0fbebb5b2941bcde3ab5eb09d99ad24b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f847f845820feaa066e1650b5779f152489633f343581c07938f8b2fc92c919d4dd7c7295d0beacea067b0b79383dbcd42a3aa8ebb1aa4bcb1fc0623ef9e97bc1e9b82d96fe37b5881'
+})
+
+describe('TxTypeSmartContractExecution', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            to: '0xe3cd4e1cd287235cc0ea48c9fd02978533f5ec2b',
+            value: 0,
+            gas: '0x15f90',
+            input,
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create smartContractExecution instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-248: If smartContractExecution not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-249: If smartContractExecution not define to, return error', () => {
+            delete transactionObj.to
+
+            const expectedError = '"to" is missing'
+            expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-250: If smartContractExecution not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-251: If smartContractExecution not define input, return error', () => {
+            delete transactionObj.input
+
+            const expectedError = '"input" is missing'
+            expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-252: If smartContractExecution define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-253: If smartContractExecution define to property with invalid address, return error', () => {
+            transactionObj.to = 'invalid'
+
+            const expectedError = `Invalid address of to: ${transactionObj.to}`
+            expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-254: If smartContractExecution define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.humanReadable,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feePayer,
+                propertiesForUnnecessary.feePayerSignatures,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeSmartContractExecution} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.smartContractExecution(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('smartContractExecution.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-255: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-256: getRLPEncoding should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-257: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-258: getRLPEncoding should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractExecution.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-259: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-260: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-261: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-262: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-263: input: keyring, custom hasher. c.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-264: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-265: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-266: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('smartContractExecution.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-267: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-268: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-269: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-270: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-271: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-272: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('smartContractExecution.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-273: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-274: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-275: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-276: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('smartContractExecution.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0x2de587b91c76fb0b92fd607c4fbd5e9a17da799f',
+                to: '0xe3cd4e1cd287235cc0ea48c9fd02978533f5ec2b',
+                value: '0x0',
+                gas: '0xdbba0',
+                gasPrice: '0x5d21dba00',
+                input,
+                chainId: '0x7e3',
+                nonce: '0x1',
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-277: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x30f8c5018505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80942de587b91c76fb0b92fd607c4fbd5e9a17da799fb844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f847f845820fe9a04a7d00c2680e5bca49a5880e23c5adb40b069af204a55e888f45746a20978e46a007b57a439201d182f4aec5db28d72192468f58f4fe7a1e717f96dd0d1def2d16'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x4a7d00c2680e5bca49a5880e23c5adb40b069af204a55e888f45746a20978e46',
+                    '0x07b57a439201d182f4aec5db28d72192468f58f4fe7a1e717f96dd0d1def2d16',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-278: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fe9',
+                    '0x4a7d00c2680e5bca49a5880e23c5adb40b069af204a55e888f45746a20978e46',
+                    '0x07b57a439201d182f4aec5db28d72192468f58f4fe7a1e717f96dd0d1def2d16',
+                ],
+            ]
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x30f8c5018505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80942de587b91c76fb0b92fd607c4fbd5e9a17da799fb844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f847f845820fe9a08494bfd86b0480e33700635d37ab0eb0ce3e6d93b5c51e6eda9fadd179569804a047f601d9fcb8682090165d8d048d6a5e3c5a48377ec9b212be6d7ee72b768bfd',
+                '0x30f8c5018505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80942de587b91c76fb0b92fd607c4fbd5e9a17da799fb844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f847f845820fe9a0f642b38cf64cf70c89a0ccd74de13266ea98854078119a4619cad3bb2e6d4530a02307abe779333fe9da8eeebf40fbfeff9f1314ae8467a0119541339dfb65f10a',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x30f90153018505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80942de587b91c76fb0b92fd607c4fbd5e9a17da799fb844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f8d5f845820fe9a04a7d00c2680e5bca49a5880e23c5adb40b069af204a55e888f45746a20978e46a007b57a439201d182f4aec5db28d72192468f58f4fe7a1e717f96dd0d1def2d16f845820fe9a08494bfd86b0480e33700635d37ab0eb0ce3e6d93b5c51e6eda9fadd179569804a047f601d9fcb8682090165d8d048d6a5e3c5a48377ec9b212be6d7ee72b768bfdf845820fe9a0f642b38cf64cf70c89a0ccd74de13266ea98854078119a4619cad3bb2e6d4530a02307abe779333fe9da8eeebf40fbfeff9f1314ae8467a0119541339dfb65f10a'
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x4a7d00c2680e5bca49a5880e23c5adb40b069af204a55e888f45746a20978e46',
+                    '0x07b57a439201d182f4aec5db28d72192468f58f4fe7a1e717f96dd0d1def2d16',
+                ],
+                [
+                    '0x0fe9',
+                    '0x8494bfd86b0480e33700635d37ab0eb0ce3e6d93b5c51e6eda9fadd179569804',
+                    '0x47f601d9fcb8682090165d8d048d6a5e3c5a48377ec9b212be6d7ee72b768bfd',
+                ],
+                [
+                    '0x0fe9',
+                    '0xf642b38cf64cf70c89a0ccd74de13266ea98854078119a4619cad3bb2e6d4530',
+                    '0x2307abe779333fe9da8eeebf40fbfeff9f1314ae8467a0119541339dfb65f10a',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-279: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.smartContractExecution(transactionObj)
+            tx.value = 10000
+
+            const rlpEncoded =
+                '0x30f8c5018505d21dba00830dbba094e3cd4e1cd287235cc0ea48c9fd02978533f5ec2b80942de587b91c76fb0b92fd607c4fbd5e9a17da799fb844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f847f845820fe9a08494bfd86b0480e33700635d37ab0eb0ce3e6d93b5c51e6eda9fadd179569804a047f601d9fcb8682090165d8d048d6a5e3c5a48377ec9b212be6d7ee72b768bfd'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractExecution.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-280: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.rlpEncoding
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(expected)
+        })
+    })
+
+    context('smartContractExecution.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-281: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.transactionHash
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-282: getTransactionHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-283: getTransactionHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-284: getTransactionHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractExecution.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-285: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const expected = txWithExpectedValues.senderTxHash
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(expected)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-286: getSenderTxHash should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-287: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-288: getSenderTxHash should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractExecution.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-289: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+
+            const expected = txWithExpectedValues.rlpEncodingForSigning
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(expected)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-290: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-291: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-292: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('smartContractExecution.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-293: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+
+            expect(commonRLPForSign).to.equal(txWithExpectedValues.rlpEncodingCommon)
+        })
+    })
+
+    context('smartContractExecution.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-294: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._gasPrice
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-295: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._nonce
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-296: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
+            delete tx._chainId
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})

--- a/test/packages/caver.transaction/valueTransferMemo.js
+++ b/test/packages/caver.transaction/valueTransferMemo.js
@@ -1,0 +1,810 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+
+const RLP = require('eth-lib/lib/rlp')
+
+chai.use(chaiAsPromised)
+chai.use(sinonChai)
+
+const expect = chai.expect
+
+const { propertiesForUnnecessary } = require('../utils')
+
+const testRPCURL = require('../../testrpc')
+const Caver = require('../../../index.js')
+const Keyring = require('../../../packages/caver-wallet/src/keyring/keyring')
+const TransactionHasher = require('../../../packages/caver-transaction/src/transactionHasher/transactionHasher')
+
+const { generateRoleBasedKeyring, checkSignature } = require('../utils')
+
+const AbstractTransaction = require('../../../packages/caver-transaction/src/transactionTypes/abstractTransaction')
+
+let caver
+let sender
+let testKeyring
+let roleBasedKeyring
+
+const txWithExpectedValues = {}
+
+const sandbox = sinon.createSandbox()
+
+before(() => {
+    caver = new Caver(testRPCURL)
+    AbstractTransaction._klaytnCall = {
+        getGasPrice: () => {},
+        getTransactionCount: () => {},
+        getChainId: () => {},
+    }
+
+    sender = caver.wallet.add(caver.wallet.keyring.generate())
+    testKeyring = caver.wallet.add(caver.wallet.keyring.generate())
+    roleBasedKeyring = generateRoleBasedKeyring([3, 3, 3])
+
+    txWithExpectedValues.tx = {
+        from: '0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B',
+        to: '0x7b65B75d204aBed71587c9E519a89277766EE1d0',
+        value: '0xa',
+        gas: '0xf4240',
+        nonce: 1234,
+        gasPrice: '0x19',
+        input: '0x68656c6c6f',
+        signatures: [
+            [
+                '0x25',
+                '0x7d2b0c89ee8afa502b3186413983bfe9a31c5776f4f820210cffe44a7d568d1c',
+                '0x2b1cbd587c73b0f54969f6b76ef2fd95cea0c1bb79256a75df9da696278509f3',
+            ],
+        ],
+        chainId: '0x1',
+    }
+    txWithExpectedValues.rlpEncodingForSigning =
+        '0xf841b83cf83a108204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b8568656c6c6f018080'
+    txWithExpectedValues.senderTxHash = '0x6c7ee543c24e5b928b638a9f4502c1eca69103f5467ed4b6a2ed0ea5aede2e6b'
+    txWithExpectedValues.transactionHash = '0x6c7ee543c24e5b928b638a9f4502c1eca69103f5467ed4b6a2ed0ea5aede2e6b'
+    txWithExpectedValues.rlpEncoding =
+        '0x10f8808204d219830f4240947b65b75d204abed71587c9e519a89277766ee1d00a94a94f5374fce5edbc8e2a8697c15331677e6ebf0b8568656c6c6ff845f84325a07d2b0c89ee8afa502b3186413983bfe9a31c5776f4f820210cffe44a7d568d1ca02b1cbd587c73b0f54969f6b76ef2fd95cea0c1bb79256a75df9da696278509f3'
+})
+
+describe('TxTypeValueTransferMemo', () => {
+    let transactionObj
+    let getGasPriceSpy
+    let getNonceSpy
+    let getChainIdSpy
+    beforeEach(() => {
+        transactionObj = {
+            from: sender.address,
+            to: testKeyring.address,
+            value: 1,
+            gas: '0x3b9ac9ff',
+            input: '0x68656c6c6f',
+        }
+
+        getGasPriceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getGasPrice')
+        getGasPriceSpy.returns('0x5d21dba00')
+        getNonceSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionCount')
+        getNonceSpy.returns('0x3a')
+        getChainIdSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getChainId')
+        getChainIdSpy.returns('0x7e3')
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    context('create valueTransferMemo instance', () => {
+        it('CAVERJS-UNIT-TRANSACTION-102: If valueTransferMemo not define from, return error', () => {
+            delete transactionObj.from
+
+            const expectedError = '"from" is missing'
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-103: If valueTransferMemo not define to, return error', () => {
+            delete transactionObj.to
+
+            const expectedError = '"to" is missing'
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-104: If valueTransferMemo not define value, return error', () => {
+            delete transactionObj.value
+
+            const expectedError = '"value" is missing'
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-105: If valueTransferMemo not define gas, return error', () => {
+            delete transactionObj.gas
+
+            const expectedError = '"gas" is missing'
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-106: If valueTransferMemo not define input, return error', () => {
+            delete transactionObj.input
+
+            const expectedError = '"input" is missing'
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-107: If valueTransferMemo define from property with invalid address, return error', () => {
+            transactionObj.from = 'invalid'
+
+            const expectedError = `Invalid address of from: ${transactionObj.from}`
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-108: If valueTransferMemo define to property with invalid address, return error', () => {
+            transactionObj.to = 'invalid address'
+
+            const expectedError = `Invalid address of to: ${transactionObj.to}`
+            expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-109: If valueTransferMemo define unnecessary property, return error', () => {
+            const unnecessaries = [
+                propertiesForUnnecessary.codeFormat,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.feePayer,
+                propertiesForUnnecessary.feePayerSignatures,
+                propertiesForUnnecessary.feeRatio,
+                propertiesForUnnecessary.account,
+                propertiesForUnnecessary.key,
+                propertiesForUnnecessary.legacyKey,
+                propertiesForUnnecessary.publicKey,
+                propertiesForUnnecessary.failKey,
+                propertiesForUnnecessary.multisig,
+                propertiesForUnnecessary.roleTransactionKey,
+                propertiesForUnnecessary.roleAccountUpdateKey,
+                propertiesForUnnecessary.roleFeePayerKey,
+                propertiesForUnnecessary.humanReadable,
+            ]
+
+            for (let i = 0; i < unnecessaries.length; i++) {
+                if (i > 0) delete transactionObj[unnecessaries[i - 1].name]
+                transactionObj[unnecessaries[i].name] = unnecessaries[i].value
+
+                const expectedError = `"${unnecessaries[i].name}" cannot be used with ${caver.transaction.type.TxTypeValueTransferMemo} transaction`
+                // eslint-disable-next-line no-loop-func
+                expect(() => new caver.transaction.valueTransferMemo(transactionObj)).to.throw(expectedError)
+            }
+        })
+    })
+
+    context('valueTransferMemo.getRLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTION-110: Returns RLP-encoded string', () => {
+            const tx = new caver.transaction.valueTransferMemo(txWithExpectedValues.tx)
+
+            expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-111: getRLPEncoding should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-112: getRLPEncoding should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-113: getRLPEncoding should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
+        })
+    })
+
+    context('valueTransferMemo.signWithKey', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeySpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeySpy = sandbox.spy(sender, 'signWithKey')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-114: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKey(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-115: input: private key string. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-116: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
+            await tx.signWithKey(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-117: input: keyring, index. should sign transaction with specific index.', async () => {
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-118: input: keyring, custom hasher.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const expectedError = `In order to pass a custom hasher, use the third parameter.`
+            await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-119: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKey(roleBasedKeyring, 1, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-120: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-121: input: rolebased keyring, index out of range. should throw error.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `Invalid index(10): index must be less than the length of keys(${roleBasedKeyring.keys[0].length}).`
+            await expect(tx.signWithKey(roleBasedKeyring, 10)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+    })
+
+    context('valueTransferMemo.signWithKeys', () => {
+        const txHash = '0xe9a11d9ef95fb437f75d07ce768d43e74f158dd54b106e7d3746ce29d545b550'
+
+        let fillTransactionSpy
+        let createFromPrivateKeySpy
+        let senderSignWithKeysSpy
+        let appendSignaturesSpy
+        let hasherSpy
+        let tx
+
+        beforeEach(() => {
+            tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            createFromPrivateKeySpy = sandbox.spy(Keyring, 'createFromPrivateKey')
+            senderSignWithKeysSpy = sandbox.spy(sender, 'signWithKeys')
+            appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            hasherSpy = sandbox.stub(TransactionHasher, 'getHashForSignature')
+            hasherSpy.returns(txHash)
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        function checkFunctionCall(customHasher = false) {
+            expect(fillTransactionSpy).to.have.been.calledOnce
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
+        }
+
+        it('CAVERJS-UNIT-TRANSACTION-122: input: keyring. should sign transaction.', async () => {
+            await tx.signWithKeys(sender)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-123: input: private key string. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.keys[0][0].privateKey)
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-124: input: KlaytnWalletKey. should sign transaction.', async () => {
+            const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
+            await tx.signWithKeys(sender.getKlaytnWalletKey())
+
+            checkFunctionCall()
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).to.have.been.calledOnce
+            expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-125: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+            const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
+            const customHasher = () => hashForCustomHasher
+
+            await tx.signWithKeys(sender, customHasher)
+
+            checkFunctionCall(true)
+            checkSignature(tx)
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-126: input: keyring. should throw error when from is different.', async () => {
+            transactionObj.from = roleBasedKeyring.address
+            tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `The from address of the transaction is different with the address of the keyring to use.`
+            await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-127: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+            const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
+
+            tx.from = roleBasedKeyring.address
+
+            await tx.signWithKeys(roleBasedKeyring)
+
+            checkFunctionCall(true)
+            checkSignature(tx, { expectedLength: roleBasedKeyring.keys[0].length })
+            expect(createFromPrivateKeySpy).not.to.have.been.calledOnce
+            expect(roleBasedSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
+        }).timeout(200000)
+    })
+
+    context('valueTransferMemo.appendSignatures', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-128: If signatures is empty, appendSignatures append signatures in transaction', () => {
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-129: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+            tx.appendSignatures(sig)
+            checkSignature(tx)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-130: If signatures is not empty, appendSignatures should append signatures', () => {
+            transactionObj.signatures = [
+                '0x0fea',
+                '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+            ]
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const sig = [
+                '0x0fea',
+                '0x7a5011b41cfcb6270af1b5f8aeac8aeabb1edb436f028261b5add564de694700',
+                '0x23ac51660b8b421bf732ef8148d0d4f19d5e29cb97be6bccb5ae505ebe89eb4a',
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-131: appendSignatures should append multiple signatures', () => {
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const sig = [
+                [
+                    '0x0fea',
+                    '0xbde66cceed35a576010966338b7ded961f2c160c96f928e193b47aaf4480aa07',
+                    '0x546eb193ec138523b7fd34c4f12a1a04d0f74470e8f3bbe91ce0b4ec16e7f0d2',
+                ],
+                [
+                    '0x0fea',
+                    '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
+                    '0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e',
+                ],
+            ]
+
+            tx.appendSignatures(sig)
+            checkSignature(tx, { expectedLength: 2 })
+        })
+    })
+
+    context('valueTransferMemo.combineSignatures', () => {
+        beforeEach(() => {
+            transactionObj = {
+                from: '0x7d0104ac150f749d36bb34999bcade9f2c0bd2e6',
+                to: '0x8723590d5D60e35f7cE0Db5C09D3938b26fF80Ae',
+                value: 1,
+                gas: 90000,
+                input: '0x68656c6c6f',
+                nonce: '0x3a',
+                gasPrice: '0x5d21dba00',
+                chainId: 2019,
+            }
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-132: combineSignatures combines single signature and sets signatures in transaction', () => {
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rlpEncoded =
+                '0x10f8853a8505d21dba0083015f90948723590d5d60e35f7ce0db5c09d3938b26ff80ae01947d0104ac150f749d36bb34999bcade9f2c0bd2e68568656c6c6ff847f845820fe9a02aea3bb7c0632f1991b0b0b7a51cd6537a35554b74c198ebd79069c72a591832a0617d2942861f2c4280e793f2bdb107751e88c43048983823110eb044d7572254'
+            const combined = tx.combineSignatures([rlpEncoded])
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x2aea3bb7c0632f1991b0b0b7a51cd6537a35554b74c198ebd79069c72a591832',
+                    '0x617d2942861f2c4280e793f2bdb107751e88c43048983823110eb044d7572254',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.calledOnce
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(rlpEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-133: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+            transactionObj.signatures = [
+                [
+                    '0x0fe9',
+                    '0x2aea3bb7c0632f1991b0b0b7a51cd6537a35554b74c198ebd79069c72a591832',
+                    '0x617d2942861f2c4280e793f2bdb107751e88c43048983823110eb044d7572254',
+                ],
+            ]
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const rlpEncodedStrings = [
+                '0x10f8853a8505d21dba0083015f90948723590d5d60e35f7ce0db5c09d3938b26ff80ae01947d0104ac150f749d36bb34999bcade9f2c0bd2e68568656c6c6ff847f845820feaa0eda88095a7e349facbb40cc68c8c082aab3c21fbdbb05dca7fce6ab6c0a92866a03420efb785a186cda7f5bf99473bff57c18f9c4384126bec6f9172d6dcce2565',
+                '0x10f8853a8505d21dba0083015f90948723590d5d60e35f7ce0db5c09d3938b26ff80ae01947d0104ac150f749d36bb34999bcade9f2c0bd2e68568656c6c6ff847f845820fe9a08d80151db0b7195adfef41443ddacd5ca57a6a479eb31fb0fea9f1c98596d4c9a079f37b400123c6a8415d8a851e8519102a02345feff6e2b3fb3b28699712e7e4',
+            ]
+
+            const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const combined = tx.combineSignatures(rlpEncodedStrings)
+
+            const expectedRLPEncoded =
+                '0x10f901133a8505d21dba0083015f90948723590d5d60e35f7ce0db5c09d3938b26ff80ae01947d0104ac150f749d36bb34999bcade9f2c0bd2e68568656c6c6ff8d5f845820fe9a02aea3bb7c0632f1991b0b0b7a51cd6537a35554b74c198ebd79069c72a591832a0617d2942861f2c4280e793f2bdb107751e88c43048983823110eb044d7572254f845820feaa0eda88095a7e349facbb40cc68c8c082aab3c21fbdbb05dca7fce6ab6c0a92866a03420efb785a186cda7f5bf99473bff57c18f9c4384126bec6f9172d6dcce2565f845820fe9a08d80151db0b7195adfef41443ddacd5ca57a6a479eb31fb0fea9f1c98596d4c9a079f37b400123c6a8415d8a851e8519102a02345feff6e2b3fb3b28699712e7e4'
+
+            const expectedSignatures = [
+                [
+                    '0x0fe9',
+                    '0x2aea3bb7c0632f1991b0b0b7a51cd6537a35554b74c198ebd79069c72a591832',
+                    '0x617d2942861f2c4280e793f2bdb107751e88c43048983823110eb044d7572254',
+                ],
+                [
+                    '0x0fea',
+                    '0xeda88095a7e349facbb40cc68c8c082aab3c21fbdbb05dca7fce6ab6c0a92866',
+                    '0x3420efb785a186cda7f5bf99473bff57c18f9c4384126bec6f9172d6dcce2565',
+                ],
+                [
+                    '0x0fe9',
+                    '0x8d80151db0b7195adfef41443ddacd5ca57a6a479eb31fb0fea9f1c98596d4c9',
+                    '0x79f37b400123c6a8415d8a851e8519102a02345feff6e2b3fb3b28699712e7e4',
+                ],
+            ]
+
+            expect(appendSignaturesSpy).to.have.been.callCount(rlpEncodedStrings.length)
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(combined).to.equal(expectedRLPEncoded)
+            checkSignature(tx, { expectedSignatures })
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-134: If decode transaction has different values, combineSignatures should throw error', () => {
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+            tx.value = 10000
+
+            const rlpEncoded =
+                '0x10f8853a8505d21dba0083015f90948723590d5d60e35f7ce0db5c09d3938b26ff80ae01947d0104ac150f749d36bb34999bcade9f2c0bd2e68568656c6c6ff847f845820feaa0eda88095a7e349facbb40cc68c8c082aab3c21fbdbb05dca7fce6ab6c0a92866a03420efb785a186cda7f5bf99473bff57c18f9c4384126bec6f9172d6dcce2565'
+            const expectedError = `Transactions containing different information cannot be combined.`
+
+            expect(() => tx.combineSignatures([rlpEncoded])).to.throw(expectedError)
+        })
+    })
+
+    context('valueTransferMemo.getRawTransaction', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-135: getRawTransaction should call getRLPEncoding function', () => {
+            const tx = new caver.transaction.valueTransferMemo(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const rawTransaction = tx.getRawTransaction()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(rawTransaction).to.equal(txWithExpectedValues.rlpEncoding)
+        })
+    })
+
+    context('CAVERJS-UNIT-TRANSACTION-136: valueTransferMemo.getTransactionHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.valueTransferMemo(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const txHash = tx.getTransactionHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(txHash).to.equal(txWithExpectedValues.transactionHash)
+            expect(caver.utils.isValidHashStrict(txHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-137: getTransactionHash should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-138: getTransactionHash should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-139: getTransactionHash should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getTransactionHash()).to.throw(expectedError)
+        })
+    })
+
+    context('valueTransferMemo.getSenderTxHash', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-140: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+            const tx = new caver.transaction.valueTransferMemo(txWithExpectedValues.tx)
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+
+            const senderTxHash = tx.getSenderTxHash()
+
+            expect(getRLPEncodingSpy).to.have.been.calledOnce
+            expect(senderTxHash).to.equal(txWithExpectedValues.senderTxHash)
+            expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-141: getSenderTxHash should throw error when nonce is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.gasPrice = '0x5d21dba00'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-142: getSenderTxHash should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-143: getSenderTxHash should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
+        })
+    })
+
+    context('valueTransferMemo.getRLPEncodingForSignature', () => {
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-144: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.valueTransferMemo(txWithExpectedValues.tx)
+
+            const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
+            const rlpEncodingForSign = tx.getRLPEncodingForSignature()
+
+            expect(rlpEncodingForSign).to.equal(txWithExpectedValues.rlpEncodingForSigning)
+            expect(commonRLPForSigningSpy).to.have.been.calledOnce
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-145: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-146: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+            transactionObj.chainId = 2019
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+
+        it('CAVERJS-UNIT-TRANSACTION-147: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
+
+            expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
+        })
+    })
+
+    context('valueTransferMemo.getCommonRLPEncodingForSignature', () => {
+        it('CAVERJS-UNIT-TRANSACTION-148: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+            const tx = new caver.transaction.valueTransferMemo(txWithExpectedValues.tx)
+
+            const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
+            const decoded = RLP.decode(txWithExpectedValues.rlpEncodingForSigning)
+
+            expect(commonRLPForSign).to.equal(decoded[0])
+        })
+    })
+
+    context('valueTransferMemo.fillTransaction', () => {
+        it('CAVERJS-UNIT-TRANSACTION-149: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+            transactionObj.nonce = '0x3a'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-150: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.chainId = 2019
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).to.have.been.calledOnce
+            expect(getChainIdSpy).not.to.have.been.calledOnce
+        }).timeout(200000)
+
+        it('CAVERJS-UNIT-TRANSACTION-151: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+            transactionObj.gasPrice = '0x5d21dba00'
+            transactionObj.nonce = '0x3a'
+            const tx = new caver.transaction.valueTransferMemo(transactionObj)
+
+            await tx.fillTransaction()
+            expect(getGasPriceSpy).not.to.have.been.calledOnce
+            expect(getNonceSpy).not.to.have.been.calledOnce
+            expect(getChainIdSpy).to.have.been.calledOnce
+        }).timeout(200000)
+    })
+})


### PR DESCRIPTION
## Proposed changes

This PR introduces adding test codes for below transactions.
- FeeDelegatedValueTransfer
- ValueTransferMemo
- FeeDelegatedValueTransferMemo
- AccountUpdate
- SmartContractDeploy
- SmartContractExecution
- Cancel
- ChainDataAnchoring

Currently, all tests except chainDataAnchoring are automatically executed in Circle-CI.
The test code of ChainDataAnchoring requires modification of the validation function, so i will add it after https://github.com/klaytn/caver-js/pull/278 PR merges.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
