### PR TITLE
Fixed bug with signature formatting when send tx to platform

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -409,9 +409,9 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
             let key = k
             if (key.startsWith('_')) key = key.slice(1)
             if (key === 'signatures' || key === 'feePayerSignatures') {
-                tx[key] = utils.transformSignaturesToObject(payload.params[0][k])
+                if (!utils.isEmptySig(payload.params[0][key])) tx[key] = utils.transformSignaturesToObject(payload.params[0][key])
             } else {
-                tx[key] = payload.params[0][k]
+                tx[key] = payload.params[0][key]
             }
         })
         payload.params[0] = tx

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -811,11 +811,11 @@ const transformSignaturesToObject = signatures => {
             sigObj.S = decoded[2]
         } else if (_.isObject(sig)) {
             Object.keys(sig).map(key => {
-                if (key === 'v' || key === 'V') {
+                if (key === 'v' || key === 'V' || key === '_v') {
                     sigObj.V = sig[key]
-                } else if (key === 'r' || key === 'R') {
+                } else if (key === 'r' || key === 'R' || key === '_r') {
                     sigObj.R = sig[key]
-                } else if (key === 's' || key === 'S') {
+                } else if (key === 's' || key === 'S' || key === '_s') {
                     sigObj.S = sig[key]
                 } else {
                     throw new Error(`Failed to transform signatures to object: invalid key(${key}) is defined in signature object.`)

--- a/test/packages/caver.rpc.js
+++ b/test/packages/caver.rpc.js
@@ -372,7 +372,9 @@ describe('caver.rpc.klay', () => {
 
             const result = await caver.rpc.klay.signTransaction(feeDelegated)
             const signed = await feeDelegated.sign(keyringToImport)
-            expect(result.tx.signatures[0].toString()).to.equal(caver.utils.transformSignaturesToObject(signed.signatures).toString())
+            expect(caver.utils.makeEven(result.tx.signatures[0].V)).to.equal(signed.signatures[0].v)
+            expect(caver.utils.makeEven(result.tx.signatures[0].R)).to.equal(signed.signatures[0].r)
+            expect(caver.utils.makeEven(result.tx.signatures[0].S)).to.equal(signed.signatures[0].s)
         }).timeout(100000)
     })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces some modification related with SignatureData.

- Modified `caver.utils. transformSignaturesToObject` function to handle SignatureData.
- Before sending transaction object to Klaytn network, define signature or feePayerSignature only when those are not empty sig.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
