### PR TITLE
Returned raw uri string without replacement

### DIFF
--- a/packages/caver-kct/src/kip37.js
+++ b/packages/caver-kct/src/kip37.js
@@ -158,22 +158,13 @@ class KIP37 extends Contract {
 
     /**
      * uri returns distinct Uniform Resource Identifier (URI) for a given token.
-     * If the string {id} exists in any URI, this function will replace this with the actual token ID in hexadecimal form.
-     * Please refer to http://kips.klaytn.com/KIPs/kip-37#metadata
      *
      * @method uri
      * @param {BigNumber|string|number} id The token id to get uri.
      * @return {string}
      */
     async uri(id) {
-        let uri = await this.methods.uri(formatParamForUint256(id)).call()
-
-        // Replace {id} to token id in hexadecimal form.
-        if (uri.includes('{id}')) {
-            let tokenIdInHex = stripHexPrefix(toHex(id))
-            tokenIdInHex = leftPad(tokenIdInHex, 64, '0')
-            uri = uri.replace('{id}', tokenIdInHex)
-        }
+        const uri = await this.methods.uri(formatParamForUint256(id)).call()
         return uri
     }
 

--- a/packages/caver-kct/src/kip37.js
+++ b/packages/caver-kct/src/kip37.js
@@ -28,7 +28,7 @@ const {
     validateDeployParameterForKIP37,
     interfaceIds,
 } = require('./kctHelper')
-const { isAddress, toBuffer, isHexStrict, toHex, stripHexPrefix, leftPad } = require('../../caver-utils')
+const { isAddress, toBuffer, isHexStrict, toHex } = require('../../caver-utils')
 const KIP13 = require('../src/kip13')
 
 class KIP37 extends Contract {

--- a/test/packages/caver.kct.kip37.js
+++ b/test/packages/caver.kct.kip37.js
@@ -226,18 +226,14 @@ describe('KIP37 token contract class test', () => {
 
             const uri = await token.uri(tokenId)
 
-            expect(uri).to.equal('https://game.example/item-id/0000000000000000000000000000000000000000000000000000000000000000.json')
+            expect(uri).to.equal('https://game.example/item-id/{id}.json')
         }).timeout(200000)
 
         it('CAVERJS-UNIT-KCT-167: should return the uri of the specific token with various tokenId types', async () => {
             const token = new caver.kct.kip37(kip37Address)
 
-            expect(await token.uri(caver.utils.toHex(tokenId))).to.equal(
-                'https://game.example/item-id/0000000000000000000000000000000000000000000000000000000000000000.json'
-            )
-            expect(await token.uri(new BigNumber(tokenId))).to.equal(
-                'https://game.example/item-id/0000000000000000000000000000000000000000000000000000000000000000.json'
-            )
+            expect(await token.uri(caver.utils.toHex(tokenId))).to.equal('https://game.example/item-id/{id}.json')
+            expect(await token.uri(new BigNumber(tokenId))).to.equal('https://game.example/item-id/{id}.json')
         }).timeout(200000)
     })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces remove replacement `{id}` string to hex token id in uri function.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
