### PR TITLE
Changed the rpc call name

### DIFF
--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -372,7 +372,7 @@ class KlayRPC {
                 params: 0,
             }),
             new Method({
-                name: 'gasPriceAt',
+                name: 'getGasPriceAt',
                 call: 'klay_gasPriceAt',
                 params: 1,
                 inputFormatter: [formatters.inputDefaultBlockNumberFormatter],


### PR DESCRIPTION
## Proposed changes

This PR introduces changing gasPriceAt RPC call name to getGasPriceAt to follow name policy.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
