### PR TITLE
Update scrypt library

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "oboe": "2.1.3",
     "request": "2.87.0",
     "requestretry": "^2.0.2",
+    "scrypt-js": "^3.0.1",
     "semver": "6.2.0",
     "utf8": "2.1.1",
     "uuid": "^3.0.0",

--- a/packages/caver-klay/caver-klay-accounts/src/index.js
+++ b/packages/caver-klay/caver-klay-accounts/src/index.js
@@ -35,7 +35,7 @@ const Bytes = require('eth-lib/lib/bytes')
 const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto')
 const uuid = require('uuid')
 const elliptic = require('elliptic')
-const scrypt = require('@web3-js/scrypt-shim')
+const scrypt = require('scrypt-js')
 const utils = require('../../../caver-utils')
 const helpers = require('../../../caver-core-helpers')
 
@@ -246,7 +246,7 @@ function encryptKey(privateKey, password, options) {
             kdfparams.n = options.n || 4096 // 2048 4096 8192 16384
             kdfparams.r = options.r || 8
             kdfparams.p = options.p || 1
-            derivedKey = scrypt(
+            derivedKey = scrypt.syncScrypt(
                 Buffer.from(password),
                 Buffer.from(kdfparams.salt, 'hex'),
                 kdfparams.n,
@@ -1445,7 +1445,7 @@ Accounts.prototype.decrypt = function(v3Keystore, password, nonStrict) {
                 kdfparams = encrypted.kdfparams
 
                 // FIXME: support progress reporting callback
-                derivedKey = scrypt(
+                derivedKey = scrypt.syncScrypt(
                     Buffer.from(password),
                     Buffer.from(kdfparams.salt, 'hex'),
                     kdfparams.n,

--- a/packages/caver-wallet/src/keyring/keyringHelper.js
+++ b/packages/caver-wallet/src/keyring/keyringHelper.js
@@ -17,7 +17,7 @@
 */
 
 const _ = require('lodash')
-const scrypt = require('@web3-js/scrypt-shim')
+const scrypt = require('scrypt-js')
 const uuid = require('uuid')
 const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto')
 const utils = require('../../../caver-utils')
@@ -80,7 +80,7 @@ const decryptKey = (encryptedArray, password) => {
             kdfparams = encrypted.kdfparams
 
             // FIXME: support progress reporting callback
-            derivedKey = scrypt(
+            derivedKey = scrypt.syncScrypt(
                 Buffer.from(password),
                 Buffer.from(kdfparams.salt, 'hex'),
                 kdfparams.n,
@@ -145,7 +145,7 @@ const encryptKey = (privateKey, password, options) => {
             kdfparams.n = options.n || 4096 // 2048 4096 8192 16384
             kdfparams.r = options.r || 8
             kdfparams.p = options.p || 1
-            derivedKey = scrypt(
+            derivedKey = scrypt.syncScrypt(
                 Buffer.from(password),
                 Buffer.from(kdfparams.salt, 'hex'),
                 kdfparams.n,


### PR DESCRIPTION
## Proposed changes

Update scrypt library from `@web3-js/scrypt-shim` to `scrypt-js`, becuase `@web3-js/scrypt-shim` is deprecated.

@web3-js/scrypt-shim => https://www.npmjs.com/package/@web3-js/scrypt-shim
scrypt-js => https://www.npmjs.com/package/scrypt-js

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
