### PR TITLE
Fix ABI function's JSDocs that showing incorrect type

### DIFF
--- a/packages/caver-abi/src/index.js
+++ b/packages/caver-abi/src/index.js
@@ -470,7 +470,7 @@ ABICoder.prototype.decodeParametersWith = function(outputs, bytes, loose) {
  * @param {Object} inputs
  * @param {String} data
  * @param {Array} topics
- * @return {Array} array of plain params
+ * @return {object} An object which includes plain params. You can use `result[0]` as it is provided to be accessed like an array in the order of the parameters.
  */
 ABICoder.prototype.decodeLog = function(inputs, data, topics) {
     const _this = this

--- a/packages/caver-abi/src/index.js
+++ b/packages/caver-abi/src/index.js
@@ -404,7 +404,7 @@ ABICoder.prototype.decodeFunctionCall = function(abi, functionCall) {
  * @method decodeParameter
  * @param {String} type
  * @param {String} bytes
- * @return {Object} plain param
+ * @return {String} plain param
  */
 ABICoder.prototype.decodeParameter = function(type, bytes) {
     return this.decodeParameters([type], bytes)[0]

--- a/packages/caver-abi/src/index.js
+++ b/packages/caver-abi/src/index.js
@@ -281,7 +281,7 @@ ABICoder.prototype.mapStructToCoderFormat = function(struct) {
  * @method formatParam
  * @param {String} - type
  * @param {any} - param
- * @return {String | Array<String>} - The formatted param
+ * @return {string | Array.<string>} - The formatted param
  */
 ABICoder.prototype.formatParam = function(type, param) {
     const paramTypeBytes = new RegExp(/^bytes([0-9]*)$/)
@@ -404,7 +404,7 @@ ABICoder.prototype.decodeFunctionCall = function(abi, functionCall) {
  * @method decodeParameter
  * @param {String} type
  * @param {String} bytes
- * @return {String} plain param
+ * @return {string} plain param
  */
 ABICoder.prototype.decodeParameter = function(type, bytes) {
     return this.decodeParameters([type], bytes)[0]

--- a/packages/caver-abi/src/index.js
+++ b/packages/caver-abi/src/index.js
@@ -430,7 +430,7 @@ ABICoder.prototype.decodeParameters = function(outputs, bytes) {
  * @param {String} bytes
  * @param {Boolean} loose must be passed for decoding bytes and string parameters for logs emitted with solc 0.4.x
  *                        Please refer to https://github.com/ChainSafe/web3.js/commit/e80337e16e5c04683fc40148378775234c28e0fb.
- * @return {Array} array of plain params
+ * @return {object} An object which includes plain params. You can use `result[0]` as it is provided to be accessed like an array in the order of the parameters.
  */
 ABICoder.prototype.decodeParametersWith = function(outputs, bytes, loose) {
     if (outputs.length > 0 && (!bytes || bytes === '0x' || bytes === '0X')) {

--- a/packages/caver-abi/src/index.js
+++ b/packages/caver-abi/src/index.js
@@ -281,7 +281,7 @@ ABICoder.prototype.mapStructToCoderFormat = function(struct) {
  * @method formatParam
  * @param {String} - type
  * @param {any} - param
- * @return {any} - The formatted param
+ * @return {String | Array<String>} - The formatted param
  */
 ABICoder.prototype.formatParam = function(type, param) {
     const paramTypeBytes = new RegExp(/^bytes([0-9]*)$/)

--- a/packages/caver-abi/src/index.js
+++ b/packages/caver-abi/src/index.js
@@ -341,7 +341,7 @@ ABICoder.prototype.formatParam = function(type, param) {
  * Encodes a function call from its json interface and parameters.
  *
  * @method encodeFunctionCall
- * @param {Array} jsonInterface
+ * @param {object} jsonInterface
  * @param {Array} [params]
  * @return {String} The encoded ABI for this function call
  */


### PR DESCRIPTION
## Proposed changes
Fix ABI function's JSDocs that showing incorrect type

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
