### PR TITLE
Returns an array of address after generating in KeyringContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "oboe": "2.1.3",
     "request": "2.87.0",
     "requestretry": "^2.0.2",
-    "scrypt-shim": "github:web3-js/scrypt-shim",
+    "@web3-js/scrypt-shim": "^0.1.0",
     "semver": "6.2.0",
     "utf8": "2.1.1",
     "uuid": "^3.0.0",

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -35,7 +35,7 @@ const Bytes = require('eth-lib/lib/bytes')
 const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto')
 const uuid = require('uuid')
 const elliptic = require('elliptic')
-const scrypt = require('scrypt-shim')
+const scrypt = require('@web3-js/scrypt-shim')
 const utils = require('../../../caver-utils')
 const helpers = require('../../../caver-core-helpers')
 

--- a/packages/caver-wallet/src/keyring/keyring.js
+++ b/packages/caver-wallet/src/keyring/keyring.js
@@ -17,7 +17,7 @@
 */
 
 const _ = require('lodash')
-const scrypt = require('scrypt-shim')
+const scrypt = require('@web3-js/scrypt-shim')
 const uuid = require('uuid')
 const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto')
 const AccountLib = require('eth-lib/lib/account')

--- a/packages/caver-wallet/src/keyringContainer.js
+++ b/packages/caver-wallet/src/keyringContainer.js
@@ -53,11 +53,14 @@ class KeyringContainer {
      *
      * @param {number} numberOfKeyrings The number of accounts to create.
      * @param {string} [entropy] A random string to increase entropy. If undefined, a random string will be generated using randomHex.
+     * @return {Array.<string>}
      */
     generate(numberOfKeyrings, entropy) {
+        const addresses = []
         for (let i = 0; i < numberOfKeyrings; ++i) {
-            this.add(Keyring.generate(entropy))
+            addresses.push(this.add(Keyring.generate(entropy)).address)
         }
+        return addresses
     }
 
     /**

--- a/test/packages/caver.wallet.js
+++ b/test/packages/caver.wallet.js
@@ -89,8 +89,13 @@ describe('wallet.generate', () => {
         it('should generate keyring instances and add to in-memory wallet', () => {
             const addSpy = sinon.spy(caver.wallet.keyringContainer, 'add')
 
-            caver.wallet.generate(10)
+            const addresses = caver.wallet.generate(10)
 
+            for (const address of addresses) {
+                expect(caver.utils.isAddress(address)).to.be.true
+            }
+
+            expect(addresses.length).to.equal(10)
             expect(caver.wallet.length).to.equal(10)
             expect(addSpy).to.have.been.callCount(10)
         })
@@ -101,8 +106,13 @@ describe('wallet.generate', () => {
             const addSpy = sinon.spy(caver.wallet.keyringContainer, 'add')
             const entropy = caver.utils.randomHex(32)
 
-            caver.wallet.generate(10, entropy)
+            const addresses = caver.wallet.generate(10, entropy)
 
+            for (const address of addresses) {
+                expect(caver.utils.isAddress(address)).to.be.true
+            }
+
+            expect(addresses.length).to.equal(10)
             expect(caver.wallet.length).to.equal(10)
             expect(addSpy).to.have.been.callCount(10)
         })


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of caver.wallet.generate return type to Array<string>

And also this PR includes fixing scrypt-shim CI bug.
Please refer https://github.com/ethereum/web3.js/issues/3210 and https://github.com/ethereum/web3.js/pull/3211

After this PR **caver-js v1.5.0-rc.1** will be released.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
