### PR TITLE
Fix stuck and timeout issues when exception happens during testing signWithMultiSig.js

### DIFF
--- a/test/signWithMultiSig.js
+++ b/test/signWithMultiSig.js
@@ -42,7 +42,11 @@ const createMultiSigAccount = async () => {
         gas: 900000,
     }
 
-    await caver.klay.sendTransaction(txObject)
+    try {
+        await caver.klay.sendTransaction(txObject)
+    } catch (error) {
+        throw error
+    }
 
     // account update transaction object
     const accountUpdateObject = {
@@ -59,10 +63,14 @@ const createMultiSigAccount = async () => {
         gas: 900000,
     }
 
-    return caver.klay.sendTransaction(accountUpdateObject)
+    try {
+        await caver.klay.sendTransaction(accountUpdateObject)
+    } catch (error) {
+        throw error
+    }
 }
 
-before(function(done) {
+before(async function () {
     this.timeout(200000)
 
     const senderPrvKey =
@@ -72,7 +80,11 @@ before(function(done) {
 
     sender = caver.klay.accounts.wallet.add(senderPrvKey)
 
-    createMultiSigAccount().then(() => done())
+    try {
+        await createMultiSigAccount()
+    } catch (error) {
+        throw error
+    }
 })
 
 describe('sign transaction with multi sig account key', () => {

--- a/test/signWithMultiSig.js
+++ b/test/signWithMultiSig.js
@@ -70,7 +70,7 @@ const createMultiSigAccount = async () => {
     }
 }
 
-before(async function () {
+before(async function() {
     this.timeout(200000)
 
     const senderPrvKey =


### PR DESCRIPTION
## Proposed changes

This PR fix stuck and timeout issues when testing `test/signWithMultiSig` with account which have KLAY less than 10.

Stuck happens at `await caver.klay.sendTransaction(txObject)` because there is no exception-handling logic when using async/await function.
I created simple example which can simulate similar problem described above. You can checkout below example.
Example: [Without catch exception, it just wait for timed out](https://gist.github.com/aeharvlee/7dd62207c8bc3728204021d3bbf8c20d)

This makes testing `test/signWithMultiSig` consumes maximum timeout.
You can re-produce this stuck issue with `$ privateKey='0x5677c4adaf9b6fd0c8765ccf1fbe9f1804f2ac9761ee3ef714cca631c74139a6' mocha test/signWithMultiSig.js`)
('0x5677c4adaf9b6fd0c8765ccf1fbe9f1804f2ac9761ee3ef714cca631c74139a6' is just a dummy private key, so you can use it freely.)

It should throw exception right away when exception happens instead of waiting for timed out.
Fixing this issue can provide a more comfortable testing experience for `caver-js` users.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
