### PR TITLE
Removed isWriteThroughCaching

### DIFF
--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -1933,24 +1933,6 @@ class Klay {
                 call: 'klay_rewardbase',
                 params: 0,
             }),
-            /**
-             * Returns `true` if the node is using writeThroughCaching.
-             *
-             * @memberof Klay
-             * @method isWriteThroughCaching
-             * @instance
-             *
-             * @example
-             * const result = await caver.rpc.klay.isWriteThroughCaching()
-             *
-             * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
-             * @return {Promise<boolean>} `true` means the node is using write-through caching.
-             */
-            new Method({
-                name: 'isWriteThroughCaching',
-                call: 'klay_writeThroughCaching',
-                params: 0,
-            }),
 
             // Filter
             /**


### PR DESCRIPTION
## Proposed changes

This PR introduces removing isWriteThroughCaching because Klaytn Node rpc does not support `klay_writeThroughCaching` anymore.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
