### PR TITLE
Wrong test case that using validateKeyring function with undefined value for expectedKey

### DIFF
--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -642,7 +642,7 @@ Contract.prototype._encodeMethodABI = function _encodeMethodABI() {
  *
  * @method decodeFunctionCall
  * @param {string} functionCall The encoded function call string.
- * @return {Array} An array of plain params
+ * @return {object} An object which includes plain params.
  */
 Contract.prototype.decodeFunctionCall = function decodeFunctionCall(functionCall) {
     functionCall = utils.addHexPrefix(functionCall)

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -363,7 +363,7 @@ describe('caver.wallet.keyring.createFromPrivateKey', () => {
             const klaytnWalletKey = keyring.getKlaytnWalletKey()
 
             const result = caver.wallet.keyring.createFromPrivateKey(utils.stripHexPrefix(klaytnWalletKey))
-            validateKeyring(result, { expectedKey: keyring.keys, expectedAddress: keyring.address })
+            validateKeyring(result, { expectedKey: keyring.key, expectedAddress: keyring.address })
         })
     })
 
@@ -385,7 +385,7 @@ describe('caver.wallet.keyring.createFromKlaytnWalletKey', () => {
             const klaytnWalletKey = keyring.getKlaytnWalletKey()
 
             const result = caver.wallet.keyring.createFromKlaytnWalletKey(klaytnWalletKey)
-            validateKeyring(result, { expectedKey: keyring.keys, expectedAddress: keyring.address })
+            validateKeyring(result, { expectedKey: keyring.key, expectedAddress: keyring.address })
         })
     })
 
@@ -406,7 +406,7 @@ describe('caver.wallet.keyring.create', () => {
             const keyring = caver.wallet.keyring.generate()
             const created = caver.wallet.keyring.create(keyring.address, keyring.key.privateKey)
 
-            validateKeyring(created, { expectedAddress: keyring.address, expectedKey: keyring.keys })
+            validateKeyring(created, { expectedAddress: keyring.address, expectedKey: keyring.key })
         })
     })
 
@@ -602,7 +602,7 @@ describe('caver.wallet.keyring.decrypt', () => {
             const encrypted = keyring.encrypt(password)
             const decrypted = caver.wallet.keyring.decrypt(encrypted, password)
 
-            validateKeyring(decrypted, { expectedAddress: keyring.address, expectedKey: keyring.keys })
+            validateKeyring(decrypted, { expectedAddress: keyring.address, expectedKey: keyring.key })
         })
     })
 
@@ -614,7 +614,7 @@ describe('caver.wallet.keyring.decrypt', () => {
             const encrypted = keyring.encrypt(password)
             const decrypted = caver.wallet.keyring.decrypt(encrypted, password)
 
-            validateKeyring(decrypted, { expectedAddress: keyring.address, expectedKey: keyring.keys })
+            validateKeyring(decrypted, { expectedAddress: keyring.address, expectedKey: keyring.key })
         })
     })
 
@@ -788,7 +788,7 @@ describe('caver.wallet.keyring.decrypt', () => {
 
             const result = caver.wallet.keyring.decrypt(keystoreJsonV3, password)
 
-            validateKeyring(result, { keys: expectedAccount.keys, address: expectedAccount.address })
+            validateKeyring(result, { keys: expectedAccount.key, address: expectedAccount.address })
             expect(keystoreJsonV3.crypto).not.to.be.undefined
         })
     })

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -788,7 +788,7 @@ describe('caver.wallet.keyring.decrypt', () => {
 
             const result = caver.wallet.keyring.decrypt(keystoreJsonV3, password)
 
-            validateKeyring(result, { keys: expectedAccount.key, address: expectedAccount.address })
+            validateKeyring(result, { expectedKey: expectedAccount.key, expectedAddress: expectedAccount.address })
             expect(keystoreJsonV3.crypto).not.to.be.undefined
         })
     })


### PR DESCRIPTION
## Proposed changes

The `SingleKeyring` type doesn't have a `keys` property, but the `keys` property is set as the `expectedKey` parameter value of the `validateKeyring` function.

The `validateKeyring` function doesn't test if the expected values are `undefined`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
