### PR TITLE
Fixed few bug with transaction handling with node account

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -89,7 +89,7 @@ const _txInputFormatter = function(options) {
         }
     }
 
-    if (options.data && options.input) {
+    if (options.data && options.input && !options.type.includes('TxType')) {
         throw new Error(
             'You can\'t have "data" and "input" as properties of transactions at the same time, please use either "data" or "input" instead.'
         )
@@ -182,7 +182,8 @@ const inputTransactionFormatter = function(options) {
     }
 
     // Set typeInt value in object
-    options.typeInt = getTypeInt(options.type)
+    const typeInt = getTypeInt(options.type)
+    if (typeInt !== '') options.typeInt = typeInt
 
     return options
 }

--- a/packages/caver-core-helpers/src/validateFunction.js
+++ b/packages/caver-core-helpers/src/validateFunction.js
@@ -559,7 +559,7 @@ function checkDeployEssential(transaction) {
         return new Error('"value" is missing')
     }
 
-    if (transaction.input !== undefined && transaction.data !== undefined) {
+    if (transaction.input !== undefined && transaction.data !== undefined && !transaction.type.includes('TxType')) {
         return new Error(`"data" and "input" cannot be used as properties of transactions at the same time.`)
     }
     if (transaction.input === undefined && transaction.data === undefined) {

--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -423,7 +423,11 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                         console.warn(`When sign/send a transaction using the Node API, existing 'feePayerSignatures' can be initialized.`)
                     }
                 }
-            } else {
+            } else if (key === 'codeFormat') {
+                tx[key] = utils.hexToNumber(payload.params[0][key])
+            } else if (key === 'account') {
+                tx.key = payload.params[0][key].getRLPEncodingAccountKey()
+            } else if (payload.params[0][key] !== '0x') {
                 tx[key] = payload.params[0][key]
             }
         })


### PR DESCRIPTION
## Proposed changes

This PR introduces fixing some bug related with sending transaction to Klaytn Node.

- Not set typeInt when TxTypeLegacyTransaction

- New transaction types which defines `input` as a member variable, also defines getter for `data`. So when validate for duplicated `data` and `input`, check the transaction type string

- Format `codeFormat` to number before sending to Klaytn Node.
- Encode accountKey to `key` before sending to Klaytn Node.
- If address is empty ('0x'), don't include to object which will be sent to Klaytn Node.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer #249 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
