### PR TITLE
Define from member variable in AbstractTransaction

### DIFF
--- a/packages/caver-core-helpers/src/validateFunction.js
+++ b/packages/caver-core-helpers/src/validateFunction.js
@@ -52,9 +52,17 @@ function validateParams(tx) {
 
     if (tx.type !== TX_TYPE_STRING.TxTypeLegacyTransaction && !tx.from) {
         error = new Error('"from" is missing')
-    } else if (tx.from && !utils.isAddress(tx.from)) {
-        error = new Error(`Invalid address of from: ${tx.from}`)
-    } else if (tx.gas === undefined && tx.gasLimit === undefined) {
+    } else if (tx.from) {
+        if (tx.from === '0x') {
+            if (tx.type !== TX_TYPE_STRING.TxTypeLegacyTransaction) {
+                error = new Error(`Invalid address of from: ${tx.from}`)
+            }
+        } else if (!utils.isAddress(tx.from)) {
+            error = new Error(`Invalid address of from: ${tx.from}`)
+        }
+    }
+
+    if (tx.gas === undefined && tx.gasLimit === undefined) {
         error = new Error('"gas" is missing')
     } else if (tx.nonce < 0 || tx.gas < 0 || tx.gasPrice < 0 || tx.chainId < 0) {
         error = new Error('gas, gasPrice, nonce or chainId is lower than 0')

--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -48,6 +48,8 @@ class AbstractTransaction {
         const err = validateParams(createTxObj)
         if (err) throw err
 
+        this.from = createTxObj.from
+
         this.gas = createTxObj.gas
 
         // The variables below are values that the user does not need to pass to the parameter.
@@ -63,6 +65,22 @@ class AbstractTransaction {
      */
     get type() {
         return this._type
+    }
+
+    /**
+     * @type {string}
+     */
+    get from() {
+        return this._from
+    }
+
+    set from(address) {
+        if (this.type === TX_TYPE_STRING.TxTypeLegacyTransaction && address === '0x') {
+            this._from = address.toLowerCase()
+        } else {
+            if (!utils.isAddress(address)) throw new Error(`Invalid address ${address}`)
+            this._from = address.toLowerCase()
+        }
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/accountUpdate/accountUpdate.js
+++ b/packages/caver-transaction/src/transactionTypes/accountUpdate/accountUpdate.js
@@ -69,20 +69,7 @@ class AccountUpdate extends AbstractTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeAccountUpdate, createTxObj)
-        this.from = createTxObj.from
         this.account = createTxObj.account
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdate.js
+++ b/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdate.js
@@ -73,20 +73,7 @@ class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedAccountUpdate, createTxObj)
-        this.from = createTxObj.from
         this.account = createTxObj.account
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdateWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdateWithRatio.js
@@ -74,20 +74,7 @@ class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWithRatioTr
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedAccountUpdateWithRatio, createTxObj)
-        this.from = createTxObj.from
         this.account = createTxObj.account
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/cancel/cancel.js
+++ b/packages/caver-transaction/src/transactionTypes/cancel/cancel.js
@@ -65,20 +65,6 @@ class Cancel extends AbstractTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeCancel, createTxObj)
-
-        this.from = createTxObj.from
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancel.js
+++ b/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancel.js
@@ -67,19 +67,6 @@ class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedCancel, createTxObj)
-        this.from = createTxObj.from
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancelWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancelWithRatio.js
@@ -70,19 +70,6 @@ class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTransacti
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedCancelWithRatio, createTxObj)
-        this.from = createTxObj.from
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/chainDataAnchoring.js
+++ b/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/chainDataAnchoring.js
@@ -67,24 +67,10 @@ class ChainDataAnchoring extends AbstractTransaction {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeChainDataAnchoring, createTxObj)
 
-        this.from = createTxObj.from
-
         if (createTxObj.input && createTxObj.data)
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoring.js
+++ b/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoring.js
@@ -71,24 +71,10 @@ class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransaction {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedChainDataAnchoring, createTxObj)
 
-        this.from = createTxObj.from
-
         if (createTxObj.input && createTxObj.data)
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoringWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoringWithRatio.js
@@ -72,24 +72,10 @@ class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegatedWithRa
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedChainDataAnchoringWithRatio, createTxObj)
 
