### PR TITLE
Modified isValidPublicKey function to handle 04 uncompressed prefixed public key

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -851,6 +851,8 @@ const getTxTypeStringFromRawTransaction = rawTransaction => {
 const isValidPublicKey = publicKey => {
     let pubString = publicKey.replace('0x', '')
 
+    if (pubString.length === 130 && pubString.slice(0, 2) === '04') pubString = pubString.slice(2)
+
     if (pubString.length !== 66 && pubString.length !== 128) return false
 
     if (pubString.length === 66 && !isCompressedPublicKey(pubString)) return false

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -1260,6 +1260,14 @@ describe('caver.utils.isValidPublicKey', () => {
         const isValid = caver.utils.isValidPublicKey(pub)
         expect(isValid).to.be.false
     })
+
+    it('CAVERJS-UNIT-ETC-253: caver.utils.isValidPublicKey should true with 04 uncompressed prefixed public key string', () => {
+        const pub =
+            '0x04019b186993b620455077b6bc37bf61666725d8d87ab33eb113ac0414cd48d78ff46e5ea48c6f22e8f19a77e5dbba9d209df60cbcb841b7e3e81fe444ba829831'
+
+        const isValid = caver.utils.isValidPublicKey(pub)
+        expect(isValid).to.be.true
+    })
 })
 
 describe('caver.utils.isValidRole', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces handling logic for 04-prefixed public key string in caver.utils.isValidPublicKey function.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
