### PR TITLE
Added logic to handle 0X as a hex prefix

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -502,7 +502,7 @@ function _flattenTypes(includeTuple, puts) {
  */
 const isHexPrefixed = function(str) {
     if (typeof str !== 'string') return false
-    return str.slice(0, 2) === '0x'
+    return str.slice(0, 2) === '0x' || str.slice(0, 2) === '0X'
 }
 
 /**
@@ -521,7 +521,7 @@ const isHexPrefixed = function(str) {
 const addHexPrefix = function(str) {
     if (typeof str !== 'string') return str
 
-    return isHexPrefixed(str) ? str : `0x${str}`
+    return isHexPrefixed(str) ? `0x${str.slice(2)}` : `0x${str}`
 }
 
 /**

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -1005,7 +1005,9 @@ describe('CAVERJS-UNIT-ETC-144: caver.utils.toTwosComplement', () => {
 describe('CAVERJS-UNIT-ETC-145: caver.utils.isHexPrefixed', () => {
     it('caver.utils.isHexPrefixed should return boolean depends on parameter', () => {
         expect(caver.utils.isHexPrefixed('0x')).to.be.true
+        expect(caver.utils.isHexPrefixed('0X')).to.be.true
         expect(caver.utils.isHexPrefixed('0x0x')).to.be.true
+        expect(caver.utils.isHexPrefixed('0X0x')).to.be.true
         expect(caver.utils.isHexPrefixed('01')).to.be.false
         expect(caver.utils.isHexPrefixed({})).to.be.false
     })
@@ -1014,6 +1016,7 @@ describe('CAVERJS-UNIT-ETC-145: caver.utils.isHexPrefixed', () => {
 describe('CAVERJS-UNIT-ETC-146: caver.utils.addHexPrefix', () => {
     it('caver.utils.addHexPrefix should return 0x hex format string', () => {
         expect(caver.utils.addHexPrefix('0x')).to.equals('0x')
+        expect(caver.utils.addHexPrefix('0X')).to.equals('0x')
         expect(caver.utils.addHexPrefix('01')).to.equals('0x01')
         expect(caver.utils.addHexPrefix('x')).to.equals('0xx')
         expect(typeof caver.utils.addHexPrefix({})).to.equals('object')
@@ -1023,9 +1026,12 @@ describe('CAVERJS-UNIT-ETC-146: caver.utils.addHexPrefix', () => {
 describe('CAVERJS-UNIT-ETC-147: caver.utils.stripHexPrefix', () => {
     it('caver.utils.stripHexPrefix should strip 0x prefix and return string', () => {
         expect(caver.utils.stripHexPrefix('0x')).to.equals('')
+        expect(caver.utils.stripHexPrefix('0X')).to.equals('')
         expect(caver.utils.stripHexPrefix('01')).to.equals('01')
         expect(caver.utils.stripHexPrefix('0x01')).to.equals('01')
+        expect(caver.utils.stripHexPrefix('0X01')).to.equals('01')
         expect(caver.utils.stripHexPrefix('0xx')).to.equals('x')
+        expect(caver.utils.stripHexPrefix('0Xx')).to.equals('x')
         expect(typeof caver.utils.stripHexPrefix({})).to.equals('object')
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces modification hex prefix handling logic with `caver.utils.isHexParameter`, `caver.utils.addHexPrefix` and `caver.utils.stripHexPrefix`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
