### PR TITLE
Update output name to make dundle in correct path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ module.exports = {
     entry: './webpack.js',
     output: {
         filename: 'caver.min.js',
+        path: `${__dirname}/dist`,
     },
     node: {
         fs: 'empty',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     entry: './webpack.js',
     output: {
-        filename: 'dist/caver.min.js',
+        filename: 'caver.min.js',
     },
     node: {
         fs: 'empty',


### PR DESCRIPTION
## Proposed changes

This PR introduces remove `dist/` in filename.
So before fixing `dist/dist/caver.min.js` was created with `npm run build`.
Now `dist/caver.min.js` was created with `npm run build`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
