### PR TITLE
Use ipfs-http-client library

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ethers": "^5.0.32",
     "ethjs-unit": "0.1.6",
     "eventemitter3": "4.0.0",
-    "ipfs-http-client-lite": "^0.3.0",
+    "ipfs-http-client": "^49.0.4",
     "it-each": "^0.4.0",
     "lodash": "^4.17.15",
     "mocha": "^8.3.2",

--- a/packages/caver-ipfs/src/index.js
+++ b/packages/caver-ipfs/src/index.js
@@ -115,7 +115,7 @@ class IPFS {
     async get(hash) {
         if (!this.ipfs) throw new Error(`Please set IPFS Node through 'caver.ipfs.setIPFSNode'.`)
         const ret = await this.ipfs.cat(hash)
-        
+
         let content = Buffer.from('')
 
         for await (const chunk of ret) {


### PR DESCRIPTION
## Proposed changes

This PR introduces use `ipfs-http-client` library instead of `ipfs-http-client-lite`.

`ipfs-http-client` is a well maintained project.
However, I chose `ipfs-http-client-lite` as the next best solution, which was not well maintained because `ipfs-http-client` do not support Node v10.

However, when the https://github.com/klaytn/caver-js/pull/445 PR is merged, it is supported from Node v12, so change to use the `ipfs-http-client` library. (Re-base required)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
