### PR TITLE
Update to latest version of multihases

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ipfs-http-client-lite": "^0.3.0",
     "it-each": "^0.4.0",
     "lodash": "^4.17.15",
-    "multihashes": "^3.0.1",
+    "multihashes": "^4.0.2",
     "node-fetch": "^2.2.0",
     "number-to-bn": "1.7.0",
     "oboe": "2.1.3",


### PR DESCRIPTION
## Proposed changes

This PR introduce update multihases library version to latest version to fix "TextDecoder is not a constructor" error when `import Caver from 'caver-js'` in react.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
