### PR TITLE
Modified to format only old transaction object before sending tx to the EN

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -148,37 +148,41 @@ const inputCallFormatter = function(options) {
  * @param {Object} options
  * @returns object
  */
-const inputTransactionFormatter = function(options) {
-    options = _txInputFormatter(options)
+const inputTransactionFormatter = function(options) {    
+    // Only transaction objects prior to Common Architecture are formatted.
+    // After the Common Architecture, the transaction does all the formatting in the setter when the instance is already created.
+    if (!options.type.includes('TxType')) {
+        options = _txInputFormatter(options)
 
-    // If senderRawTransaction' exist in transaction, it means object is fee payer transaction format like below
-    // { senderRawTransaction: '', feePayer: '' }
-    if (options.senderRawTransaction) {
-        if (options.feePayer === undefined) {
-            throw new Error('The "feePayer" field must be defined for signing with feePayer!')
+        // If senderRawTransaction' exist in transaction, it means object is fee payer transaction format like below
+        // { senderRawTransaction: '', feePayer: '' }
+        if (options.senderRawTransaction) {
+            if (options.feePayer === undefined) {
+                throw new Error('The "feePayer" field must be defined for signing with feePayer!')
+            }
+            options.feePayer = inputAddressFormatter(options.feePayer)
+            return options
         }
-        options.feePayer = inputAddressFormatter(options.feePayer)
-        return options
-    }
-
-    // check from, only if not number, or object
-    if (!_.isNumber(options.from) && !_.isObject(options.from)) {
-        options.from = options.from || (this ? this.defaultAccount : null)
-
-        if (!options.from && !_.isNumber(options.from)) {
-            throw new Error('The send transactions "from" field must be defined!')
+        
+        // check from, only if not number, or object
+        if (!_.isNumber(options.from) && !_.isObject(options.from)) {
+            options.from = options.from || (this ? this.defaultAccount : null)
+            
+            if (!options.from && !_.isNumber(options.from)) {
+                throw new Error('The send transactions "from" field must be defined!')
+            }
+            
+            options.from = inputAddressFormatter(options.from)
         }
-
-        options.from = inputAddressFormatter(options.from)
-    }
-
-    if (options.data) {
-        options.data = utils.addHexPrefix(options.data)
-    }
-
-    const err = validateParams(options)
-    if (err) {
-        throw err
+        
+        if (options.data) {
+            options.data = utils.addHexPrefix(options.data)
+        }
+        
+        const err = validateParams(options)
+        if (err) {
+            throw err
+        }
     }
 
     // Set typeInt value in object

--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -148,7 +148,7 @@ const inputCallFormatter = function(options) {
  * @param {Object} options
  * @returns object
  */
-const inputTransactionFormatter = function(options) {    
+const inputTransactionFormatter = function(options) {
     // Only transaction objects prior to Common Architecture are formatted.
     // After the Common Architecture, the transaction does all the formatting in the setter when the instance is already created.
     if (!options.type.includes('TxType')) {
@@ -163,22 +163,22 @@ const inputTransactionFormatter = function(options) {
             options.feePayer = inputAddressFormatter(options.feePayer)
             return options
         }
-        
+
         // check from, only if not number, or object
         if (!_.isNumber(options.from) && !_.isObject(options.from)) {
             options.from = options.from || (this ? this.defaultAccount : null)
-            
+
             if (!options.from && !_.isNumber(options.from)) {
                 throw new Error('The send transactions "from" field must be defined!')
             }
-            
+
             options.from = inputAddressFormatter(options.from)
         }
-        
+
         if (options.data) {
             options.data = utils.addHexPrefix(options.data)
         }
-        
+
         const err = validateParams(options)
         if (err) {
             throw err


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of formatter to format the old transaction object only before sending tx to the EN.

Because common architecture transactions uese `input` field instead of `data.
But formatter uses `data` over `input`, so there are conflict when sending transaction to the Klaytn.

In the case of Common Architecture transaction, when creating an instance, all validation is done and formatting is done in the setter, so there is no need to format in the formatter separately.
This reduces unnecessary formatting work.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
