### PR TITLE
Closed websocket connection without timeout to continue test code

### DIFF
--- a/test/reconnectTest.js
+++ b/test/reconnectTest.js
@@ -46,16 +46,13 @@ describe('websocket reconnect', () => {
         }, 90000)
     }).timeout(150000)
 
-    it('CAVERJS-UNIT-ETC-252: if user defined reconnect option, reconnect the connection when connection is removed from remote peer', done => {
+    it('CAVERJS-UNIT-ETC-252: if user defined reconnect option, reconnect the connection when connection is removed from remote peer', () => {
         const ws = new Caver.providers.WebsocketProvider(websocketURL, { reconnect: { auto: true } })
         const caver = new Caver(ws)
-        const reconnectSpy = sandbox.spy(caver.currentProvider, 'reconnect')
+        const reconnectStub = sandbox.stub(caver.currentProvider, 'reconnect')
         expect(caver.currentProvider.reconnectOptions.auto).to.be.true
 
-        setTimeout(() => {
-            expect(reconnectSpy).to.have.been.called
-            caver.currentProvider.connection.close()
-            done()
-        }, 90000)
-    }).timeout(150000)
+        caver.currentProvider.connection.close()
+        expect(reconnectStub).to.have.been.called
+    }).timeout(15000)
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces modification websocket reconnect test.

Changed the test to artificially close the connection in the test to check whether reconnect is performed at the close event in order not to depend on the setting value of the Node being connected.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
