### PR TITLE
Defined getCommonRLPEncodingForSignature as an abstract method

### DIFF
--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -311,6 +311,18 @@ class AbstractTransaction {
     }
 
     /**
+     * Returns the RLP-encoded string to make the signature of this transaction.
+     * This method has to be overrided in classes which extends AbstractTransaction.
+     * getCommonRLPEncodingForSignature is used in getRLPEncodingForSignature.
+     *
+     * @return {string}
+     */
+    // eslint-disable-next-line class-methods-use-this
+    getCommonRLPEncodingForSignature() {
+        throw new Error('getCommonRLPEncodingForSignature has to be implemented')
+    }
+
+    /**
      * Fills empty optional transaction properties(gasPrice, nonce, chainId).
      */
     async fillTransaction() {

--- a/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
@@ -170,6 +170,16 @@ class LegacyTransaction extends AbstractTransaction {
             '0x',
         ])
     }
+
+    /**
+     * LegacyTransaction does not have a common RLP encoding because no other type exists.
+     * So getCommonRLPEncodingForSignature calls getRLPEncodingForSignature to return RLP-encoded string.
+     *
+     * @return {string}
+     */
+    getCommonRLPEncodingForSignature() {
+        return this.getRLPEncodingForSignature()
+    }
 }
 
 module.exports = LegacyTransaction


### PR DESCRIPTION
## Proposed changes

This PR introduces modification AbstractTransaction for defining getCommonRLPEncodingForSignature as an abstract method.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
