### PR TITLE
Fixed bug to handle KlaytnWalletKey with options.address

### DIFF
--- a/packages/caver-wallet/src/keyring/keyring.js
+++ b/packages/caver-wallet/src/keyring/keyring.js
@@ -170,14 +170,15 @@ class Keyring {
         } else if (_.isString(key)) {
             if (options.address) {
                 if (utils.isKlaytnWalletKey(key)) {
-                    const fromKlaytnWalletKey = Keyring.createFromKlaytnWalletKey(key)
-                    if (fromKlaytnWalletKey.address.toLowerCase() !== options.address.toLowerCase()) {
+                    keyring = Keyring.createFromKlaytnWalletKey(key)
+                    if (keyring.address.toLowerCase() !== options.address.toLowerCase()) {
                         throw new Error(
-                            `The address defined in options(${options.address}) does not match the address of KlaytnWalletKey(${fromKlaytnWalletKey.address}) entered as a parameter.`
+                            `The address defined in options(${options.address}) does not match the address of KlaytnWalletKey(${keyring.address}) entered as a parameter.`
                         )
                     }
+                } else {
+                    keyring = Keyring.createWithSingleKey(options.address, key)
                 }
-                keyring = Keyring.createWithSingleKey(options.address, key)
             } else {
                 keyring = Keyring.createFromPrivateKey(key)
             }

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -486,7 +486,7 @@ describe('caver.wallet.keyring.encrypt', () => {
             const keyring = generateDecoupledKeyring()
             const klaytnWalletKey = keyring.getKlaytnWalletKey()
 
-            const result = caver.wallet.keyring.encrypt(klaytnWalletKey, password, { address: klaytnWalletKey.address })
+            const result = caver.wallet.keyring.encrypt(klaytnWalletKey, password, { address: keyring.address })
             validateKeystore(result, password, { address: keyring.address, expectedKey: keyring.keys })
         })
     })


### PR DESCRIPTION
## Proposed changes

This PR introduces fixing bug in caver.wallet.keyring.encrypt with KlaytnWalletKey.



## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
