### PR TITLE
Handling resonse error with statusText when reponseText is empty

### DIFF
--- a/packages/caver-core-helpers/src/errors.js
+++ b/packages/caver-core-helpers/src/errors.js
@@ -63,6 +63,7 @@ const txErrorTable = {
 
 module.exports = {
     InvalidConnection: host => new Error(`CONNECTION ERROR: Couldn't connect to node ${host}.`),
+    RequestFailed: err => new Error(`Request failed: ${err}`),
     ConnectionTimeout: ms => new Error(`CONNECTION TIMEOUT: timeout of ${ms}ms achived`),
     ConnectionNotOpenError: event => {
         const error = new Error('connection not open on send()')

--- a/packages/caver-core-requestmanager/caver-providers-http/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-http/src/index.js
@@ -106,8 +106,12 @@ HttpProvider.prototype.send = function(payload, callback) {
                 try {
                     result = JSON.parse(result)
                 } catch (e) {
-                    console.error(`Invalid JSON RPC response: ${JSON.stringify(request.responseText)}`)
-                    error = errors.InvalidResponse(request.responseText)
+                    if (request.responseText === '') {
+                        error = errors.RequestFailed(request.statusText)
+                    } else {
+                        console.error(`Invalid JSON RPC response: ${JSON.stringify(request.responseText)}`)
+                        error = errors.InvalidResponse(request.responseText)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

This PR introduces adding error handling logic with statusText when responseText is ''.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
