### PR TITLE
Added governance and net rpc jsdoc

### DIFF
--- a/packages/caver-rpc/src/governance.js
+++ b/packages/caver-rpc/src/governance.js
@@ -25,82 +25,308 @@ const utils = require('../../caver-utils')
 /**
  * A class that can invoke Governance RPC Calls.
  * @class
+ * @hideconstructor
  */
-const GovernanceRPC = function GovernanceRPC(...args) {
+const Governance = function Governance(...args) {
     const _this = this
 
     core.packageInit(this, args)
 
     const govMethods = [
+        /**
+         * Submits a new vote. If the node has the right to vote based on the governance mode, the vote can be submitted. If not, an error will occur and the vote will be ignored.
+         *
+         * @memberof Governance
+         * @method vote
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.vote('governance.governancemode', 'ballot')
+         *
+         * @param {string} key Name of the configuration setting to be changed. Key has the form "domain.field".
+         * @param {string|number|boolean} value Various types of value for each key.
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<string>} Result of vote submission.
+         */
         new Method({
             name: 'vote',
             call: 'governance_vote',
             params: 2,
         }),
+        /**
+         * An object defines the vote's value and the approval rate in percentage.
+         *
+         * @typedef {object} Governance.TallyItem
+         * @property {string} Key - The name of the vote.
+         * @property {*} Value - The value of the vote.
+         * @property {number} ApprovalPercentage - The approval rate in percentage.
+         */
+        /**
+         * Submits a new vote. If the node has the right to vote based on the governance mode, the vote can be submitted. If not, an error will occur and the vote will be ignored.
+         *
+         * @memberof Governance
+         * @method showTally
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.showTally()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<Array.<Governance.TallyItem>>} An array containing the vote's value and the approval rate in percentage.
+         */
         new Method({
             name: 'showTally',
             call: 'governance_showTally',
             params: 0,
         }),
+        /**
+         * Provides the sum of all voting power that CNs have. Each CN has 1.0 ~ 2.0 voting power.
+         * In the "none" and "single" governance modes, totalVotingPower doesn't provide any information.
+         *
+         * @memberof Governance
+         * @method getTotalVotingPower
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getTotalVotingPower()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<number>} Total Voting Power.
+         */
         new Method({
             name: 'getTotalVotingPower',
             call: 'governance_totalVotingPower',
             outputFormatter: formatters.outputVotingPowerFormatter,
             params: 0,
         }),
+        /**
+         * Provides the voting power of the node. The voting power can be anywhere between 1.0 ~ 2.0.
+         * In the "none" and "single" governance modes, totalVotingPower doesn't provide any information.
+         *
+         * @memberof Governance
+         * @method getMyVotingPower
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getMyVotingPower()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<number>} Node's Voting Power.
+         */
         new Method({
             name: 'getMyVotingPower',
             call: 'governance_myVotingPower',
             outputFormatter: formatters.outputVotingPowerFormatter,
             params: 0,
         }),
+        /**
+         * An object defines the vote's value and the approval rate in percentage for my votes.
+         *
+         * @typedef {object} Governance.MyVote
+         * @property {string} Key - The name of the vote.
+         * @property {*} Value - The value of the vote.
+         * @property {boolean} Casted - If this vote is stored in a block or not
+         * @property {number} BlockNum - The block number that this vote is stored
+         */
+        /**
+         * Provides my vote information in the epoch.
+         * Each vote is stored in a block when the user's node generates a new block.
+         * After current epoch ends, this information is cleared.
+         *
+         * @memberof Governance
+         * @method getMyVotes
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getMyVotes()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<Array.<MyVote>>} Node's Voting status in the epoch
+         */
         new Method({
             name: 'getMyVotes',
             call: 'governance_myVotes',
             params: 0,
         }),
+        /**
+         * Provides the initial chain configuration.
+         * Because it just stores the initial configuration, if there were changes in the governance made by voting, the result of chainConfig will differ from the current states.
+         * To see the current information, please use {@link itemsAt}.
+         *
+         * @memberof Governance
+         * @method getChainConfig
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getChainConfig()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} The initial chain configuration
+         */
         new Method({
             name: 'getChainConfig',
             call: 'governance_chainConfig',
             params: 0,
         }),
+        /**
+         * Provides the address of the node that a user is using.
+         * It is derived from the nodekey and used to sign consensus messages.
+         * And the value of "governingnode" has to be one of validator's node address.
+         *
+         * @memberof Governance
+         * @method getNodeAddress
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getNodeAddress()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<string>} The address of a node
+         */
         new Method({
             name: 'getNodeAddress',
             call: 'governance_nodeAddress',
             params: 0,
         }),
+        /**
+         * Returns governance items at a specific block.
+         * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+         *
+         * @memberof Governance
+         * @method getItemsAt
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getItemsAt()
+         *
+         * @param {string|number} [blockNumberOrTag] A block number, or the string `latest` or `earliest`. If omitted, `latest` will be used.
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} The governance items.
+         */
         new Method({
             name: 'getItemsAt',
             call: 'governance_itemsAt',
             params: 1,
             inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
         }),
+        /**
+         * Returns the list of items that have received enough number of votes but not yet finalized.
+         * At the end of the current epoch, these changes will be finalized and the result will be in effect from the epoch after next epoch.
+         *
+         * @memberof Governance
+         * @method getPendingChanges
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getPendingChanges()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} Currently pending changes composed of keys and values.
+         */
         new Method({
             name: 'getPendingChanges',
             call: 'governance_pendingChanges',
             params: 0,
         }),
+        /**
+         * An object defines the vote's value and the approval rate in percentage.
+         *
+         * @typedef {object} Governance.Vote
+         * @property {string} key - The name of the vote.
+         * @property {*} value - The value of the vote.
+         * @property {string} validator - The node address.
+         */
+        /**
+         * Returns the votes from all nodes in the epoch. These votes are gathered from the header of each block.
+         *
+         * @memberof Governance
+         * @method getVotes
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getVotes()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<Array.<Governance.Vote>>} Current votes composed of keys, values and node addresses.
+         */
         new Method({
             name: 'getVotes',
             call: 'governance_votes',
             params: 0,
         }),
+        /**
+         * Returns an array of current idxCache in the memory cache.
+         * idxCache contains the block numbers where governance change happened. The cache can have up to 1000 block numbers in memory by default.
+         *
+         * @memberof Governance
+         * @method getIdxCache
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getIdxCache()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<Array.<number>>} Block numbers where governance change happened.
+         */
         new Method({
             name: 'getIdxCache',
             call: 'governance_idxCache',
             params: 0,
         }),
+        /**
+         * Returns an array that contains all block numbers at which any governance changes ever took place.
+         * The result of `idxCacheFromDb` is the same or longer than that of {@link idxCache}.
+         *
+         * @memberof Governance
+         * @method getIdxCacheFromDb
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getIdxCacheFromDb()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<Array.<number>>} Block numbers where governance change happened.
+         */
         new Method({
             name: 'getIdxCacheFromDb',
             call: 'governance_idxCacheFromDb',
             params: 0,
         }),
+        /**
+         * Returns the governance information stored on the given block.
+         * If no changes are stored on the given block, the function returns `null`.
+         *
+         * @memberof Governance
+         * @method getIdxCacheFromDb
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getIdxCacheFromDb()
+         *
+         * @param {number|string} blockNumber A block number, or the hex number string to query the governance change made on the block.
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} Stored governance information at a given block.
+         */
         new Method({
             name: 'getItemCacheFromDb',
             call: 'governance_itemCacheFromDb',
             params: 1,
             inputFormatter: [utils.numberToHex],
         }),
+        /**
+         * Returns the staking information at a specific block.
+         *
+         * @memberof Governance
+         * @method getStakingInfo
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getStakingInfo()
+         *
+         * @param {string|number} [blockNumberOrTag] A block number, or the string `latest` or `earliest`. If omitted, `latest` will be used.
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} Stored governance information at a given block.
+         */
         new Method({
             name: 'getStakingInfo',
             call: 'governance_getStakingInfo',
@@ -115,4 +341,4 @@ const GovernanceRPC = function GovernanceRPC(...args) {
     })
 }
 
-module.exports = GovernanceRPC
+module.exports = Governance

--- a/packages/caver-rpc/src/index.js
+++ b/packages/caver-rpc/src/index.js
@@ -21,6 +21,11 @@ const Net = require('./net')
 const Governance = require('./governance')
 const core = require('../../caver-core')
 
+/**
+ * A class that manages RPC call classes supported by caver.
+ * @hideconstructor
+ * @class
+ */
 class RPC {
     constructor(...args) {
         const _this = this
@@ -47,8 +52,13 @@ class RPC {
             _this.setRequestManager(_this._requestManager)
         }
 
+        /** @type {Klay} */
         this.klay = new Klay(this)
+
+        /** @type {Net} */
         this.net = new Net(this)
+
+        /** @type {Governance} */
         this.governance = new Governance(this)
     }
 }

--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -36,7 +36,7 @@ const utils = require('../../caver-utils')
 const AbstractTransaction = require('../../caver-transaction/src/transactionTypes/abstractTransaction')
 const Validator = require('../../caver-validator')
 
-class KlayRPC {
+class Klay {
     constructor(...args) {
         const _this = this
 
@@ -545,4 +545,4 @@ class KlayRPC {
     }
 }
 
-module.exports = KlayRPC
+module.exports = Klay

--- a/packages/caver-rpc/src/net.js
+++ b/packages/caver-rpc/src/net.js
@@ -19,27 +19,84 @@
 const core = require('../../caver-core')
 const Method = require('../../caver-core-method')
 
+/**
+ * A class that can invoke Net RPC Calls.
+ * @class
+ * @hideconstructor
+ */
 const Net = function Net(...args) {
     const _this = this
 
     core.packageInit(this, args)
 
     const netMethods = [
+        /**
+         * Returns the network identifier (network ID) of the Klaytn Node.
+         *
+         * @memberof Net
+         * @method getNetworkId
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.net.getNetworkId()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<number>} The network id.
+         */
         new Method({
             name: 'getNetworkId',
             call: 'net_networkID',
             params: 0,
         }),
+        /**
+         * Returns `true` if the Klaytn Node is actively listening for network connections.
+         *
+         * @memberof Net
+         * @method isListening
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.net.isListening()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<boolean>} `true` when listening, otherwise `false`.
+         */
         new Method({
             name: 'isListening',
             call: 'net_listening',
             params: 0,
         }),
+        /**
+         * Returns the number of peers currently connected to the Klaytn Node.
+         *
+         * @memberof Net
+         * @method getPeerCount
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.net.getPeerCount()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<string>} The number of connected peers in hex.
+         */
         new Method({
             name: 'getPeerCount',
             call: 'net_peerCount',
             params: 0,
         }),
+        /**
+         * Returns the number of connected nodes by type and the total number of connected nodes with key/value pairs.
+         *
+         * @memberof Net
+         * @method getPeerCountByType
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.net.getPeerCountByType()
+         *
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} The number of connected peers by type as well as the total number of connected peers.
+         */
         new Method({
             name: 'getPeerCountByType',
             call: 'net_peerCountByType',


### PR DESCRIPTION
## Proposed changes

This PR introduces adding governance and net jsdoc.
Also i renamed `GovernanceRPC` to `Governance`, and `KlayRPC` to `Klay`.

I will upload PR separate for Klay later.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