-        this.from = createTxObj.from
-
         if (createTxObj.input && createTxObj.data)
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
@@ -51,8 +51,9 @@ class LegacyTransaction extends AbstractTransaction {
      */
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = LegacyTransaction.decode(createTxObj)
+        createTxObj.from = createTxObj.from || '0x'
+
         super(TX_TYPE_STRING.TxTypeLegacyTransaction, createTxObj)
-        this.from = createTxObj.from || '0x'
         this.to = createTxObj.to || '0x'
 
         if (createTxObj.input && createTxObj.data)
@@ -60,18 +61,6 @@ class LegacyTransaction extends AbstractTransaction {
         this.input = createTxObj.input || createTxObj.data || '0x'
 
         this.value = createTxObj.value || '0x0'
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (address !== '0x' && !utils.isAddress(address)) throw new Error(`Invalid address ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
@@ -77,7 +77,6 @@ class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractDeploy, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to || '0x'
         this.value = createTxObj.value
 
@@ -88,18 +87,6 @@ class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
 
         this.humanReadable = createTxObj.humanReadable !== undefined ? createTxObj.humanReadable : false
         this.codeFormat = createTxObj.codeFormat !== undefined ? createTxObj.codeFormat : CODE_FORMAT.EVM
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
@@ -90,7 +90,6 @@ class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegatedWithR
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractDeployWithRatio, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to || '0x'
         this.value = createTxObj.value
 
@@ -101,18 +100,6 @@ class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegatedWithR
 
         this.humanReadable = createTxObj.humanReadable !== undefined ? createTxObj.humanReadable : false
         this.codeFormat = createTxObj.codeFormat !== undefined ? createTxObj.codeFormat : CODE_FORMAT.EVM
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
@@ -73,7 +73,6 @@ class SmartContractDeploy extends AbstractTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeSmartContractDeploy, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to || '0x'
         this.value = createTxObj.value
 
@@ -84,18 +83,6 @@ class SmartContractDeploy extends AbstractTransaction {
 
         this.humanReadable = createTxObj.humanReadable !== undefined ? createTxObj.humanReadable : false
         this.codeFormat = createTxObj.codeFormat !== undefined ? createTxObj.codeFormat : CODE_FORMAT.EVM
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.js
@@ -73,7 +73,6 @@ class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTransaction
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractExecution, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value || '0x0'
 
@@ -81,18 +80,6 @@ class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTransaction
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecutionWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecutionWithRatio.js
@@ -74,7 +74,6 @@ class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDelegatedWi
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractExecutionWithRatio, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value || '0x0'
 
@@ -82,18 +81,6 @@ class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDelegatedWi
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.js
@@ -70,7 +70,6 @@ class SmartContractExecution extends AbstractTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeSmartContractExecution, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value || '0x0'
 
@@ -78,18 +77,6 @@ class SmartContractExecution extends AbstractTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransfer.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransfer.js
@@ -71,21 +71,8 @@ class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedValueTransfer, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransferWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransferWithRatio.js
@@ -72,21 +72,8 @@ class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWithRatioTr
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedValueTransferWithRatio, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransfer/valueTransfer.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransfer/valueTransfer.js
@@ -68,21 +68,8 @@ class ValueTransfer extends AbstractTransaction {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeValueTransfer, createTxObj)
 
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.js
@@ -72,7 +72,6 @@ class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedValueTransferMemo, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value
 
@@ -80,18 +79,6 @@ class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.js
@@ -73,7 +73,6 @@ class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegatedWithRat
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedValueTransferMemoWithRatio, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value
 
@@ -81,18 +80,6 @@ class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegatedWithRat
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.js
@@ -68,7 +68,6 @@ class ValueTransferMemo extends AbstractTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeValueTransferMemo, createTxObj)
-        this.from = createTxObj.from
         this.to = createTxObj.to
         this.value = createTxObj.value
 
@@ -76,18 +75,6 @@ class ValueTransferMemo extends AbstractTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
-    }
-
-    /**
-     * @type {string}
-     */
-    get from() {
-        return this._from
-    }
-
-    set from(address) {
-        if (!utils.isAddress(address)) throw new Error(`Invalid address of from: ${address}`)
-        this._from = address.toLowerCase()
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

This PR introduces adding from variable in AbstractTransaction.
In AbstractTransaction, `this.from` is used for validation when sign, so from should be defined in AbstractTransaction.

But for LegacyTransaction, if user didn't define from variable, then '0x' will be used for from.
And when sign transaction, this '0x' value will be replaced with keyring.address.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
