### PR TITLE
Handling contract when a keyring is not existed in the in-memory wallet

### DIFF
--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -1304,7 +1304,7 @@ Contract.prototype._executeMethod = async function _executeMethod() {
                   })
 
         case 'send':
-            let transaction = await createTransactionFromArgs(args, this._method, this._deployData, defer)
+            const transaction = await createTransactionFromArgs(args, this._method, this._deployData, defer)
             // make sure receipt logs are decoded
             const extraFormatters = {
                 receiptFormatter(receipt) {
@@ -1387,10 +1387,10 @@ Contract.prototype._executeMethod = async function _executeMethod() {
                 // 2. FD/FDR Transaction
                 //    2.1. `from` is existed in the `caver.wallet`
                 //        2.1.1. `feePayer` is existed in the `caver.wallet` -> caver.wallet.sign / caver.wallet.signAsFeePayer
-                //        2.1.2. `feePayer` is not existed in the `caver.wallet` -> caver.wallet.sign / `klay_sendTransactionAsFeePayer`
+                //        2.1.2. `feePayer` is not existed in the `caver.wallet` -> caver.wallet.sign / `klay_signTransactionAsFeePayer`
                 //    2.2. `from` is not existed in the `caver.wallet`
                 //        2.2.1. `feePayer` is existed in the `caver.wallet` -> `klay_signTransaction` / caver.wallet.signAsFeePayer
-                //        2.2.2. `feePayer` is not existed in the `caver.wallet` -> `klay_signTransaction` / klay_signTransactionAsFeePayer`
+                //        2.2.2. `feePayer` is not existed in the `caver.wallet` -> `klay_signTransaction` / `klay_signTransactionAsFeePayer`
                 const isExistedInWallet = await wallet.isExisted(args.options.from)
 
                 async function fillFeePayerSignatures(txToSign) {

--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -1343,7 +1343,7 @@ Contract.prototype._executeMethod = async function _executeMethod() {
                 const isExistedInWallet = await wallet.isExisted(args.options.from)
                 if (!isExistedInWallet) {
                     if (wallet instanceof KeyringContainer) {
-                        return sendTransaction(args.options, args.callback)
+                        return sendTransaction(transaction, args.callback)
                     }
                     throw new Error(`Failed to find ${args.options.from}. Please check that the corresponding account or keyring exists.`)
                 }

--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -1393,6 +1393,7 @@ Contract.prototype._executeMethod = async function _executeMethod() {
                 //        2.2.2. `feePayer` is not existed in the `caver.wallet` -> `klay_signTransaction` / `klay_signTransactionAsFeePayer`
                 const isExistedInWallet = await wallet.isExisted(args.options.from)
 
+                // eslint-disable-next-line no-inner-declarations
                 async function fillFeePayerSignatures(txToSign) {
                     // To fill the optional values (chainId, nonde, gasPrice)
                     await txToSign.fillTransaction()

--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -151,7 +151,7 @@ const inputCallFormatter = function(options) {
 const inputTransactionFormatter = function(options) {
     // Only transaction objects prior to Common Architecture are formatted.
     // After the Common Architecture, the transaction does all the formatting in the setter when the instance is already created.
-    if (!options.type.includes('TxType')) {
+    if (!options.type || !options.type.includes('TxType')) {
         options = _txInputFormatter(options)
 
         // If senderRawTransaction' exist in transaction, it means object is fee payer transaction format like below

--- a/test/packages/caver.contract.js
+++ b/test/packages/caver.contract.js
@@ -2831,4 +2831,140 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
             expect(signed.feeRatio).to.equal(contract.options.feeRatio)
         }).timeout(200000)
     })
+
+    context('Send to the Klaytn if a keyring cannnot be found in caver.wallet', () => {
+        it(`CAVERJS-UNIT-ETC-389: should throw an error if Node also does not have that account when send basic`, async () => {
+            const contract = new caver.contract(abiWithoutConstructor, contractAddress)
+
+            let sendOptions = {
+                from: caver.wallet.keyring.generate().address,
+                gas: 1000000,
+            }
+
+            const expectedError = `Returned error: unknown account`
+            await expect(contract.send(sendOptions, 'set', 'k', 'v')).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it(`CAVERJS-UNIT-ETC-390: should throw an error if Node also does not have that account when send fd`, async () => {
+            const contract = new caver.contract(abiWithoutConstructor, contractAddress)
+
+            let sendOptions = {
+                from: caver.wallet.keyring.generate().address,
+                gas: 1000000,
+                feeDelegation: true,
+                feePayer: caver.wallet.keyring.generate().address,
+            }
+
+            const expectedError = `Returned error: unknown account`
+            await expect(contract.send(sendOptions, 'set', 'k', 'v')).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it(`CAVERJS-UNIT-ETC-391: should throw an error if Node also does not have that account when sign`, async () => {
+            const contract = new caver.contract(abiWithoutConstructor, contractAddress)
+
+            let sendOptions = {
+                from: caver.wallet.keyring.generate().address,
+                gas: 1000000,
+            }
+
+            const expectedError = `Returned error: unknown account`
+            await expect(contract.sign(sendOptions, 'set', 'k', 'v')).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it(`CAVERJS-UNIT-ETC-392: should throw an error if Node also does not have that account when signAsFeePayer`, async () => {
+            const contract = new caver.contract(abiWithoutConstructor, contractAddress)
+
+            let sendOptions = {
+                from: caver.wallet.keyring.generate().address,
+                gas: 1000000,
+                feeDelegation: true,
+                feePayer: caver.wallet.keyring.generate().address,
+            }
+
+            const expectedError = `Returned error: unknown account`
+            await expect(contract.signAsFeePayer(sendOptions, 'set', 'k', 'v')).to.be.rejectedWith(expectedError)
+        }).timeout(200000)
+
+        it(`CAVERJS-UNIT-ETC-393: should send to the Klaytn if in-memory wallet does not have a from account`, async () => {
+            try {
+                await caver.klay.personal.importRawKey(sender.key.privateKey, 'passphrase')
+            } catch (e) {}
+            await caver.klay.personal.unlockAccount(sender.address, 'passphrase')
+
+            const contract = new caver.contract(abiWithoutConstructor, contractAddress)
+
+            // To send to the Klaytn, should remove in the in-memory wallet
+            caver.wallet.remove(sender.address)
+
+            // Basic Transaction - `from` is not existed in the `caver.wallet`
+            const sendOptionsForBasic = {
+                from: sender.address,
+                gas: 1000000,
+            }
+
+            const resultBasic = await contract.send(sendOptionsForBasic, 'set', 'k', 'v')
+
+            expect(resultBasic.from).to.equal(sender.address)
+            expect(resultBasic.status).to.be.true
+            expect(resultBasic.type).to.equal(TX_TYPE_STRING.TxTypeSmartContractExecution)
+
+            // FD/FDR Transaction - `from` is not existed in the `caver.wallet` / `feePayer` is existed in the `caver.wallet`
+            const sendOptionsForFD = {
+                from: sender.address,
+                gas: 1000000,
+                feeDelegation: true,
+                feePayer: feePayer.address,
+            }
+
+            const resultFD = await contract.send(sendOptionsForFD, 'set', 'k', 'v')
+
+            expect(resultFD.from).to.equal(sender.address)
+            expect(resultFD.feePayer).to.equal(feePayer.address)
+            expect(resultFD.status).to.be.true
+            expect(resultFD.type).to.equal(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractExecution)
+
+            // FD/FDR Transaction - `from` is not existed in the `caver.wallet` / `feePayer` is not existed in the `caver.wallet`
+            try {
+                await caver.klay.personal.importRawKey(feePayer.key.privateKey, 'passphrase')
+            } catch (e) {}
+            await caver.klay.personal.unlockAccount(feePayer.address, 'passphrase')
+
+            caver.wallet.remove(feePayer.address)
+            const sendOptionsForFDWithNodeAccount = {
+                from: sender.address,
+                gas: 1000000,
+                feeDelegation: true,
+                feePayer: feePayer.address,
+            }
+
+            const resultForFDWithNodeAccount = await contract.send(sendOptionsForFDWithNodeAccount, 'set', 'k', 'v')
+
+            expect(resultForFDWithNodeAccount.from).to.equal(sender.address)
+            expect(resultForFDWithNodeAccount.feePayer).to.equal(feePayer.address)
+            expect(resultForFDWithNodeAccount.status).to.be.true
+            expect(resultForFDWithNodeAccount.type).to.equal(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractExecution)
+        }).timeout(200000)
+
+        it(`CAVERJS-UNIT-ETC-394: should send to the Klaytn if in-memory wallet does not have a feePayer account`, async () => {
+            const contract = new caver.contract(abiWithoutConstructor, contractAddress)
+
+            // To send to the Klaytn, should remove in the in-memory wallet
+            caver.wallet.add(sender)
+
+            // FD/FDR Transaction - `feePayer` is not existed in the `caver.wallet`. And `from` is existed in the `caver.wallet`.
+            const sendOptionsForFD = {
+                from: sender.address,
+                gas: 1000000,
+                feeDelegation: true,
+                feePayer: feePayer.address,
+            }
+
+            const resultFD = await contract.send(sendOptionsForFD, 'set', 'k', 'v')
+
+            expect(resultFD.from).to.equal(sender.address)
+            expect(resultFD.feePayer).to.equal(feePayer.address)
+            expect(resultFD.status).to.be.true
+            expect(resultFD.type).to.equal(TX_TYPE_STRING.TxTypeFeeDelegatedSmartContractExecution)
+        }).timeout(200000)
+    })
 })

--- a/test/packages/caver.contract.js
+++ b/test/packages/caver.contract.js
@@ -2836,7 +2836,7 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
         it(`CAVERJS-UNIT-ETC-389: should throw an error if Node also does not have that account when send basic`, async () => {
             const contract = new caver.contract(abiWithoutConstructor, contractAddress)
 
-            let sendOptions = {
+            const sendOptions = {
                 from: caver.wallet.keyring.generate().address,
                 gas: 1000000,
             }
@@ -2848,7 +2848,7 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
         it(`CAVERJS-UNIT-ETC-390: should throw an error if Node also does not have that account when send fd`, async () => {
             const contract = new caver.contract(abiWithoutConstructor, contractAddress)
 
-            let sendOptions = {
+            const sendOptions = {
                 from: caver.wallet.keyring.generate().address,
                 gas: 1000000,
                 feeDelegation: true,
@@ -2862,7 +2862,7 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
         it(`CAVERJS-UNIT-ETC-391: should throw an error if Node also does not have that account when sign`, async () => {
             const contract = new caver.contract(abiWithoutConstructor, contractAddress)
 
-            let sendOptions = {
+            const sendOptions = {
                 from: caver.wallet.keyring.generate().address,
                 gas: 1000000,
             }
@@ -2874,7 +2874,7 @@ describe('caver.contract makes it easy to interact with smart contracts on the K
         it(`CAVERJS-UNIT-ETC-392: should throw an error if Node also does not have that account when signAsFeePayer`, async () => {
             const contract = new caver.contract(abiWithoutConstructor, contractAddress)
 
-            let sendOptions = {
+            const sendOptions = {
                 from: caver.wallet.keyring.generate().address,
                 gas: 1000000,
                 feeDelegation: true,


### PR DESCRIPTION
## Proposed changes

This PR introduces adding logic that handle when the keyring(from or fee payer) is not existed in the in-memory wallet.
`caver.contract` should cover below scenarios.

1. Basic Transaction
   1.1. `from` is existed in the `caver.wallet` -> caver.wallet.sign
   1.2. `from` is not existed in the `caver.wallet` -> `klay_sendTransaction`
2. FD/FDR Transaction
   2.1. `from` is existed in the `caver.wallet`
       2.1.1. `feePayer` is existed in the `caver.wallet` -> caver.wallet.sign / caver.wallet.signAsFeePayer / `klay_sendRawTransaction`
       2.1.2. `feePayer` is not existed in the `caver.wallet` -> caver.wallet.sign / `klay_signTransactionAsFeePayer` / `klay_sendRawTransaction`
   2.2. `from` is not existed in the `caver.wallet`
       2.2.1. `feePayer` is existed in the `caver.wallet` -> `klay_signTransaction` / caver.wallet.signAsFeePayer / `klay_sendRawTransaction`
       2.2.2. `feePayer` is not existed in the `caver.wallet` -> `klay_signTransaction` / `klay_signTransactionAsFeePayer` / `klay_sendRawTransaction`
       
To test when the keyring is not existed in the wallet, i added two test cases.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
