### PR TITLE
Modified encryptV3 to handle KlaytnWalletKey with options.address

### DIFF
--- a/packages/caver-wallet/src/keyring/keyring.js
+++ b/packages/caver-wallet/src/keyring/keyring.js
@@ -202,12 +202,23 @@ class Keyring {
             throw new Error(`Invalid parameter. key should be a private key string, KlaytnWalletKey or instance of Keyring`)
         }
 
-        const keyring =
-            key instanceof Keyring
-                ? key
-                : options.address
-                ? Keyring.createWithSingleKey(options.address, key)
-                : Keyring.createFromPrivateKey(key)
+        let keyring
+        if (key instanceof Keyring) {
+            keyring = key
+        } else if (options.address) {
+            if (utils.isKlaytnWalletKey(key)) {
+                keyring = Keyring.createFromKlaytnWalletKey(key)
+                if (keyring.address.toLowerCase() !== options.address.toLowerCase()) {
+                    throw new Error(
+                        `The address defined in options(${options.address}) does not match the address of KlaytnWalletKey(${keyring.address}) entered as a parameter.`
+                    )
+                }
+            } else {
+                keyring = Keyring.createWithSingleKey(options.address, key)
+            }
+        } else {
+            keyring = Keyring.createFromPrivateKey(key)
+        }
 
         return keyring.encryptV3(password, options)
     }

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -715,7 +715,7 @@ describe('caver.wallet.keyring.encrypt', () => {
 
 describe('caver.wallet.keyring.encryptV3', () => {
     context('CAVERJS-UNIT-KEYRING-038: input: private key string, password', () => {
-        it('should encrypted as v4Keystore', () => {
+        it('should encrypted as v3Keystore', () => {
             const password = 'password'
             const privateKey = caver.wallet.generatePrivateKey()
             const keyring = caver.wallet.keyring.createFromPrivateKey(privateKey)
@@ -726,7 +726,7 @@ describe('caver.wallet.keyring.encryptV3', () => {
     })
 
     context('CAVERJS-UNIT-KEYRING-039: input: private key string, password, {address}', () => {
-        it('should encrypted as v4Keystore', () => {
+        it('should encrypted as v3Keystore', () => {
             const password = 'password'
             const keyring = generateDecoupledKeyring()
             const privateKey = keyring.keys[0][0].privateKey
@@ -735,14 +735,38 @@ describe('caver.wallet.keyring.encryptV3', () => {
             validateKeystore(result, password, { address: keyring.address, expectedKey: privateKey }, 3)
         })
     })
+
     context('CAVERJS-UNIT-KEYRING-040: input: klaytnWalletKey, password', () => {
-        it('should encrypted as v4Keystore', () => {
+        it('should encrypted as v3Keystore', () => {
             const password = 'password'
             const keyring = generateDecoupledKeyring()
             const klaytnWalletKey = keyring.getKlaytnWalletKey()
 
             const result = caver.wallet.keyring.encryptV3(klaytnWalletKey, password)
             validateKeystore(result, password, { address: keyring.address, expectedKey: keyring.keys }, 3)
+        })
+    })
+
+    context('CAVERJS-UNIT-KEYRING-145: input: klaytnWalletKey, password, {address}', () => {
+        it('should encrypted as v3Keystore', () => {
+            const password = 'password'
+            const keyring = generateDecoupledKeyring()
+            const klaytnWalletKey = keyring.getKlaytnWalletKey()
+
+            const result = caver.wallet.keyring.encryptV3(klaytnWalletKey, password, { address: keyring.address })
+            validateKeystore(result, password, { address: keyring.address, expectedKey: keyring.keys }, 3)
+        })
+    })
+
+    context('CAVERJS-UNIT-KEYRING-146: input: klaytnWalletKey, password, {invalid address}', () => {
+        it('should throw error', () => {
+            const password = 'password'
+            const keyring = generateDecoupledKeyring()
+            const klaytnWalletKey = keyring.getKlaytnWalletKey()
+            const invalidAddress = '0x6726d0c6fc895e8db37039d94b440563118f3137'
+
+            const errormsg = `The address defined in options(${invalidAddress}) does not match the address of KlaytnWalletKey(${keyring.address}) entered as a parameter.`
+            expect(() => caver.wallet.keyring.encryptV3(klaytnWalletKey, password, { address: invalidAddress })).to.throws(errormsg)
         })
     })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces modification caver.wallet.keyring.encryptV3 logic to handle KlaytnWalletKey with options.address.

I also added additional test cases for this.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
