### PR TITLE
Wrong test case that using validateKeyringInWallet function with undefined value for expectedKey

### DIFF
--- a/test/packages/caver.wallet.js
+++ b/test/packages/caver.wallet.js
@@ -131,7 +131,7 @@ describe('wallet.newKeyring', () => {
             const keyring = caver.wallet.keyring.generate()
             const added = caver.wallet.newKeyring(keyring.address, keyring.key.privateKey)
 
-            validateKeyringInWallet(added, { expectedAddress: keyring.address, expectedKey: keyring.keys })
+            validateKeyringInWallet(added, { expectedAddress: keyring.address, expectedKey: keyring.key })
             expect(addSpy).to.have.been.calledOnce
             expect(caver.wallet.length).to.equal(1)
         })
@@ -253,7 +253,7 @@ describe('wallet.getKeyring', () => {
 
             const keyring = caver.wallet.getKeyring(added.address)
 
-            validateKeyringInWallet(keyring, { expectedAddress: added.address, expectedKey: added.keys })
+            validateKeyringInWallet(keyring, { expectedAddress: added.address, expectedKey: added.key })
         })
     })
 
@@ -284,8 +284,8 @@ describe('wallet.add', () => {
             const added = caver.wallet.add(keyringToAdd)
             const keyringFromContainer = caver.wallet.getKeyring(added.address)
 
-            validateKeyringInWallet(added, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.keys })
-            validateKeyringInWallet(keyringFromContainer, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.keys })
+            validateKeyringInWallet(added, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.key })
+            validateKeyringInWallet(keyringFromContainer, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.key })
 
             expect(caver.wallet.length).to.equal(1)
         })
@@ -298,8 +298,8 @@ describe('wallet.add', () => {
             const added = caver.wallet.add(keyringToAdd)
             const keyringFromContainer = caver.wallet.getKeyring(added.address)
 
-            validateKeyringInWallet(added, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.keys })
-            validateKeyringInWallet(keyringFromContainer, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.keys })
+            validateKeyringInWallet(added, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.key })
+            validateKeyringInWallet(keyringFromContainer, { expectedAddress: keyringToAdd.address, expectedKey: keyringToAdd.key })
 
             expect(caver.wallet.length).to.equal(1)
         })


### PR DESCRIPTION
## Proposed changes

The `SingleKeyring` type doesn't have a `keys` property, but the `keys` property is set as the `expectedKey` parameter value of the `validateKeyringInWallet` function.

The `validateKeyringInWallet` function doesn't test if the expected values are `undefined`.

same case as #486 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
