### PR TITLE
Extends Method to disable receipt formatter

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -58,6 +58,8 @@ function Method(options) {
 
     this.defaultBlock = options.defaultBlock || 'latest'
     this.defaultAccount = options.defaultAccount || null
+
+    this.outputFormatterDisable = options.outputFormatterDisable
 }
 
 Method.prototype.setRequestManager = setRequestManager
@@ -502,7 +504,9 @@ const addCustomSendMethod = mutableConfirmationPack => {
             name: 'getTransactionReceipt',
             call: 'klay_getTransactionReceipt',
             params: 1,
-            outputFormatter: formatters.outputTransactionReceiptFormatter,
+            outputFormatter: !mutableConfirmationPack.method.outputFormatterDisable
+                ? formatters.outputTransactionReceiptFormatter
+                : undefined,
         }),
         new Method({
             name: 'getCode',

--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -29,7 +29,7 @@ const _ = require('lodash')
 const core = require('../../caver-core')
 const { formatters } = require('../../caver-core-helpers')
 const Subscriptions = require('../../caver-core-subscriptions').subscriptions
-const Method = require('../../caver-core-method')
+const MethodBase = require('../../caver-core-method')
 
 const utils = require('../../caver-utils')
 
@@ -57,6 +57,13 @@ class KlayRPC {
         }
 
         this.clearSubscriptions = _this._requestManager.clearSubscriptions
+
+        class Method extends MethodBase {
+            constructor(options) {
+                options.outputFormatterDisable = true
+                super(options)
+            }
+        }
 
         const _klaytnCall = [
             new Method({


### PR DESCRIPTION
## Proposed changes

This PR introduces changes to disable outputFormatting in Method.

The old logic was to format the receipt as an outputFormatter after sending the transaction.
However, from the common architecture, it was decided not to format the result of the RPC call separately.
Therefore, even in the method that is automatically called inside the core-method after the transaction is sent, the logic has been modified so that it is not formatted in the case of a transaction sent through `caver.rpc.klay`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
