### PR TITLE
Added AccountKey typedef and fixed description

### DIFF
--- a/packages/caver-account/src/index.js
+++ b/packages/caver-account/src/index.js
@@ -224,6 +224,11 @@ class Account {
     }
 
     /**
+     * The account key types which are used in the `caver.account` package.
+     *
+     * @typedef {AccountKeyLegacy|AccountKeyPublic|AccountKeyFail|AccountKeyWeightedMultiSig|AccountKeyRoleBased} Account.AccountKey
+     */
+    /**
      * Creates an account. It is recommended to use [caver.account.create]{@link Account#create} rather than using the constructor directly.
      *
      * @example
@@ -233,7 +238,7 @@ class Account {
      * @constructor
      * @hideconstructor
      * @param {string} address - The address of account.
-     * @param {AccountKeyLegacy|AccountKeyPublic|AccountKeyFail|AccountKeyWeightedMultiSig|AccountKeyRoleBased} accountKey - The accountKey of account.
+     * @param {Account.AccountKey} accountKey - The accountKey of account.
      */
     constructor(address, accountKey) {
         this.address = address
@@ -254,7 +259,7 @@ class Account {
     }
 
     /**
-     * @type {AccountKeyLegacy|AccountKeyPublic|AccountKeyFail|AccountKeyWeightedMultiSig|AccountKeyRoleBased}
+     * @type {Account.AccountKey}
      */
     get accountKey() {
         return this._accountKey
@@ -291,19 +296,16 @@ class Account {
 Account.weightedMultiSigOptions = WeightedMultiSigOptions
 
 /**
- * The option values for the contract instance.
- * Those values will be used for default value when make a transaction to deploy or execute the smart contract.
- * If the user passes the object defined in the fields below as a parameter when deploying or executing the contract,
- * the values defined for default in the contract are not used.
+ * A module that provides functions for accountKey.
  *
  * @typedef {Object} AccountKeyModule
- * @property {Function} decode - The address from which transactions should be made.
- * @property {typeof AccountKeyLegacy} accountKeyLegacy - The address from which transactions should be made.
- * @property {typeof AccountKeyPublic} accountKeyPublic - The address from which transactions should be made.
- * @property {typeof AccountKeyFail} accountKeyFail - The address from which transactions should be made.
- * @property {typeof AccountKeyWeightedMultiSig} accountKeyWeightedMultiSig - The address from which transactions should be made.
- * @property {typeof AccountKeyRoleBased} accountKeyRoleBased - The address from which transactions should be made.
- * @property {typeof WeightedPublicKey} weightedPublicKey - The address from which transactions should be made.
+ * @property {function} decode - A function to decode the accountKey. Please refer to {@link AccountKeyDecoder.decode|caver.account.accountKey.decode}.
+ * @property {typeof AccountKeyLegacy} accountKeyLegacy - Class representing accountKeyLegacy.
+ * @property {typeof AccountKeyPublic} accountKeyPublic - Class representing AccountKeyPublic.
+ * @property {typeof AccountKeyFail} accountKeyFail - Class representing AccountKeyFail.
+ * @property {typeof AccountKeyWeightedMultiSig} accountKeyWeightedMultiSig - Class representing AccountKeyWeightedMultiSig.
+ * @property {typeof AccountKeyRoleBased} accountKeyRoleBased - Class representing AccountKeyRoleBased.
+ * @property {typeof WeightedPublicKey} weightedPublicKey - Class representing WeightedPublicKey.
  */
 /**
  * @example


### PR DESCRIPTION
## Proposed changes

This PR introduces adding `Account.AccountKey` typedef for jsdoc and also fixed wrong description.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
