### PR TITLE
Added connected event emitter with subscription

### DIFF
--- a/packages/caver-core-subscriptions/src/subscription.js
+++ b/packages/caver-core-subscriptions/src/subscription.js
@@ -257,6 +257,7 @@ Subscription.prototype.subscribe = function() {
     this.options.requestManager.send(payload, function(err, result) {
         if (!err && result) {
             _this.id = result
+            _this.emit('connected', result)
 
             // call callback on notifications
             _this.options.requestManager.addSubscription(_this.id, payload.params[0], _this.options.type, function(error, ret) {

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -82,7 +82,18 @@ describe('get transaction', () => {
         expect(receipt.type).not.to.undefined
         expect(receipt.typeInt).not.to.undefined
         expect(receipt.value).not.to.undefined
-
-        caver.currentProvider.connection.close()
     }).timeout(10000)
+})
+
+describe('Subscribe test throught contract event', () => {
+    it('CAVERJS-UNIT-ETC-262: should emit subscription id when subscription is created', done => {
+        caver.wallet.add(caver.wallet.keyring.createFromPrivateKey(senderPrvKey)).address
+        caver.kct.kip17.deploy({ name: 'Jasmine', symbol: 'JAS' }, senderAddress).then(deployed => {
+            deployed.events.MinterAdded({}).on('connected', subscriptionId => {
+                expect(subscriptionId).not.to.be.undefined
+                caver.currentProvider.connection.close()
+                done()
+            })
+        })
+    }).timeout(30000)
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces `'connected'` event emitter which returns `subscriptionId` when subscription is successfully connected.

Refer to https://github.com/ChainSafe/web3.js/commit/cf9613369754443b57851b652028ebffd95aec57

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-js/issues/417

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
