### PR TITLE
Modified to check essential optional value per function

### DIFF
--- a/packages/caver-transaction/src/transactionTypes/abstractFeeDelegatedTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractFeeDelegatedTransaction.js
@@ -220,7 +220,7 @@ class AbstractFeeDelegatedTransaction extends AbstractTransaction {
      * @return {string}
      */
     getRLPEncodingForFeePayerSignature() {
-        return RLP.encode([this.getCommonRLPEncodingForSignature(), this.feePayer, Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
+        return RLP.encode([this.getCommonRLPEncodingForSignature(), this.feePayer, Bytes.fromNat(this.chainId), '0x', '0x'])
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -241,7 +241,7 @@ class AbstractTransaction {
         // If the signatures are empty, there may be an undefined member variable.
         // In this case, the empty information is filled with the decoded result.
         let fillVariables = false
-        if (this.signatures.length === 0) fillVariables = true
+        if (this.signatures.length === 0 || utils.isEmptySig(this.signatures)) fillVariables = true
 
         for (const encoded of rlpEncodedTxs) {
             const type = typeDetectionFromRLPEncoding(encoded)
@@ -306,6 +306,8 @@ class AbstractTransaction {
      */
     getRLPEncodingForSignature() {
         this.validateOptionalValues()
+        if (this.chainId === undefined)
+            throw new Error(`chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`)
 
         return RLP.encode([this.getCommonRLPEncodingForSignature(), Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
     }
@@ -346,8 +348,6 @@ class AbstractTransaction {
             throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
         if (this.nonce === undefined)
             throw new Error(`nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`)
-        if (this.chainId === undefined)
-            throw new Error(`chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -309,7 +309,7 @@ class AbstractTransaction {
         if (this.chainId === undefined)
             throw new Error(`chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`)
 
-        return RLP.encode([this.getCommonRLPEncodingForSignature(), Bytes.fromNat(this.chainId || '0x1'), '0x', '0x'])
+        return RLP.encode([this.getCommonRLPEncodingForSignature(), Bytes.fromNat(this.chainId), '0x', '0x'])
     }
 
     /**

--- a/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
@@ -157,6 +157,8 @@ class LegacyTransaction extends AbstractTransaction {
      */
     getRLPEncodingForSignature() {
         this.validateOptionalValues()
+        if (this.chainId === undefined)
+            throw new Error(`chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`)
 
         return RLP.encode([
             Bytes.fromNat(this.nonce),

--- a/packages/caver-wallet/src/keyring/privateKey.js
+++ b/packages/caver-wallet/src/keyring/privateKey.js
@@ -58,7 +58,7 @@ class PrivateKey {
      * @return {Array<string>}
      */
     sign(transactionHash, chainId) {
-        const signature = AccountLib.makeSigner(Nat.toNumber(chainId || '0x1') * 2 + 35)(transactionHash, this.privateKey)
+        const signature = AccountLib.makeSigner(Nat.toNumber(chainId) * 2 + 35)(transactionHash, this.privateKey)
         const [v, r, s] = AccountLib.decodeSignature(signature).map(sig => utils.makeEven(utils.trimLeadingZero(sig)))
         return [v, r, s]
     }

--- a/test/packages/caver.transaction/accountUpdate.js
+++ b/test/packages/caver.transaction/accountUpdate.js
@@ -395,17 +395,6 @@ describe('TxTypeAccountUpdate', () => {
                 expect(() => tx.getRLPEncoding()).to.throw(expectedError)
             }
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-159: getRLPEncoding should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-            }
-        })
     })
 
     context('accountUpdate.signWithKey', () => {
@@ -898,17 +887,6 @@ describe('TxTypeAccountUpdate', () => {
                 expect(() => tx.getTransactionHash()).to.throw(expectedError)
             }
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-185: getTransactionHash should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getTransactionHash()).to.throw(expectedError)
-            }
-        })
     })
 
     context('accountUpdate.getSenderTxHash', () => {
@@ -948,17 +926,6 @@ describe('TxTypeAccountUpdate', () => {
                 delete tx._gasPrice
 
                 const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-            }
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-189: getSenderTxHash should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.accountUpdate(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
                 expect(() => tx.getSenderTxHash()).to.throw(expectedError)
             }

--- a/test/packages/caver.transaction/cancel.js
+++ b/test/packages/caver.transaction/cancel.js
@@ -182,15 +182,6 @@ describe('TxTypeCancel', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-304: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('cancel.signWithKey', () => {
@@ -618,15 +609,6 @@ describe('TxTypeCancel', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-330: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('cancel.getSenderTxHash', () => {
@@ -651,24 +633,6 @@ describe('TxTypeCancel', () => {
             delete tx._nonce
 
             const expectedError = `nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-334: getSenderTxHash should throw error when gasPrice is undefined', () => {
-            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
-            delete tx._gasPrice
-
-            const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-334: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.cancel(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/chainDataAnchoring.js
+++ b/test/packages/caver.transaction/chainDataAnchoring.js
@@ -193,15 +193,6 @@ describe('TxTypeChainDataAnchoring', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-351: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('chainDataAnchoring.signWithKey', () => {
@@ -630,15 +621,6 @@ describe('TxTypeChainDataAnchoring', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-377: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('chainDataAnchoring.getSenderTxHash', () => {
@@ -672,15 +654,6 @@ describe('TxTypeChainDataAnchoring', () => {
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-381: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.chainDataAnchoring(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedAccountUpdate.js
+++ b/test/packages/caver.transaction/feeDelegatedAccountUpdate.js
@@ -480,17 +480,6 @@ describe('TxTypeFeeDelegatedAccountUpdate', () => {
                 expect(() => tx.getRLPEncoding()).to.throw(expectedError)
             }
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-160: getRLPEncoding should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.feeDelegatedAccountUpdate(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-            }
-        })
     })
 
     context('feeDelegatedAccountUpdate.signWithKey', () => {
@@ -1478,17 +1467,6 @@ describe('TxTypeFeeDelegatedAccountUpdate', () => {
                 expect(() => tx.getTransactionHash()).to.throw(expectedError)
             }
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-209: getTransactionHash should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.feeDelegatedAccountUpdate(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getTransactionHash()).to.throw(expectedError)
-            }
-        })
     })
 
     context('feeDelegatedAccountUpdate.getSenderTxHash', () => {
@@ -1528,17 +1506,6 @@ describe('TxTypeFeeDelegatedAccountUpdate', () => {
                 delete tx._gasPrice
 
                 const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-            }
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-213: getSenderTxHash should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.feeDelegatedAccountUpdate(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
                 expect(() => tx.getSenderTxHash()).to.throw(expectedError)
             }

--- a/test/packages/caver.transaction/feeDelegatedAccountUpdateWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedAccountUpdateWithRatio.js
@@ -520,17 +520,6 @@ describe('TxTypeFeeDelegatedAccountUpdateWithRatio', () => {
                 expect(() => tx.getRLPEncoding()).to.throw(expectedError)
             }
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-163: getRLPEncoding should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.feeDelegatedAccountUpdateWithRatio(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-            }
-        })
     })
 
     context('feeDelegatedAccountUpdateWithRatio.signWithKey', () => {
@@ -1519,17 +1508,6 @@ describe('TxTypeFeeDelegatedAccountUpdateWithRatio', () => {
                 expect(() => tx.getTransactionHash()).to.throw(expectedError)
             }
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-212: getTransactionHash should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.feeDelegatedAccountUpdateWithRatio(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getTransactionHash()).to.throw(expectedError)
-            }
-        })
     })
 
     context('feeDelegatedAccountUpdateWithRatio.getSenderTxHash', () => {
@@ -1569,17 +1547,6 @@ describe('TxTypeFeeDelegatedAccountUpdateWithRatio', () => {
                 delete tx._gasPrice
 
                 const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-                expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-            }
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-216: getSenderTxHash should throw error when chainId is undefined', () => {
-            for (let i = 0; i < expectedValues.length; i++) {
-                const tx = new caver.transaction.feeDelegatedAccountUpdateWithRatio(expectedValues[i].tx)
-                delete tx._chainId
-
-                const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
                 expect(() => tx.getSenderTxHash()).to.throw(expectedError)
             }

--- a/test/packages/caver.transaction/feeDelegatedCancel.js
+++ b/test/packages/caver.transaction/feeDelegatedCancel.js
@@ -210,15 +210,6 @@ describe('TxTypeFeeDelegatedCancel', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-380: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedCancel(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedCancel.signWithKey', () => {
@@ -1079,15 +1070,6 @@ describe('TxTypeFeeDelegatedCancel', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-429: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedCancel(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedCancel.getSenderTxHash', () => {
@@ -1120,15 +1102,6 @@ describe('TxTypeFeeDelegatedCancel', () => {
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-433: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedCancel(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedCancelWIthRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedCancelWIthRatio.js
@@ -243,15 +243,6 @@ describe('TxTypeFeeDelegatedCancelWithRatio', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-386: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedCancelWithRatio(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedCancelWithRatio.signWithKey', () => {
@@ -1113,15 +1104,6 @@ describe('TxTypeFeeDelegatedCancelWithRatio', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-435: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedCancelWithRatio(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedCancelWithRatio.getSenderTxHash', () => {
@@ -1154,15 +1136,6 @@ describe('TxTypeFeeDelegatedCancelWithRatio', () => {
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-439: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedCancelWithRatio(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedChainDataAnchoring.js
+++ b/test/packages/caver.transaction/feeDelegatedChainDataAnchoring.js
@@ -221,15 +221,6 @@ describe('TxTypeFeeDelegatedChainDataAnchoring', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-452: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedChainDataAnchoring(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedChainDataAnchoring.signWithKey', () => {
@@ -1091,15 +1082,6 @@ describe('TxTypeFeeDelegatedChainDataAnchoring', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-501: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedChainDataAnchoring(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedChainDataAnchoring.getSenderTxHash', () => {
@@ -1132,15 +1114,6 @@ describe('TxTypeFeeDelegatedChainDataAnchoring', () => {
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-505: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedChainDataAnchoring(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedChainDataAnchoringWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedChainDataAnchoringWithRatio.js
@@ -121,42 +121,42 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
     })
 
     context('create feeDelegatedChainDataAnchoringWithRatio instance', () => {
-        it('CAVERJS-UNIT-TRANSACTIONFD-448: If feeDelegatedChainDataAnchoringWithRatio not define from, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-448: If feeDelegatedChainDataAnchoringWithRatio not define from, return error', () => {
             delete transactionObj.from
 
             const expectedError = '"from" is missing'
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-449: If feeDelegatedChainDataAnchoringWithRatio not define gas, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-449: If feeDelegatedChainDataAnchoringWithRatio not define gas, return error', () => {
             delete transactionObj.gas
 
             const expectedError = '"gas" is missing'
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-450: If feeDelegatedChainDataAnchoringWithRatio not define input, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-450: If feeDelegatedChainDataAnchoringWithRatio not define input, return error', () => {
             delete transactionObj.input
 
             const expectedError = '"input" is missing'
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-451: If feeDelegatedChainDataAnchoringWithRatio not define feeRatio, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-451: If feeDelegatedChainDataAnchoringWithRatio not define feeRatio, return error', () => {
             delete transactionObj.feeRatio
 
             const expectedError = '"feeRatio" is missing'
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-452: If feeDelegatedChainDataAnchoringWithRatio define from property with invalid address, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-452: If feeDelegatedChainDataAnchoringWithRatio define from property with invalid address, return error', () => {
             transactionObj.from = 'invalid'
 
             const expectedError = `Invalid address of from: ${transactionObj.from}`
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-453: If feeDelegatedChainDataAnchoringWithRatio define feePayer property with invalid address, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-453: If feeDelegatedChainDataAnchoringWithRatio define feePayer property with invalid address, return error', () => {
             transactionObj.feePayer = 'invalid'
 
             const expectedError = `Invalid address of fee payer: ${transactionObj.feePayer}`
@@ -188,7 +188,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-454: If feeDelegatedChainDataAnchoringWithRatio define feePayerSignatures property without feePayer, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-454: If feeDelegatedChainDataAnchoringWithRatio define feePayerSignatures property without feePayer, return error', () => {
             transactionObj.feePayerSignatures = [
                 [
                     '0x26',
@@ -201,7 +201,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-455: If feeDelegatedChainDataAnchoringWithRatio define unnecessary property, return error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-455: If feeDelegatedChainDataAnchoringWithRatio define unnecessary property, return error', () => {
             const unnecessaries = [
                 propertiesForUnnecessary.to,
                 propertiesForUnnecessary.value,
@@ -231,13 +231,13 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
     })
 
     context('feeDelegatedChainDataAnchoringWithRatio.getRLPEncoding', () => {
-        it('CAVERJS-UNIT-TRANSACTIONFD-456: Returns RLP-encoded string', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-456: Returns RLP-encoded string', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
 
             expect(tx.getRLPEncoding()).to.equal(txWithExpectedValues.rlpEncoding)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-457: getRLPEncoding should throw error when nonce is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-457: getRLPEncoding should throw error when nonce is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._nonce
 
@@ -246,20 +246,11 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-458: getRLPEncoding should throw error when gasPrice is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-458: getRLPEncoding should throw error when gasPrice is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-459: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
@@ -296,7 +287,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
         }
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-460: input: keyring. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-460: input: keyring. should sign transaction.', async () => {
             await tx.signWithKey(sender)
 
             checkFunctionCall()
@@ -305,7 +296,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-461: input: private key string. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-461: input: private key string. should sign transaction.', async () => {
             const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
             await tx.signWithKey(sender.keys[0][0].privateKey)
 
@@ -315,7 +306,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-462: input: KlaytnWalletKey. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-462: input: KlaytnWalletKey. should sign transaction.', async () => {
             const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
             await tx.signWithKey(sender.getKlaytnWalletKey())
 
@@ -325,7 +316,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-463: input: keyring, index. should sign transaction with specific index.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-463: input: keyring, index. should sign transaction with specific index.', async () => {
             const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
 
             tx.from = roleBasedKeyring.address
@@ -338,7 +329,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 0, 1)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-464: input: keyring, custom hasher. should throw error.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-464: input: keyring, custom hasher. should throw error.', async () => {
             const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
             const customHasher = () => hashForCustomHasher
 
@@ -346,7 +337,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             await expect(tx.signWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-465: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-465: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
             const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
             const customHasher = () => hashForCustomHasher
 
@@ -362,7 +353,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0, 1)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-466: input: keyring. should throw error when from is different.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-466: input: keyring. should throw error when from is different.', async () => {
             transactionObj.from = roleBasedKeyring.address
             tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
@@ -370,7 +361,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             await expect(tx.signWithKey(sender)).to.be.rejectedWith(expectedError)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-467: input: rolebased keyring, index out of range. should throw error.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-467: input: rolebased keyring, index out of range. should throw error.', async () => {
             transactionObj.from = roleBasedKeyring.address
             tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
@@ -411,7 +402,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
         }
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-468: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-468: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
             tx.feePayer = '0x'
             await tx.signFeePayerWithKey(sender)
 
@@ -422,7 +413,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-469: input: keyring. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-469: input: keyring. should sign transaction.', async () => {
             await tx.signFeePayerWithKey(sender)
 
             checkFunctionCall()
@@ -431,7 +422,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-470: input: private key string. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-470: input: private key string. should sign transaction.', async () => {
             const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
             await tx.signFeePayerWithKey(sender.keys[0][0].privateKey)
 
@@ -441,7 +432,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-471: input: KlaytnWalletKey. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-471: input: KlaytnWalletKey. should sign transaction.', async () => {
             const signWithKeyProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKey')
             await tx.signFeePayerWithKey(sender.getKlaytnWalletKey())
 
@@ -451,7 +442,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeyProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2, 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-472: input: keyring, index. should sign transaction with specific index.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-472: input: keyring, index. should sign transaction with specific index.', async () => {
             const roleBasedSignWithKeySpy = sandbox.spy(roleBasedKeyring, 'signWithKey')
 
             tx.feePayer = roleBasedKeyring.address
@@ -464,7 +455,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(roleBasedSignWithKeySpy).to.have.been.calledWith(txHash, '0x7e3', 2, 1)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-473: input: keyring, custom hasher. should throw error.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-473: input: keyring, custom hasher. should throw error.', async () => {
             const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
             const customHasher = () => hashForCustomHasher
 
@@ -472,7 +463,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             await expect(tx.signFeePayerWithKey(sender, customHasher)).to.be.rejectedWith(expectedError)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-474: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-474: input: keyring, index, custom hasher. should use custom hasher when sign transaction.', async () => {
             const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
             const customHasher = () => hashForCustomHasher
 
@@ -488,14 +479,14 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(roleBasedSignWithKeySpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 2, 1)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-475: input: keyring. should throw error when feePayer is different.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-475: input: keyring. should throw error when feePayer is different.', async () => {
             tx.feePayer = roleBasedKeyring.address
 
             const expectedError = `The feePayer address of the transaction is different with the address of the keyring to use.`
             await expect(tx.signFeePayerWithKey(sender)).to.be.rejectedWith(expectedError)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-476: input: rolebased keyring, index out of range. should throw error.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-476: input: rolebased keyring, index out of range. should throw error.', async () => {
             transactionObj.from = roleBasedKeyring.address
             tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
@@ -535,7 +526,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
         }
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-477: input: keyring. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-477: input: keyring. should sign transaction.', async () => {
             await tx.signWithKeys(sender)
 
             checkFunctionCall()
@@ -544,7 +535,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-478: input: private key string. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-478: input: private key string. should sign transaction.', async () => {
             const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
             await tx.signWithKeys(sender.keys[0][0].privateKey)
 
@@ -554,7 +545,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-479: input: KlaytnWalletKey. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-479: input: KlaytnWalletKey. should sign transaction.', async () => {
             const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
             await tx.signWithKeys(sender.getKlaytnWalletKey())
 
@@ -564,7 +555,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-480: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-480: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
             const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
             const customHasher = () => hashForCustomHasher
 
@@ -576,7 +567,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 0)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-481: input: keyring. should throw error when from is different.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-481: input: keyring. should throw error when from is different.', async () => {
             transactionObj.from = roleBasedKeyring.address
             tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
@@ -584,7 +575,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             await expect(tx.signWithKeys(sender)).to.be.rejectedWith(expectedError)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-482: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-482: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
             const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
 
             tx.from = roleBasedKeyring.address
@@ -629,7 +620,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             if (!customHasher) expect(hasherSpy).to.have.been.calledWith(tx)
         }
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-483: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-483: input: keyring. If feePayer is not defined, should be set with keyring address.', async () => {
             tx.feePayer = '0x'
             await tx.signFeePayerWithKeys(sender)
 
@@ -639,7 +630,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-484: input: keyring. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-484: input: keyring. should sign transaction.', async () => {
             await tx.signFeePayerWithKeys(sender)
 
             checkFunctionCall()
@@ -648,7 +639,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeysSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-485: input: private key string. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-485: input: private key string. should sign transaction.', async () => {
             const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
             await tx.signFeePayerWithKeys(sender.keys[0][0].privateKey)
 
@@ -658,7 +649,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-486: input: KlaytnWalletKey. should sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-486: input: KlaytnWalletKey. should sign transaction.', async () => {
             const signWithKeysProtoSpy = sandbox.spy(Keyring.prototype, 'signWithKeys')
             await tx.signFeePayerWithKeys(sender.getKlaytnWalletKey())
 
@@ -668,7 +659,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(signWithKeysProtoSpy).to.have.been.calledWith(txHash, '0x7e3', 2)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-487: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-487: input: keyring, custom hasher. should use custom hasher when sign transaction.', async () => {
             const hashForCustomHasher = '0x9e4b4835f6ea5ce55bd1037fe92040dd070af6154aefc30d32c65364a1123cae'
             const customHasher = () => hashForCustomHasher
 
@@ -680,14 +671,14 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(senderSignWithKeysSpy).to.have.been.calledWith(hashForCustomHasher, '0x7e3', 2)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-488: input: keyring. should throw error when feePayer is different.', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-488: input: keyring. should throw error when feePayer is different.', async () => {
             tx.feePayer = roleBasedKeyring.address
 
             const expectedError = `The feePayer address of the transaction is different with the address of the keyring to use.`
             await expect(tx.signFeePayerWithKeys(sender)).to.be.rejectedWith(expectedError)
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-489: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-489: input: roleBased keyring. should sign with multiple keys and append signatures', async () => {
             const roleBasedSignWithKeysSpy = sandbox.spy(roleBasedKeyring, 'signWithKeys')
 
             tx.feePayer = roleBasedKeyring.address
@@ -706,7 +697,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-490: If signatures is empty, appendSignatures append signatures in transaction', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-490: If signatures is empty, appendSignatures append signatures in transaction', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             const sig = [
@@ -718,7 +709,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkSignature(tx)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-491: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-491: If signatures is empty, appendSignatures append signatures with two-dimensional signature array', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             const sig = [
@@ -732,7 +723,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkSignature(tx)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-492: If signatures is not empty, appendSignatures should append signatures', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-492: If signatures is not empty, appendSignatures should append signatures', () => {
             transactionObj.signatures = [
                 '0x0fea',
                 '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
@@ -750,7 +741,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkSignature(tx, { expectedLength: 2 })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-493: appendSignatures should append multiple signatures', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-493: appendSignatures should append multiple signatures', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             const sig = [
@@ -779,7 +770,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-494: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures in transaction', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-494: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures in transaction', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             const sig = [
@@ -791,7 +782,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkFeePayerSignature(tx)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-495: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures with two-dimensional signature array', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-495: If feePayerSignatures is empty, appendFeePayerSignatures append feePayerSignatures with two-dimensional signature array', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             const sig = [
@@ -805,7 +796,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkFeePayerSignature(tx)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-496: If feePayerSignatures is not empty, appendFeePayerSignatures should append feePayerSignatures', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-496: If feePayerSignatures is not empty, appendFeePayerSignatures should append feePayerSignatures', () => {
             transactionObj.feePayerSignatures = [
                 '0x0fea',
                 '0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e',
@@ -823,7 +814,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkFeePayerSignature(tx, { expectedLength: 2 })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-497: appendFeePayerSignatures should append multiple feePayerSignatures', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-497: appendFeePayerSignatures should append multiple feePayerSignatures', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             const sig = [
@@ -860,7 +851,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-498: combineSignatures combines single signature and sets signatures in transaction', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-498: combineSignatures combines single signature and sets signatures in transaction', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
             const appendSignaturesSpy = sandbox.spy(tx, 'appendSignatures')
             const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
@@ -883,7 +874,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkSignature(tx, { expectedSignatures })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-499: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-499: combineSignatures combines multiple signatures and sets signatures in transaction', () => {
             transactionObj.signatures = [
                 [
                     '0x0fea',
@@ -930,7 +921,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkSignature(tx, { expectedSignatures })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-500: combineSignatures combines single feePayerSignature and sets feePayerSignatures in transaction', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-500: combineSignatures combines single feePayerSignature and sets feePayerSignatures in transaction', () => {
             transactionObj.feePayer = '0x75d141c9dbefde51f488c8d79da55f48282a1e52'
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
             const appendSignaturesSpy = sandbox.spy(tx, 'appendFeePayerSignatures')
@@ -954,7 +945,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkFeePayerSignature(tx, { expectedSignatures })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-501: combineSignatures combines multiple feePayerSignatures and sets feePayerSignatures in transaction', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-501: combineSignatures combines multiple feePayerSignatures and sets feePayerSignatures in transaction', () => {
             transactionObj.feePayer = '0x75d141c9dbefde51f488c8d79da55f48282a1e52'
             transactionObj.feePayerSignatures = [
                 [
@@ -1002,7 +993,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkFeePayerSignature(tx, { expectedSignatures })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-502: combineSignatures combines multiple signatures and feePayerSignatures', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-502: combineSignatures combines multiple signatures and feePayerSignatures', () => {
             let tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
 
             // RLP encoding with only signatures
@@ -1065,7 +1056,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             checkFeePayerSignature(tx, { expectedFeePayerSignatures })
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-503: If decode transaction has different values, combineSignatures should throw error', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-503: If decode transaction has different values, combineSignatures should throw error', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(transactionObj)
             tx.nonce = 1234
 
@@ -1082,7 +1073,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-504: getRawTransaction should call getRLPEncoding function', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-504: getRawTransaction should call getRLPEncoding function', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
 
@@ -1098,7 +1089,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-505: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-505: getTransactionHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
             const txHash = tx.getTransactionHash()
@@ -1108,7 +1099,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(caver.utils.isValidHashStrict(txHash)).to.be.true
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-506: getTransactionHash should throw error when nonce is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-506: getTransactionHash should throw error when nonce is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._nonce
 
@@ -1117,20 +1108,11 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-507: getTransactionHash should throw error when gasPrice is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-507: getTransactionHash should throw error when gasPrice is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-508: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
@@ -1141,7 +1123,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-509: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-509: getSenderTxHash should call getRLPEncoding function and return hash of RLPEncoding', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
 
@@ -1152,7 +1134,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(caver.utils.isValidHashStrict(senderTxHash)).to.be.true
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-510: getSenderTxHash should throw error when nonce is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-510: getSenderTxHash should throw error when nonce is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._nonce
 
@@ -1161,20 +1143,11 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-511: getSenderTxHash should throw error when gasPrice is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-511: getSenderTxHash should throw error when gasPrice is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-512: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })
@@ -1185,7 +1158,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             sandbox.restore()
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-513: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-513: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
 
             const commonRLPForSigningSpy = sandbox.spy(tx, 'getCommonRLPEncodingForSignature')
@@ -1196,7 +1169,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(commonRLPForSigningSpy).to.have.been.calledOnce
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-514: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-514: getRLPEncodingForSignature should throw error when nonce is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._nonce
 
@@ -1205,7 +1178,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-515: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-515: getRLPEncodingForSignature should throw error when gasPrice is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._gasPrice
 
@@ -1214,7 +1187,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(() => tx.getRLPEncodingForSignature()).to.throw(expectedError)
         })
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-516: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-516: getRLPEncodingForSignature should throw error when chainId is undefined', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._chainId
 
@@ -1225,7 +1198,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
     })
 
     context('feeDelegatedChainDataAnchoringWithRatio.getCommonRLPEncodingForSignature', () => {
-        it('CAVERJS-UNIT-TRANSACTIONFD-517: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-517: getRLPEncodingForSignature should return RLP-encoded transaction string for signing', () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
 
             const commonRLPForSign = tx.getCommonRLPEncodingForSignature()
@@ -1236,7 +1209,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
     })
 
     context('feeDelegatedChainDataAnchoringWithRatio.fillTransaction', () => {
-        it('CAVERJS-UNIT-TRANSACTIONFD-518: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-518: fillTransaction should call klay_getGasPrice to fill gasPrice when gasPrice is undefined', async () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._gasPrice
 
@@ -1246,7 +1219,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(getChainIdSpy).not.to.have.been.calledOnce
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-519: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-519: fillTransaction should call klay_getTransactionCount to fill nonce when nonce is undefined', async () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._nonce
 
@@ -1256,7 +1229,7 @@ describe('TxTypeFeeDelegatedChainDataAnchoringWithRatio', () => {
             expect(getChainIdSpy).not.to.have.been.calledOnce
         }).timeout(200000)
 
-        it('CAVERJS-UNIT-TRANSACTIONFD-520: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
+        it('CAVERJS-UNIT-TRANSACTIONFDR-520: fillTransaction should call klay_getChainid to fill chainId when chainId is undefined', async () => {
             const tx = new caver.transaction.feeDelegatedChainDataAnchoringWithRatio(txWithExpectedValues.tx)
             delete tx._chainId
 

--- a/test/packages/caver.transaction/feeDelegatedSmartContractDeploy.js
+++ b/test/packages/caver.transaction/feeDelegatedSmartContractDeploy.js
@@ -245,16 +245,6 @@ describe('TxTypeFeeDelegatedSmartContractDeploy', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-235: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractDeploy(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractDeploy.signWithKey', () => {
@@ -1122,16 +1112,6 @@ describe('TxTypeFeeDelegatedSmartContractDeploy', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-284: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractDeploy(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractDeploy.getSenderTxHash', () => {
@@ -1166,16 +1146,6 @@ describe('TxTypeFeeDelegatedSmartContractDeploy', () => {
             const tx = new caver.transaction.feeDelegatedSmartContractDeploy(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-288: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractDeploy(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedSmartContractDeployWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedSmartContractDeployWithRatio.js
@@ -278,16 +278,6 @@ describe('TxTypeFeeDelegatedSmartContractDeployWithRatio', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-239: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractDeployWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractDeployWithRatio.signWithKey', () => {
@@ -1156,16 +1146,6 @@ describe('TxTypeFeeDelegatedSmartContractDeployWithRatio', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-288: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractDeployWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractDeployWithRatio.getSenderTxHash', () => {
@@ -1200,16 +1180,6 @@ describe('TxTypeFeeDelegatedSmartContractDeployWithRatio', () => {
             const tx = new caver.transaction.feeDelegatedSmartContractDeployWithRatio(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-292: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractDeployWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedSmartContractExecution.js
+++ b/test/packages/caver.transaction/feeDelegatedSmartContractExecution.js
@@ -236,16 +236,6 @@ describe('TxTypeFeeDelegatedSmartContractExecution', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-309: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractExecution(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractExecution.signWithKey', () => {
@@ -1112,16 +1102,6 @@ describe('TxTypeFeeDelegatedSmartContractExecution', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-358: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractExecution(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractExecution.getSenderTxHash', () => {
@@ -1156,16 +1136,6 @@ describe('TxTypeFeeDelegatedSmartContractExecution', () => {
             const tx = new caver.transaction.feeDelegatedSmartContractExecution(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-362: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractExecution(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedSmartContractExecutionWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedSmartContractExecutionWithRatio.js
@@ -269,16 +269,6 @@ describe('TxTypeFeeDelegatedSmartContractExecutionWithRatio', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-314: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractExecutionWithRatio.signWithKey', () => {
@@ -1146,16 +1136,6 @@ describe('TxTypeFeeDelegatedSmartContractExecutionWithRatio', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-363: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedSmartContractExecutionWithRatio.getSenderTxHash', () => {
@@ -1190,16 +1170,6 @@ describe('TxTypeFeeDelegatedSmartContractExecutionWithRatio', () => {
             const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-367: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedValueTransfer.js
+++ b/test/packages/caver.transaction/feeDelegatedValueTransfer.js
@@ -238,16 +238,6 @@ describe('TxTypeFeeDelegatedValueTransfer', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-013: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransfer.signWithKey', () => {
@@ -1112,16 +1102,6 @@ describe('TxTypeFeeDelegatedValueTransfer', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-062: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransfer.getSenderTxHash', () => {
@@ -1156,16 +1136,6 @@ describe('TxTypeFeeDelegatedValueTransfer', () => {
             const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-066: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransfer(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedValueTransferMemo.js
+++ b/test/packages/caver.transaction/feeDelegatedValueTransferMemo.js
@@ -245,16 +245,6 @@ describe('TxTypeFeeDelegatedValueTransferMemo', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-088: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransferMemo.signWithKey', () => {
@@ -1120,16 +1110,6 @@ describe('TxTypeFeeDelegatedValueTransferMemo', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-137: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransferMemo.getSenderTxHash', () => {
@@ -1164,16 +1144,6 @@ describe('TxTypeFeeDelegatedValueTransferMemo', () => {
             const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-141: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferMemo(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedValueTransferMemoWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedValueTransferMemoWithRatio.js
@@ -278,16 +278,6 @@ describe('TxTypeFeeDelegatedValueTransferMemoWithRatio', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-090: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferMemoWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransferMemoWithRatio.signWithKey', () => {
@@ -1154,16 +1144,6 @@ describe('TxTypeFeeDelegatedValueTransferMemoWithRatio', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-139: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferMemoWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransferMemoWithRatio.getSenderTxHash', () => {
@@ -1198,16 +1178,6 @@ describe('TxTypeFeeDelegatedValueTransferMemoWithRatio', () => {
             const tx = new caver.transaction.feeDelegatedValueTransferMemoWithRatio(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-143: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferMemoWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/feeDelegatedValueTransferWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedValueTransferWithRatio.js
@@ -271,16 +271,6 @@ describe('TxTypeFeeDelegatedValueTransferWithRatio', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-014: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransferWithRatio.signWithKey', () => {
@@ -1146,16 +1136,6 @@ describe('TxTypeFeeDelegatedValueTransferWithRatio', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-063: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('feeDelegatedValueTransferWithRatio.getSenderTxHash', () => {
@@ -1190,16 +1170,6 @@ describe('TxTypeFeeDelegatedValueTransferWithRatio', () => {
             const tx = new caver.transaction.feeDelegatedValueTransferWithRatio(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-067: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.feeDelegatedValueTransferWithRatio(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/legacyTransaction.js
+++ b/test/packages/caver.transaction/legacyTransaction.js
@@ -187,16 +187,6 @@ describe('TxTypeLegacyTransaction', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-046: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.legacyTransaction(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('legacyTransaction.signWithKey', () => {
@@ -669,16 +659,6 @@ describe('TxTypeLegacyTransaction', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-049: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.legacyTransaction(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('legacyTransaction.getSenderTxHash', () => {
@@ -728,16 +708,6 @@ describe('TxTypeLegacyTransaction', () => {
             const tx = new caver.transaction.legacyTransaction(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-052: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.legacyTransaction(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/smartContractDeploy.js
+++ b/test/packages/caver.transaction/smartContractDeploy.js
@@ -216,15 +216,6 @@ describe('TxTypeSmartContractDeploy', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-209: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('smartContractDeploy.signWithKey', () => {
@@ -656,15 +647,6 @@ describe('TxTypeSmartContractDeploy', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-235: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('smartContractDeploy.getSenderTxHash', () => {
@@ -698,15 +680,6 @@ describe('TxTypeSmartContractDeploy', () => {
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-239: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.smartContractDeploy(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/smartContractExecution.js
+++ b/test/packages/caver.transaction/smartContractExecution.js
@@ -210,15 +210,6 @@ describe('TxTypeSmartContractExecution', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-258: getRLPEncoding should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('smartContractExecution.signWithKey', () => {
@@ -649,15 +640,6 @@ describe('TxTypeSmartContractExecution', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-284: getTransactionHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('smartContractExecution.getSenderTxHash', () => {
@@ -691,15 +673,6 @@ describe('TxTypeSmartContractExecution', () => {
             delete tx._gasPrice
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-288: getSenderTxHash should throw error when chainId is undefined', () => {
-            const tx = new caver.transaction.smartContractExecution(txWithExpectedValues.tx)
-            delete tx._chainId
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/valueTransfer.js
+++ b/test/packages/caver.transaction/valueTransfer.js
@@ -210,16 +210,6 @@ describe('TxTypeValueTransfer', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-063: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.valueTransfer(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('valueTransfer.signWithKey', () => {
@@ -646,16 +636,6 @@ describe('TxTypeValueTransfer', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-089: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.valueTransfer(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('valueTransfer.getSenderTxHash', () => {
@@ -690,16 +670,6 @@ describe('TxTypeValueTransfer', () => {
             const tx = new caver.transaction.valueTransfer(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-093: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.valueTransfer(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })

--- a/test/packages/caver.transaction/valueTransferMemo.js
+++ b/test/packages/caver.transaction/valueTransferMemo.js
@@ -217,16 +217,6 @@ describe('TxTypeValueTransferMemo', () => {
 
             expect(() => tx.getRLPEncoding()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-113: getRLPEncoding should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.valueTransferMemo(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getRLPEncoding()).to.throw(expectedError)
-        })
     })
 
     context('valueTransferMemo.signWithKey', () => {
@@ -657,16 +647,6 @@ describe('TxTypeValueTransferMemo', () => {
 
             expect(() => tx.getTransactionHash()).to.throw(expectedError)
         })
-
-        it('CAVERJS-UNIT-TRANSACTION-139: getTransactionHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.valueTransferMemo(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getTransactionHash()).to.throw(expectedError)
-        })
     })
 
     context('valueTransferMemo.getSenderTxHash', () => {
@@ -701,16 +681,6 @@ describe('TxTypeValueTransferMemo', () => {
             const tx = new caver.transaction.valueTransferMemo(transactionObj)
 
             const expectedError = `gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`
-
-            expect(() => tx.getSenderTxHash()).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-143: getSenderTxHash should throw error when chainId is undefined', () => {
-            transactionObj.gasPrice = '0x5d21dba00'
-            transactionObj.nonce = '0x3a'
-            const tx = new caver.transaction.valueTransferMemo(transactionObj)
-
-            const expectedError = `chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`
 
             expect(() => tx.getSenderTxHash()).to.throw(expectedError)
         })


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of optional value validation.

this.chainId is needed in getRLPEncodingForSignature only, so check that in that function.
In getTransactionHash, getSenderTxHash and getRLPEncoding functions, don't need this.chainId, so there is no point to check.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
