### PR TITLE
Added caver.utils.publicKeyToAddress

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -569,4 +569,5 @@ module.exports = {
     hashMessage: utils.hashMessage,
     recover: utils.recover,
     recoverPublicKey: utils.recoverPublicKey,
+    publicKeyToAddress: utils.publicKeyToAddress,
 }

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -1017,6 +1017,32 @@ const recover = (message, signature, isHashed = false) => {
     return Account.recover(message, Account.encodeSignature(signature.encode())).toLowerCase()
 }
 
+/**
+ * Returns an address which is derived by a public key.
+ * This function simply converts the public key string into address form by hashing it.
+ * It has nothing to do with the actual account in the Klaytn.
+ *
+ * @example
+ * const address = caver.utils.publicKeyToAddress('0x{public key}')
+ *
+ * @method publicKeyToAddress The public key string to get the address.
+ * @param {string} publicKey
+ * @return {string}
+ */
+const publicKeyToAddress = publicKey => {
+    publicKey = publicKey.slice(0, 2) === '0x' ? publicKey : `0x${publicKey}`
+
+    if (isCompressedPublicKey(publicKey)) publicKey = decompressPublicKey(publicKey)
+
+    const publicHash = Hash.keccak256(publicKey)
+    const address = `0x${publicHash.slice(-40)}`
+
+    const addressHash = Hash.keccak256s(address.slice(2))
+    let checksumAddress = '0x'
+    for (let i = 0; i < 40; i++) checksumAddress += parseInt(addressHash[i + 2], 16) > 7 ? address[i + 2].toUpperCase() : address[i + 2]
+    return checksumAddress
+}
+
 module.exports = {
     BN: BN,
     isBN: isBN,
@@ -1078,4 +1104,5 @@ module.exports = {
     hashMessage: hashMessage,
     recover: recover,
     recoverPublicKey: recoverPublicKey,
+    publicKeyToAddress: publicKeyToAddress,
 }

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -2065,3 +2065,32 @@ describe('caver.utils.recoverPublicKey', () => {
         expect(result).to.equal(keyring.getPublicKey())
     })
 })
+
+describe('caver.utils.publicKeyToAddress', () => {
+    it('CAVERJS-UNIT-ETC-381: return an address which is derived by public key', () => {
+        const address = '0x5b2840bcbc2be07fb12d9129ed3a02d8e4465944'
+        const publicKey =
+            '0x68ffedd4a1d9fefa38f6ed9d58f0b85741a90ad604ab901c130c1fea42eab666dec186a48ad4db56b14898e8e18fe0176d926a2c1ffeeb6b6df805ec0bf41eb8'
+
+        const result = caver.utils.publicKeyToAddress(publicKey)
+        expect(result.toLowerCase()).to.equal(address)
+    })
+
+    it('CAVERJS-UNIT-ETC-382: return an address which is derived by uncompressed public key', () => {
+        const address = '0x5b2840bcbc2be07fb12d9129ed3a02d8e4465944'
+        const publicKey =
+            '0x68ffedd4a1d9fefa38f6ed9d58f0b85741a90ad604ab901c130c1fea42eab666dec186a48ad4db56b14898e8e18fe0176d926a2c1ffeeb6b6df805ec0bf41eb8'
+
+        const result = caver.utils.publicKeyToAddress(caver.utils.decompressPublicKey(publicKey))
+        expect(result.toLowerCase()).to.equal(address)
+    })
+
+    it('CAVERJS-UNIT-ETC-383: return an address which is derived by compressed public key', () => {
+        const address = '0x5b2840bcbc2be07fb12d9129ed3a02d8e4465944'
+        const publicKey =
+            '0x68ffedd4a1d9fefa38f6ed9d58f0b85741a90ad604ab901c130c1fea42eab666dec186a48ad4db56b14898e8e18fe0176d926a2c1ffeeb6b6df805ec0bf41eb8'
+
+        const result = caver.utils.publicKeyToAddress(caver.utils.compressPublicKey(publicKey))
+        expect(result.toLowerCase()).to.equal(address)
+    })
+})


### PR DESCRIPTION
## Proposed changes

This PR introduce implementation of `caver.utils.publicKeyToAddress` function.
This function will hash the public key parameter to get an address which is derived by the public key.

This function will be used in validation function in next PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
