### PR TITLE
Handled array and object format signature in recover and recoverPublicKey

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -982,13 +982,14 @@ const hashMessage = data => {
  *
  * @method recoverPublicKey
  * @param {string} message The raw message string. If this message is hased with Klaytn specific prefix, the third parameter should be passed as `true`.
- * @param {SignatureData} signature An instance of `SignatureData`.
+ * @param {SignatureData|Array.<string>|object} signature An instance of `SignatureData`, `[v, r, s]` or `{v, r, s}`.
  * @param {boolean} [isHashed] (optional, default: `false`) If the `isHashed` is true, the given message will NOT automatically be prefixed with "\x19Klaytn Signed Message:\n" + message.length + message, and be assumed as already prefixed.
  * @return {string}
  */
 const recoverPublicKey = (message, signature, isHashed = false) => {
     if (!isHashed) message = hashMessage(message)
 
+    if (_.isArray(signature)) signature = { v: signature[0], r: signature[1], s: signature[2] }
     const vrs = { v: parseInt(signature.v.slice(2), 16), r: signature.r.slice(2), s: signature.s.slice(2) }
 
     const ecPublicKey = secp256k1.recoverPubKey(Buffer.from(message.slice(2), 'hex'), vrs, vrs.v < 2 ? vrs.v : 1 - (vrs.v % 2))
@@ -1005,7 +1006,7 @@ const recoverPublicKey = (message, signature, isHashed = false) => {
  *
  * @method recover
  * @param {string} message The raw message string. If this message is hased with Klaytn specific prefix, the third parameter should be passed as `true`.
- * @param {SignatureData} signature An instance of `SignatureData`.
+ * @param {SignatureData|Array.<string>|object} signature An instance of `SignatureData`, `[v, r, s]` or `{v, r, s}`.
  * @param {boolean} [isHashed] (optional, default: `false`) If the `isHashed` is true, the given message will NOT automatically be prefixed with "\x19Klaytn Signed Message:\n" + message.length + message, and be assumed as already prefixed.
  * @return {string}
  */
@@ -1014,7 +1015,7 @@ const recover = (message, signature, isHashed = false) => {
         message = hashMessage(message)
     }
 
-    return Account.recover(message, Account.encodeSignature(signature.encode())).toLowerCase()
+    return Account.recover(message, Account.encodeSignature(resolveSignature(signature))).toLowerCase()
 }
 
 /**

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -2045,6 +2045,28 @@ describe('caver.utils.recover', () => {
         const result = caver.utils.recover(signed.messageHash, signed.signatures[0], true)
         expect(result).to.equal(keyring.address)
     })
+
+    it('CAVERJS-UNIT-ETC-387: return recovered address when signature is an array', () => {
+        const message = 'Some Message'
+
+        const result = caver.utils.recover(message, [
+            '0x1b',
+            '0x8213e560e7bbe1f2e28fd69cbbb41c9108b84c98cd7c2c88d3c8e3549fd6ab10',
+            '0x3ca40c9e20c1525348d734a6724db152b9244bff6e0ff0c2b811d61d8f874f00',
+        ])
+        expect(result.toLowerCase()).to.equal('0xa84a1ce657e9d5b383cece6f4ba365e23fa234dd')
+    })
+
+    it('CAVERJS-UNIT-ETC-388: return recovered address when signature is an object', () => {
+        const message = 'Some Message'
+
+        const result = caver.utils.recover(message, {
+            v: '0x1b',
+            r: '0x8213e560e7bbe1f2e28fd69cbbb41c9108b84c98cd7c2c88d3c8e3549fd6ab10',
+            s: '0x3ca40c9e20c1525348d734a6724db152b9244bff6e0ff0c2b811d61d8f874f00',
+        })
+        expect(result.toLowerCase()).to.equal('0xa84a1ce657e9d5b383cece6f4ba365e23fa234dd')
+    })
 })
 
 describe('caver.utils.recoverPublicKey', () => {
@@ -2064,6 +2086,28 @@ describe('caver.utils.recoverPublicKey', () => {
 
         const result = caver.utils.recoverPublicKey(signed.messageHash, signed.signatures[0], true)
         expect(result).to.equal(keyring.getPublicKey())
+    })
+
+    it('CAVERJS-UNIT-ETC-385: return recovered public key when signature is an array', () => {
+        const message = 'Some Message'
+
+        const result = caver.utils.recoverPublicKey(message, [
+            '0x1b',
+            '0x8213e560e7bbe1f2e28fd69cbbb41c9108b84c98cd7c2c88d3c8e3549fd6ab10',
+            '0x3ca40c9e20c1525348d734a6724db152b9244bff6e0ff0c2b811d61d8f874f00',
+        ])
+        expect(result.toLowerCase()).to.equal('0xb5df4d5e6b4ee7a136460b911a69030fdd42c18ed067bcc2e25eda1b851314fad994c5fe946aad01ca2e348d4ff3094960661a8bc095f358538af54aeea48ff3')
+    })
+
+    it('CAVERJS-UNIT-ETC-386: return recovered public key when signature is an object', () => {
+        const message = 'Some Message'
+
+        const result = caver.utils.recoverPublicKey(message, {
+            v: '0x1b',
+            r: '0x8213e560e7bbe1f2e28fd69cbbb41c9108b84c98cd7c2c88d3c8e3549fd6ab10',
+            s: '0x3ca40c9e20c1525348d734a6724db152b9244bff6e0ff0c2b811d61d8f874f00',
+        })
+        expect(result.toLowerCase()).to.equal('0xb5df4d5e6b4ee7a136460b911a69030fdd42c18ed067bcc2e25eda1b851314fad994c5fe946aad01ca2e348d4ff3094960661a8bc095f358538af54aeea48ff3')
     })
 })
 

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -2096,7 +2096,9 @@ describe('caver.utils.recoverPublicKey', () => {
             '0x8213e560e7bbe1f2e28fd69cbbb41c9108b84c98cd7c2c88d3c8e3549fd6ab10',
             '0x3ca40c9e20c1525348d734a6724db152b9244bff6e0ff0c2b811d61d8f874f00',
         ])
-        expect(result.toLowerCase()).to.equal('0xb5df4d5e6b4ee7a136460b911a69030fdd42c18ed067bcc2e25eda1b851314fad994c5fe946aad01ca2e348d4ff3094960661a8bc095f358538af54aeea48ff3')
+        expect(result.toLowerCase()).to.equal(
+            '0xb5df4d5e6b4ee7a136460b911a69030fdd42c18ed067bcc2e25eda1b851314fad994c5fe946aad01ca2e348d4ff3094960661a8bc095f358538af54aeea48ff3'
+        )
     })
 
     it('CAVERJS-UNIT-ETC-386: return recovered public key when signature is an object', () => {
@@ -2107,7 +2109,9 @@ describe('caver.utils.recoverPublicKey', () => {
             r: '0x8213e560e7bbe1f2e28fd69cbbb41c9108b84c98cd7c2c88d3c8e3549fd6ab10',
             s: '0x3ca40c9e20c1525348d734a6724db152b9244bff6e0ff0c2b811d61d8f874f00',
         })
-        expect(result.toLowerCase()).to.equal('0xb5df4d5e6b4ee7a136460b911a69030fdd42c18ed067bcc2e25eda1b851314fad994c5fe946aad01ca2e348d4ff3094960661a8bc095f358538af54aeea48ff3')
+        expect(result.toLowerCase()).to.equal(
+            '0xb5df4d5e6b4ee7a136460b911a69030fdd42c18ed067bcc2e25eda1b851314fad994c5fe946aad01ca2e348d4ff3094960661a8bc095f358538af54aeea48ff3'
+        )
     })
 })
 


### PR DESCRIPTION
## Proposed changes

This PR introduces adding logic to handle array and object format signature in `caver.utils.recover` and `caver.utils.recoverPublicKey`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
