### PR TITLE
Added await to wait error handling with Promise

### DIFF
--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -1220,7 +1220,7 @@ Contract.prototype._executeMethod = async function _executeMethod() {
 
         case 'sign':
         case 'signAsFeePayer':
-            const tx = createTransactionFromArgs(args, this._method, this._deployData, defer)
+            const tx = await createTransactionFromArgs(args, this._method, this._deployData, defer)
 
             if (!wallet) {
                 return utils._fireError(
@@ -1246,7 +1246,7 @@ Contract.prototype._executeMethod = async function _executeMethod() {
             })
 
         case 'send':
-            const transaction = createTransactionFromArgs(args, this._method, this._deployData, defer)
+            const transaction = await createTransactionFromArgs(args, this._method, this._deployData, defer)
             // make sure receipt logs are decoded
             const extraFormatters = {
                 receiptFormatter(receipt) {

--- a/test/packages/caver.contract.js
+++ b/test/packages/caver.contract.js
@@ -2219,6 +2219,47 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
                 const value = await contract.methods.get(newKey).call({ from: sender.address })
                 expect(value).to.equal(newValue)
             }).timeout(200000)
+
+            it(`CAVERJS-UNIT-ETC-365: contract.signAsFeePayer({ from, feeRatio, ... }, functionName, arguments) will throw error when feeDelegation is undefined`, async () => {
+                const contract = new caver.contract(abiWithoutConstructor, '0x1da61ed1c876206ff1aafdeb39717da7f078040b')
+
+                const newKey = 'contract sign func'
+                const newValue = 'should return signed tx'
+
+                const expectedError = `feeDelegation field should be defined as 'true' to sign as a fee payer`
+                await expect(contract.signAsFeePayer(
+                    {
+                        from: sender.address,
+                        feePayer: feePayer.address,
+                        feeRatio: 30,
+                        gas: 1000000,
+                    },
+                    'set',
+                    newKey,
+                    newValue
+                )).to.be.rejectedWith(expectedError)
+            }).timeout(200000)
+
+            it(`CAVERJS-UNIT-ETC-366: contract.signAsFeePayer({ from, feeRatio, ... }, functionName, arguments) will throw error when feeDelegation is false`, async () => {
+                const contract = new caver.contract(abiWithoutConstructor, '0x1da61ed1c876206ff1aafdeb39717da7f078040b')
+
+                const newKey = 'contract sign func'
+                const newValue = 'should return signed tx'
+
+                const expectedError = `feeDelegation field should be defined as 'true' to sign as a fee payer`
+                await expect(contract.signAsFeePayer(
+                    {
+                        from: sender.address,
+                        feePayer: feePayer.address,
+                        feeDelegation: false,
+                        feeRatio: 30,
+                        gas: 1000000,
+                    },
+                    'set',
+                    newKey,
+                    newValue
+                )).to.be.rejectedWith(expectedError)
+            }).timeout(200000)
         }
     )
 

--- a/test/packages/caver.contract.js
+++ b/test/packages/caver.contract.js
@@ -2227,17 +2227,19 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
                 const newValue = 'should return signed tx'
 
                 const expectedError = `feeDelegation field should be defined as 'true' to sign as a fee payer`
-                await expect(contract.signAsFeePayer(
-                    {
-                        from: sender.address,
-                        feePayer: feePayer.address,
-                        feeRatio: 30,
-                        gas: 1000000,
-                    },
-                    'set',
-                    newKey,
-                    newValue
-                )).to.be.rejectedWith(expectedError)
+                await expect(
+                    contract.signAsFeePayer(
+                        {
+                            from: sender.address,
+                            feePayer: feePayer.address,
+                            feeRatio: 30,
+                            gas: 1000000,
+                        },
+                        'set',
+                        newKey,
+                        newValue
+                    )
+                ).to.be.rejectedWith(expectedError)
             }).timeout(200000)
 
             it(`CAVERJS-UNIT-ETC-366: contract.signAsFeePayer({ from, feeRatio, ... }, functionName, arguments) will throw error when feeDelegation is false`, async () => {
@@ -2247,18 +2249,20 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
                 const newValue = 'should return signed tx'
 
                 const expectedError = `feeDelegation field should be defined as 'true' to sign as a fee payer`
-                await expect(contract.signAsFeePayer(
-                    {
-                        from: sender.address,
-                        feePayer: feePayer.address,
-                        feeDelegation: false,
-                        feeRatio: 30,
-                        gas: 1000000,
-                    },
-                    'set',
-                    newKey,
-                    newValue
-                )).to.be.rejectedWith(expectedError)
+                await expect(
+                    contract.signAsFeePayer(
+                        {
+                            from: sender.address,
+                            feePayer: feePayer.address,
+                            feeDelegation: false,
+                            feeRatio: 30,
+                            gas: 1000000,
+                        },
+                        'set',
+                        newKey,
+                        newValue
+                    )
+                ).to.be.rejectedWith(expectedError)
             }).timeout(200000)
         }
     )


### PR DESCRIPTION
## Proposed changes

This PR introduces adding `await` for `createTransactionFromArgs` function to wait error handling with Promise.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
