### PR TITLE
Fix Decoding Legacy Transaction RLP

### DIFF
--- a/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
@@ -32,7 +32,7 @@ function _decode(rlpEncoded) {
         gas: utils.trimLeadingZero(gas),
         to,
         value: utils.trimLeadingZero(value),
-        input: utils.trimLeadingZero(input),
+        input: input,
         signatures: [v, r, s],
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix RLP Decoding bug when parse legacy transaction.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

before this fix. caver-js cannot decode legacy transaction properly that has leading zero method signature. ex: KIP7.approve ( 095ea7b3 )
