### PR TITLE
Fixed data setter bug

### DIFF
--- a/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
@@ -117,7 +117,7 @@ class LegacyTransaction extends AbstractTransaction {
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
@@ -145,7 +145,7 @@ class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
@@ -158,7 +158,7 @@ class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegatedWithR
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
@@ -141,7 +141,7 @@ class SmartContractDeploy extends AbstractTransaction {
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.js
@@ -138,7 +138,7 @@ class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTransaction
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecutionWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecutionWithRatio.js
@@ -139,7 +139,7 @@ class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDelegatedWi
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.js
@@ -135,7 +135,7 @@ class SmartContractExecution extends AbstractTransaction {
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.js
@@ -137,7 +137,7 @@ class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.js
@@ -138,7 +138,7 @@ class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegatedWithRat
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.js
@@ -133,7 +133,7 @@ class ValueTransferMemo extends AbstractTransaction {
     }
 
     set data(data) {
-        this.input = data
+        this._input = data
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

This PR introduces data setter bug with Transaction types.

The input member varibale name is `_input`, so data setter should set data to `_input`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
