### PR TITLE
Added sendTransactionAsFeePayer for polling receipt

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -457,6 +457,7 @@ function buildCall() {
     const method = this
     const isSendTx =
         method.call === 'klay_sendTransaction' ||
+        method.call === 'klay_sendTransactionAsFeePayer' ||
         method.call === 'klay_sendRawTransaction' ||
         method.call === 'personal_sendTransaction' ||
         method.call === 'personal_sendValueTransfer' ||


### PR DESCRIPTION
## Proposed changes

This PR introduces adding `sendTransactionAsFeePayer` RPC call name to buildCall function in Method. 
To determine `sendTransactionAsFeePayer` RPC call is send transaciton to the network and continue to get receipt after sending.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
