### PR TITLE
Unified error message for abstract methods

### DIFF
--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -141,6 +141,27 @@ class AbstractTransaction {
     }
 
     /**
+     * Returns the RLP-encoded string of this transaction (i.e., rawTransaction).
+     * This method has to be overrided in classes which extends AbstractTransaction.
+     *
+     * @return {string}
+     */
+    getRLPEncoding() {
+        throw new Error(`Not implemented.`)
+    }
+
+    /**
+     * Returns the RLP-encoded string to make the signature of this transaction.
+     * This method has to be overrided in classes which extends AbstractTransaction.
+     * getCommonRLPEncodingForSignature is used in getRLPEncodingForSignature.
+     *
+     * @return {string}
+     */
+    getCommonRLPEncodingForSignature() {
+        throw new Error(`Not implemented.`)
+    }
+
+    /**
      * Signs to the transaction with private key(s) in the `key`.
      * @async
      * @param {Keyring|string} key - The instance of Keyring, private key string or KlaytnWalletKey string.
@@ -286,18 +307,6 @@ class AbstractTransaction {
             throw new Error(`chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`)
 
         return RLP.encode([this.getCommonRLPEncodingForSignature(), Bytes.fromNat(this.chainId), '0x', '0x'])
-    }
-
-    /**
-     * Returns the RLP-encoded string to make the signature of this transaction.
-     * This method has to be overrided in classes which extends AbstractTransaction.
-     * getCommonRLPEncodingForSignature is used in getRLPEncodingForSignature.
-     *
-     * @return {string}
-     */
-    // eslint-disable-next-line class-methods-use-this
-    getCommonRLPEncodingForSignature() {
-        throw new Error('getCommonRLPEncodingForSignature has to be implemented')
     }
 
     /**

--- a/packages/caver-wallet/src/keyring/abstractKeyring.js
+++ b/packages/caver-wallet/src/keyring/abstractKeyring.js
@@ -47,12 +47,52 @@ class AbstractKeyring {
     }
 
     /**
+     * signs with transactionHash with a key and returns signature(s).
+     * This method has to be overrided in classes which extends AbstractKeyring.
+     *
+     * @return {Array.<string>|Array.<Array.<string>>}
+     */
+    sign(transactionHash, chainId, role, index) {
+        throw new Error(`Not implemented.`)
+    }
+
+    /**
+     * signs with hashed message and returns result object that includes `signatures`, `message` and `messageHash`.
+     * This method has to be overrided in classes which extends AbstractKeyring.
+     *
+     * @return {object}
+     */
+    signMessage(message, role, index) {
+        throw new Error(`Not implemented.`)
+    }
+
+    /**
+     * encrypts a keyring and returns a keystore v4 object.
+     * This method has to be overrided in classes which extends AbstractKeyring.
+     *
+     * @return {object}
+     */
+    encrypt(password, options = {}) {
+        throw new Error(`Not implemented.`)
+    }
+
+    /**
+     * returns a copied singleKeyring instance.
+     * This method has to be overrided in classes which extends AbstractKeyring.
+     *
+     * @return {AbstractKeyring}
+     */
+    copy() {
+        throw new Error(`Not implemented.`)
+    }
+
+    /**
      * returns KlaytnWalletKey format. If keyring uses more than one private key, this function will throw error.
      *
      * @return {string}
      */
     getKlaytnWalletKey() {
-        throw new Error(`The keyring cannot be exported in KlaytnWalletKey format. Use keyring.encrypt.`)
+        throw new Error(`Not supported for this class.`)
     }
 
     /**
@@ -63,7 +103,7 @@ class AbstractKeyring {
      * @return {object}
      */
     encryptV3(password, options) {
-        throw new Error(`This keyring cannot be encrypted keystore v3. use 'keyring.encrypt(password)'.`)
+        throw new Error(`Not supported for this class. Use 'keyring.encrypt(password)'.`)
     }
 
     /**

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -1414,7 +1414,7 @@ describe('keyring.getKlaytnWalletKey', () => {
 
     context('CAVERJS-UNIT-KEYRING-110: keyring type: multiSig', () => {
         it('should throw error when keyring has multiple keys', () => {
-            const expectedError = `The keyring cannot be exported in KlaytnWalletKey format. Use keyring.encrypt.`
+            const expectedError = `Not supported for this class.`
 
             expect(() => multiSig.getKlaytnWalletKey()).to.throw(expectedError)
         })
@@ -1422,7 +1422,7 @@ describe('keyring.getKlaytnWalletKey', () => {
 
     context('CAVERJS-UNIT-KEYRING-111: keyring type: roleBased', () => {
         it('should throw error when keyring has multiple keys', () => {
-            const expectedError = `The keyring cannot be exported in KlaytnWalletKey format. Use keyring.encrypt.`
+            const expectedError = `Not supported for this class.`
 
             expect(() => roleBased.getKlaytnWalletKey()).to.throw(expectedError)
         })
@@ -1686,7 +1686,7 @@ describe('keyring.encryptV3', () => {
     context('CAVERJS-UNIT-KEYRING-135: keyring type: multiSig, input: password', () => {
         it('should throw error when keyring use multiple private key', () => {
             const password = 'password'
-            const expectedError = `This keyring cannot be encrypted keystore v3. use 'keyring.encrypt(password)'.`
+            const expectedError = `Not supported for this class. Use 'keyring.encrypt(password)'.`
             expect(() => multiSig.encryptV3(password)).to.throw(expectedError)
         })
     })
@@ -1694,7 +1694,7 @@ describe('keyring.encryptV3', () => {
     context('CAVERJS-UNIT-KEYRING-136: keyring type: roleBased, input: password', () => {
         it('should throw error when keyring use different private keys by roles', () => {
             const password = 'password'
-            const expectedError = `This keyring cannot be encrypted keystore v3. use 'keyring.encrypt(password)'.`
+            const expectedError = `Not supported for this class. Use 'keyring.encrypt(password)'.`
             expect(() => roleBased.encryptV3(password)).to.throw(expectedError)
         })
     })


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of error handling for abstract methods.
For this, abstract methods are defined in abstract classes to throw error.

- Defined as an abstract method, but if it is not implemented, "Not implemented"
- "Not supported for this class" when implemented to throw exception to abstract class as default because it is supported only in specific class

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
