### PR TITLE
Call redefined constructor to set wallet to instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,9 @@ function Caver(provider, net) {
     }
 
     Contract.create = function() {
-        return BaseContract.create.apply(this, arguments)
+        // With `caver.contract`, `caver.wallet` must be set in the `contarct._wallet`,
+        // so the Contract constructor defined above must be called here.
+        return new Contract(...arguments)
     }
 
     Contract.setProvider = function() {

--- a/test/createTest.js
+++ b/test/createTest.js
@@ -51,6 +51,7 @@ describe('caver.contract', () => {
         ]
         const created = caver.contract.create(abi)
         expect(created.constructor.name).to.equal('Contract')
+        expect(created._wallet).not.to.be.undefined
     })
 })
 
@@ -58,16 +59,19 @@ describe('caver.kct', () => {
     it('CAVERJS-UNIT-KCT-219: caver.kct.kip7.create method creates a KIP7 instance.', () => {
         const created = caver.kct.kip7.create()
         expect(created.constructor.name).to.equal('KIP7')
+        expect(created._wallet).not.to.be.undefined
     })
 
     it('CAVERJS-UNIT-KCT-220: caver.kct.kip17.create method creates a KIP17 instance.', () => {
         const created = caver.kct.kip17.create()
         expect(created.constructor.name).to.equal('KIP17')
+        expect(created._wallet).not.to.be.undefined
     })
 
     it('CAVERJS-UNIT-KCT-221: caver.kct.kip37.create method creates a KIP37 instance.', () => {
         const created = caver.kct.kip37.create()
         expect(created.constructor.name).to.equal('KIP37')
+        expect(created._wallet).not.to.be.undefined
     })
 })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces the contents of calling the overridden constructor when `caver.contract.create` is executed.

When using `caver.contract`, the constructor is redefining to internally allocate `caver.wallet` to `_wallet`.
Therefore, even when calling `caver.contract.create`, `caver.wallet` is internally assigned to `_wallet` by calling the redefined constructor as well.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
