### PR TITLE
Set default value with smart contract deploy transactions

### DIFF
--- a/packages/caver-core-helpers/src/validateFunction.js
+++ b/packages/caver-core-helpers/src/validateFunction.js
@@ -555,7 +555,7 @@ function validateFeeDelegatedAccountUpdateWithRatio(transaction) {
 }
 
 function checkDeployEssential(transaction) {
-    if (transaction.value === undefined) {
+    if (transaction.value === undefined && !transaction.type.includes('TxType')) {
         return new Error('"value" is missing')
     }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
@@ -78,7 +78,7 @@ class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractDeploy, createTxObj)
         this.to = createTxObj.to || '0x'
-        this.value = createTxObj.value
+        this.value = createTxObj.value || '0x0'
 
         if (createTxObj.input && createTxObj.data)
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
@@ -91,7 +91,7 @@ class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegatedWithR
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractDeployWithRatio, createTxObj)
         this.to = createTxObj.to || '0x'
-        this.value = createTxObj.value
+        this.value = createTxObj.value || '0x0'
 
         if (createTxObj.input && createTxObj.data)
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
@@ -74,7 +74,7 @@ class SmartContractDeploy extends AbstractTransaction {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeSmartContractDeploy, createTxObj)
         this.to = createTxObj.to || '0x'
-        this.value = createTxObj.value
+        this.value = createTxObj.value || '0x0'
 
         if (createTxObj.input && createTxObj.data)
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)

--- a/test/packages/caver.transaction/feeDelegatedSmartContractDeploy.js
+++ b/test/packages/caver.transaction/feeDelegatedSmartContractDeploy.js
@@ -105,7 +105,6 @@ describe('TxTypeFeeDelegatedSmartContractDeploy', () => {
     beforeEach(() => {
         transactionObj = {
             from: sender.address,
-            value: 0,
             input,
             gas: '0x15f90',
         }
@@ -127,13 +126,6 @@ describe('TxTypeFeeDelegatedSmartContractDeploy', () => {
             delete transactionObj.from
 
             const expectedError = '"from" is missing'
-            expect(() => new caver.transaction.feeDelegatedSmartContractDeploy(transactionObj)).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFD-223: If feeDelegatedSmartContractDeploy not define value, return error', () => {
-            delete transactionObj.value
-
-            const expectedError = '"value" is missing'
             expect(() => new caver.transaction.feeDelegatedSmartContractDeploy(transactionObj)).to.throw(expectedError)
         })
 

--- a/test/packages/caver.transaction/feeDelegatedSmartContractDeployWithRatio.js
+++ b/test/packages/caver.transaction/feeDelegatedSmartContractDeployWithRatio.js
@@ -106,7 +106,6 @@ describe('TxTypeFeeDelegatedSmartContractDeployWithRatio', () => {
     beforeEach(() => {
         transactionObj = {
             from: sender.address,
-            value: 0,
             input,
             feeRatio: 30,
             gas: '0x15f90',
@@ -129,13 +128,6 @@ describe('TxTypeFeeDelegatedSmartContractDeployWithRatio', () => {
             delete transactionObj.from
 
             const expectedError = '"from" is missing'
-            expect(() => new caver.transaction.feeDelegatedSmartContractDeployWithRatio(transactionObj)).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTIONFDR-226: If feeDelegatedSmartContractDeployWithRatio not define value, return error', () => {
-            delete transactionObj.value
-
-            const expectedError = '"value" is missing'
             expect(() => new caver.transaction.feeDelegatedSmartContractDeployWithRatio(transactionObj)).to.throw(expectedError)
         })
 

--- a/test/packages/caver.transaction/smartContractDeploy.js
+++ b/test/packages/caver.transaction/smartContractDeploy.js
@@ -96,7 +96,6 @@ describe('TxTypeSmartContractDeploy', () => {
     beforeEach(() => {
         transactionObj = {
             from: sender.address,
-            value: 0,
             gas: '0x15f90',
             input: byteCode,
         }
@@ -118,13 +117,6 @@ describe('TxTypeSmartContractDeploy', () => {
             delete transactionObj.from
 
             const expectedError = '"from" is missing'
-            expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
-        })
-
-        it('CAVERJS-UNIT-TRANSACTION-199: If smartContractDeploy not define value, return error', () => {
-            delete transactionObj.value
-
-            const expectedError = '"value" is missing'
             expect(() => new caver.transaction.smartContractDeploy(transactionObj)).to.throw(expectedError)
         })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces setting default '0x0' value with smart contract deploy transactions.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
