### PR TITLE
Defined defaultSendOptions in contract

### DIFF
--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -91,6 +91,12 @@ const Contract = function Contract(jsonInterface, address, options) {
         }
     }
 
+    Object.defineProperty(this, 'defaultSendOptions', {
+        get() {
+            return _this.options
+        },
+    })
+
     // set address
     Object.defineProperty(this.options, 'address', {
         set(value) {


### PR DESCRIPTION
## Proposed changes

This PR is about the properties added to the contract.
Add a property called `defaultSendOptions` to access contract.options. (Changed to follow common architecture)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
