### PR TITLE
Modified to throw error in deploy function

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "caver-js is a JavaScript API library that allows developers to interact with a Klaytn node",
   "main": "index.js",
   "scripts": {
-    "test": "npm run build && npm run transactionTest && mocha test/packages/caver.utils.js && mocha test/packages/caver.klay.net.js && npm run accountTest && npm run serTest && npm run walletTest",
+    "test": "npm run build && npm run transactionTest && mocha test/packages/caver.utils.js && mocha test/packages/caver.klay.net.js && npm run accountTest && npm run serTest && npm run walletTest && mocha test/contractError.js",
     "build-all": "gulp all",
     "build": "./node_modules/.bin/webpack --mode production",
     "lint": "./node_modules/.bin/eslint './**/*.js'",
@@ -15,7 +15,7 @@
     "rpcTest": "mocha test/packages/caver.rpc.js",
     "transactionTest": "mocha test/packages/caver.transaction/*.js",
     "txTest": "mocha test/methodErrorHandling.js && mocha test/sendSignedTransaction.js && mocha test/estimateComputationCost.js && mocha test/getTransactionReceipt.js && mocha test/setNonceWithPendingTag.js && mocha test/getTransaction.js && mocha test/setContractOptions.js && mocha test/encodeContractDeploy.js && mocha test/accounts.signTransaction.js && mocha test/sendTransactionCallback.js && mocha test/signWithMultiSig.js && mocha test/transactionType/legacyTransaction.js && mocha test/transactionType/valueTransfer* && mocha test/transactionType/accountUpdate.js && mocha test/transactionType/contract* && mocha test/transactionType/cancelTransaction.js && mocha test/transactionType/feeDelegated*",
-    "etcTest": "mocha test/reconnectTest.js && mocha test/packages/caver.utils.js && mocha test/confirmationListener.js && mocha test/hashMessage.js && mocha test/iban.* && mocha test/randomHex.js && mocha test/sha3.js && mocha test/toChecksumAddress.js && mocha test/unitMap.js && mocha test/default* && mocha test/getNodeInfo.js && mocha test/eventEmitter.js && mocha test/packages/caver.klay.net.js && mocha test/getNetworkType.js && mocha test/invalidResponse.js && mocha test/isContractDeployment.js && mocha test/personal.js && mocha test/multiProviderTest.js && mocha test/subscription.js && mocha test/supportsSubscriptions.js && mocha test/contract.once.js && mocha test/setProvider.js",
+    "etcTest": "mocha test/contractError.js && mocha test/reconnectTest.js && mocha test/packages/caver.utils.js && mocha test/confirmationListener.js && mocha test/hashMessage.js && mocha test/iban.* && mocha test/randomHex.js && mocha test/sha3.js && mocha test/toChecksumAddress.js && mocha test/unitMap.js && mocha test/default* && mocha test/getNodeInfo.js && mocha test/eventEmitter.js && mocha test/packages/caver.klay.net.js && mocha test/getNetworkType.js && mocha test/invalidResponse.js && mocha test/isContractDeployment.js && mocha test/personal.js && mocha test/multiProviderTest.js && mocha test/subscription.js && mocha test/supportsSubscriptions.js && mocha test/contract.once.js && mocha test/setProvider.js",
     "accountKeyTest": "mocha test/scenarioTest/accountKeyPublic.js && mocha test/scenarioTest/accountKeyMultiSig.js && mocha test/scenarioTest/accountKeyRoleBased.js",
     "kctTest": "mocha test/packages/caver.klay.KIP7.js && mocha test/packages/caver.klay.KIP17.js",
     "intTxTest": "npm run intLEGACYTest && npm run intVTTest && npm run intVTMTest && npm run intACCUPTest && npm run intDEPLTest && npm run intEXETest && npm run intCANCELTest && npm run intFDTest && npm run intFDRTest",

--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -601,12 +601,10 @@ Contract.prototype.deploy = function(options, callback) {
 
     // return error, if no "data" is specified
     if (!options.data) {
-        return utils._fireError(
-            new Error('No "data" specified in neither the given options, nor the default options.'),
-            null,
-            null,
-            callback
-        )
+        const error = new Error('No "data" specified in neither the given options, nor the default options.')
+        if (callback) callback(error)
+
+        throw error
     }
 
     const constructor =

--- a/test/contractError.js
+++ b/test/contractError.js
@@ -1,0 +1,109 @@
+/*
+    Copyright 2020 The caver-js Authors
+    This file is part of the caver-js library.
+
+    The caver-js library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The caver-js library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const { expect } = require('./extendedChai')
+
+const testRPCURL = require('./testrpc')
+
+const Caver = require('../index.js')
+
+let caver
+
+const abi = [
+    {
+        constant: true,
+        inputs: [],
+        name: 'count',
+        outputs: [
+            {
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'getBlockNumber',
+        outputs: [
+            {
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'addr',
+        outputs: [
+            {
+                name: '',
+                type: 'address',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_str',
+                type: 'bytes32',
+            },
+        ],
+        name: 'setAddress',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_count',
+                type: 'uint256',
+            },
+        ],
+        name: 'setCount',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+]
+
+describe('caver.contract error handling', () => {
+    before(() => {
+        caver = new Caver(testRPCURL)
+    })
+
+    it('CAVERJS-UNIT-ETC-254: contract.deploy throw error when data is not defined', async () => {
+        const contract = new caver.contract(abi)
+        expect(() => contract.deploy()).to.throw('No "data" specified in neither the given options, nor the default options.')
+    }).timeout(200000)
+})


### PR DESCRIPTION
## Proposed changes

This PR introduces modification error handling logic in `contract.deploy`

The existing contract deploy function calls the `utils._fireError` function and returns the result when the `data` field where the byteCode is defined is not defined.

`utils._fireError` is useful to handle errors using `EventEmitte`r or `callback` with asynchronous functions.
However, since the `deploy` function is a synchronous function and both eventEmitter and reject are passed as null when calling `utils._fireError`, the error handling logic does not actually work.

So, if the `callback` is not defined, error handling is not possible, so change the logic to throw an error without using utils._fireError in the deploy function of the contract.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
