### PR TITLE
Added validation logic in utils and isEqual function in SignatureData

### DIFF
--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -318,13 +318,21 @@ const unitKlayToEthMap = {
     TKLAY: 'tether',
 }
 
-const getKlayUnitValue = function(unit) {
-    unit = unit || 'KLAY'
+const getKlayUnitValue = function(u) {
+    unit = u || 'KLAY'
+
+    if (_.isObject(u) && u.unit) unit = u.unit
+
     if (!unitKlayMap[unit]) {
         throw new Error(
             `This unit "${unit}" doesn't exist, please use the one of the following units${JSON.stringify(unitKlayMap, null, 2)}`
         )
     }
+
+    if (u.pebFactor !== undefined && KlayUnit[u.unit].pebFactor !== u.pebFactor) {
+        throw new Error(`peb factor does not match with given unit`)
+    }
+
     return unit
 }
 
@@ -378,7 +386,6 @@ const toPeb = function(number, unit) {
  * @return {string} The string number.
  */
 const convertFromPeb = function(amount, unitString) {
-    if (_.isObject(unitString) && unitString.unit) unitString = unitString.unit
     const converted = fromPeb(amount, unitString)
     return utils.isBN(converted) ? converted.toString(10) : converted
 }
@@ -400,7 +407,6 @@ const convertFromPeb = function(amount, unitString) {
  * @return {string|BN}
  */
 const convertToPeb = function(number, unitString) {
-    if (_.isObject(unitString) && unitString.unit) unitString = unitString.unit
     const converted = toPeb(number, unitString)
     return utils.isBN(converted) ? converted.toString(10) : converted
 }
@@ -555,6 +561,9 @@ const stripHexPrefix = function(str) {
  * @return {SignatureData}
  */
 const decodeSignature = signature => {
+    if (Buffer.byteLength(stripHexPrefix(signature), 'hex') !== 65)
+        throw new Error(`Invalid signature: The length of raw signature must be 65 byte.`)
+
     const ret = Account.decodeSignature(signature).map(sig => utils.makeEven(utils.trimLeadingZero(sig)))
     return new SignatureData(ret)
 }

--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -319,7 +319,7 @@ const unitKlayToEthMap = {
 }
 
 const getKlayUnitValue = function(u) {
-    unit = u || 'KLAY'
+    let unit = u || 'KLAY'
 
     if (_.isObject(u) && u.unit) unit = u.unit
 

--- a/packages/caver-utils/src/index.js
+++ b/packages/caver-utils/src/index.js
@@ -329,7 +329,7 @@ const getKlayUnitValue = function(u) {
         )
     }
 
-    if (u.pebFactor !== undefined && KlayUnit[u.unit].pebFactor !== u.pebFactor) {
+    if (u && u.pebFactor !== undefined && KlayUnit[u.unit].pebFactor !== u.pebFactor) {
         throw new Error(`peb factor does not match with given unit`)
     }
 

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -1453,13 +1453,16 @@ const recover = (message, signature, isHashed = false) => {
  * @inner
  *
  * @method publicKeyToAddress
- * @param {string} publicKey The public key string to get the address.
+ * @param {string} pubKey The public key string to get the address.
  * @return {string}
  */
-const publicKeyToAddress = publicKey => {
-    publicKey = publicKey.slice(0, 2) === '0x' ? publicKey : `0x${publicKey}`
+const publicKeyToAddress = pubKey => {
+    let publicKey = pubKey.slice(0, 2) === '0x' ? pubKey : `0x${pubKey}`
 
     if (isCompressedPublicKey(publicKey)) publicKey = decompressPublicKey(publicKey)
+
+    // With '0x' prefix, 65 bytes in uncompressed format.
+    if (Buffer.byteLength(publicKey, 'hex') !== 65) throw new Error(`Invalid public key: ${pubKey}`)
 
     const publicHash = Hash.keccak256(publicKey)
     const address = `0x${publicHash.slice(-40)}`

--- a/packages/caver-wallet/src/keyring/signatureData.js
+++ b/packages/caver-wallet/src/keyring/signatureData.js
@@ -162,6 +162,20 @@ class SignatureData {
     toString() {
         return this.v + this.r + this.s
     }
+
+    /**
+     * Checks that the signature data is the same.
+     *
+     * @example
+     * const isEqual = signatureData.isEqual([ '0x1b', '0xc6901...', '0x642d8...' ])
+     *
+     * @param {Array.<string>|SignatureData} sig - The ECDSA signatureData to compare
+     * @return {boolean}
+     */
+    isEqual(sig) {
+        sig = new SignatureData(sig)
+        return this.toString() === sig.toString()
+    }
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

This PR introduces adding some validation logic to test with conformance TC.

And the reason for deleting the line `if (_.isObject(unitString) && unitString.unit) unitString = unitString.unit` is that the `convertToPeb` and `convertFromPeb` functions call the `toPeb` and `fromPeb` functions.
Since each function calls `getKlayUnitValue` internally, duplicate logic was removed by adding validation logic to `getKlayUnitValue` and changing it to be verified together.

And also i added `isEqual` function in `SignatureData` to compare signature easily.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
