### PR TITLE
Added logic to handle BigNumber at toBuffer and change isHumanReadable field to type

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -36,14 +36,6 @@ const Iban = require('../iban')
 const SignatureData = require('../../caver-wallet/src/keyring/signatureData')
 
 /**
- * The util module.
- * @module utils
- *
- * @example
- * caver.utils
- */
-
-/**
  * Fires an error in an event emitter and callback and returns the eventemitter
  *
  * @method _fireError
@@ -481,6 +473,13 @@ const decodeSignature = signature => {
     return new SignatureData(ret)
 }
 
+/**
+ * The util module.
+ * @module utils
+ *
+ * @example
+ * caver.utils
+ */
 module.exports = {
     _fireError: _fireError,
     _jsonInterfaceMethodToString: _jsonInterfaceMethodToString,
@@ -510,6 +509,7 @@ module.exports = {
 
     BN: utils.BN,
     isBN: utils.isBN,
+    BigNumber: utils.BigNumber,
     isBigNumber: utils.isBigNumber,
     isHex: utils.isHex,
     isHexStrict: utils.isHexStrict,
@@ -598,4 +598,7 @@ module.exports = {
     publicKeyToAddress: utils.publicKeyToAddress,
 
     decodeSignature: decodeSignature,
+
+    isBloom: utils.isBloom,
+    isTopic: utils.isTopic,
 }

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -712,7 +712,7 @@ const isKlaytnWalletKey = privateKey => {
                 if (splited[i].length !== 64 || !isValidPrivateKey(splited[i])) return false
                 break
             case 1:
-                if (splited[i].length !== 2 || (splited[i] !== '00' && splited[i] !== '01')) return false
+                if (splited[i].length !== 2 || splited[i] !== '00') return false
                 break
             case 2:
                 if (splited[i].length !== 40 || !isAddress(splited[i])) return false

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -626,16 +626,28 @@ const sha3 = function(value) {
 sha3._Hash = Hash
 
 /**
+ * An object defines the AccountKeyLegacy.
+ *
+ * @example
+ * { privateKey: '0x{private key}', address: '0x{address in hex}', type: '0x00' }
+ *
+ * @typedef {object} module:utils.ParsedPrivateKey
+ * @property {string} privateKey - The private key string.
+ * @property {string} address - The address string.
+ * @property {string} type - The type string. Currently only `0x00` is supported.
+ */
+/**
  * Parses private key string to { privateKey, address, type }.
  *
  * @example
- * const hash = caver.utils.sha3('234')
+ * const { privateKey, address, type } = caver.utils.parsePrivateKey('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
+ * const { privateKey, address, type } = caver.utils.parsePrivateKey('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d80x000xa94f5374fce5edbc8e2a8697c15331677e6ebf0b')
  *
  * @memberof module:utils
  * @inner
  *
- * @param {string} str - A string to hash.
- * @return {string} The result hash.
+ * @param {string} privateKey - A private key or KlaytnWalletKey string to parse.
+ * @return {module:utils.ParsedPrivateKey} A parsed private key object.
  */
 function parsePrivateKey(privateKey) {
     if (typeof privateKey !== 'string') throw new Error('The private key must be of type string')

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -1089,6 +1089,7 @@ const publicKeyToAddress = publicKey => {
 
 module.exports = {
     BN: BN,
+    BigNumber: BigNumber,
     isBN: isBN,
     isBigNumber: isBigNumber,
     toBN: toBN,

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -674,7 +674,7 @@ function parsePrivateKey(privateKey) {
     }
 
     const type = privateKey.slice(66, 68)
-    if (type === '01') throw new Error('Invalid type: Currently only type `0x00` is supported.')
+    if (type !== '00') throw new Error('Invalid type: Currently only type `0x00` is supported.')
 
     if (!isKlaytnWalletKey(privateKey)) throw new Error(`Invalid KlaytnWalletKey format.`)
 

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -673,10 +673,11 @@ function parsePrivateKey(privateKey) {
         }
     }
 
-    if (!isKlaytnWalletKey(privateKey)) throw new Error(`Invalid KlaytnWalletKey format.`)
-
     const type = privateKey.slice(66, 68)
     if (type === '01') throw new Error('Invalid type: Currently only type `0x00` is supported.')
+
+    if (!isKlaytnWalletKey(privateKey)) throw new Error(`Invalid KlaytnWalletKey format.`)
+
     const parsedAddress = privateKey.slice(68)
     return {
         privateKey: `0x${parsedPrivateKey}`,

--- a/test/accountLib.js
+++ b/test/accountLib.js
@@ -57,7 +57,7 @@ describe('caver.klay.accounts.privateKeyToAccount', () => {
             caver.klay.accounts.privateKeyToAccount(
                 '0x600dfc414fe433881f6606c24955e4143df9d203ccb3e335efe970a4ad017d040x010x6a61736d696e652e6b6c6179746e000000000000'
             )
-        ).to.throw('HumanReadableAddress is not supported yet.')
+        ).to.throw('Invalid type: Currently only type `0x00` is supported.')
     })
 })
 

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -1049,6 +1049,13 @@ describe('caver.utils.toBuffer', () => {
         expect(caver.utils.toBuffer(new BN('377', 8)).toString('hex')).to.deep.equal('ff')
         expect(caver.utils.toBuffer(new BN('11111111', 2)).toString('hex')).to.deep.equal('ff')
     })
+    it('CAVERJS-UNIT-ETC-395: caver.utils.toBuffer should convert BN to buffer', () => {
+        expect(caver.utils.toBuffer(new caver.utils.BigNumber(1))).to.deep.equal(Buffer.from([1]))
+        expect(caver.utils.toBuffer(new caver.utils.BigNumber(255)).toString('hex')).to.deep.equal('ff')
+        expect(caver.utils.toBuffer(new caver.utils.BigNumber('ff', 16)).toString('hex')).to.deep.equal('ff')
+        expect(caver.utils.toBuffer(new caver.utils.BigNumber('377', 8)).toString('hex')).to.deep.equal('ff')
+        expect(caver.utils.toBuffer(new caver.utils.BigNumber('11111111', 2)).toString('hex')).to.deep.equal('ff')
+    })
     it('CAVERJS-UNIT-ETC-152: caver.utils.toBuffer should convert Object has toArray function to buffer', () => {
         expect(
             caver.utils.toBuffer({
@@ -1623,30 +1630,32 @@ describe('caver.utils.isKlaytnWalletKey', () => {
 })
 
 describe('caver.utils.parsePrivateKey', () => {
-    it('CAVERJS-UNIT-ETC-198: should return parsed private key, address and isHumanReadable when key parameter is single private key string', () => {
+    it('CAVERJS-UNIT-ETC-198: should return parsed private key, address and type when key parameter is single private key string', () => {
         const key = '0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8'
 
         const parsed = caver.utils.parsePrivateKey(key)
 
         expect(parsed.privateKey).to.be.equals(key)
         expect(parsed.address).to.be.equals('')
-        expect(parsed.isHumanReadable).to.be.false
+        expect(parsed.isHumanReadable).to.be.undefined
+        expect(parsed.type).to.be.equals('')
     })
 
-    it('CAVERJS-UNIT-ETC-199: should return parsed private key, address and isHumanReadable when key parameter is in format of KlaytnWalletKey', () => {
+    it('CAVERJS-UNIT-ETC-199: should return parsed private key, address and type when key parameter is in format of KlaytnWalletKey', () => {
         const key = '0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d80x000xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'
 
         const parsed = caver.utils.parsePrivateKey(key)
 
         expect(parsed.privateKey).to.be.equals('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
         expect(parsed.address).to.be.equals('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b')
-        expect(parsed.isHumanReadable).to.be.false
+        expect(parsed.isHumanReadable).to.be.undefined
+        expect(parsed.type).to.be.equals('0x00')
     })
 
-    it('CAVERJS-UNIT-ETC-200: should throw error when humanReadable flag is true', () => {
+    it('CAVERJS-UNIT-ETC-200: should throw error when type is not 00', () => {
         const key = '0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d80x010xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'
 
-        const expectedError = 'HumanReadableAddress is not supported yet.'
+        const expectedError = 'Invalid type: Currently only type `0x00` is supported.'
 
         expect(() => caver.utils.parsePrivateKey(key)).to.throws(expectedError)
     })

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -1583,7 +1583,7 @@ describe('caver.utils.isKlaytnWalletKey', () => {
         isKlaytnWalletKey = caver.utils.isKlaytnWalletKey(key)
         expect(isKlaytnWalletKey).to.be.false
 
-        // without '0x' for human readable
+        // without '0x' for type
         key = '0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8000xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'
         isKlaytnWalletKey = caver.utils.isKlaytnWalletKey(key)
         expect(isKlaytnWalletKey).to.be.false


### PR DESCRIPTION
## Proposed changes

This PR introduces Adding logic to handle BigNumber at toBuffer and change isHumanReadable field to type.
The `parsePrivateKey` function was not added to the Klaytn Docs because this was for inside usage, so compatibility will not be an big issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
