### PR TITLE
Added ArrayBuffer to add function in IPFS

### DIFF
--- a/packages/caver-ipfs/src/index.js
+++ b/packages/caver-ipfs/src/index.js
@@ -55,15 +55,25 @@ class IPFS {
     /**
      * adds a file to IPFS
      *
-     * @param {string|Buffer} data The file path string or file contents.
+     * @param {string|Buffer|ArrayBuffer} data The file path string or file contents.
      * @return {string}
      */
     async add(data) {
         if (!this.ipfs) throw new Error(`Please set IPFS Node through 'caver.ipfs.setIPFSNode'.`)
 
         // Read file
-        if (lodash.isString(data)) data = fs.readFileSync(data)
-        if (!lodash.isBuffer(data)) throw new Error(`Invalid data: ${data}`)
+        if (lodash.isString(data) && fs && Object.keys(fs).length > 0) data = fs.readFileSync(data)
+        if (lodash.isArrayBuffer(data)) {
+            const buffer = Buffer.alloc(data.byteLength)
+            const view = new Uint8Array(data)
+            for (let i = 0; i < buffer.length; ++i) {
+                buffer[i] = view[i]
+            }
+            data = buffer
+        } else if (!lodash.isBuffer(data))
+            throw new Error(
+                `Invalid data: In order to upload file contents to IPFS, Buffer or ArrayBuffer must be passed as a parameter. ${data}`
+            )
 
         const ret = await this.ipfs.add(data)
         return ret[0].hash


### PR DESCRIPTION
## Proposed changes

This PR introduces adding ArrayBuffer parameter in `caver.ipfs.add` function.
The existing logic does not work properly because `lodash.isBuffer` is returned `false` in the case of ArrayBuffer.
Added logic to handle the case of receiving ArrayBuffer as a parameter.

In the case of a String, fs is used to read the file only if fs is available.
Therefore, if fs cannot be used, file contents must be uploaded, and an error message has been specified.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
