### PR TITLE
When creating an instance of a subclass, use the requestManager of the upperclass.

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,14 +135,7 @@ function Caver(provider, net) {
     const Contract = function Contract() {
         BaseContract.apply(this, arguments)
 
-        // when caver.setProvider is called, call 'packageInit' all contract instances instantiated via this Caver instances.
-        // This will update the currentProvider for the contract instances
-        const _this = this // eslint-disable-line no-shadow
-        const setProvider = self.setProvider // eslint-disable-line no-shadow
-        self.setProvider = function() {
-            setProvider.apply(self, arguments)
-            core.packageInit(_this, [self])
-        }
+        core.packageInit(this, [self])
         this.setWallet(self.wallet)
     }
 

--- a/packages/caver-core/src/index.js
+++ b/packages/caver-core/src/index.js
@@ -33,7 +33,19 @@ module.exports = {
         // make property of pkg._provider, which can properly set providers
         Object.defineProperty(pkg, 'currentProvider', {
             get: function() {
-                return pkg._provider
+                return pkg._requestManager.provider
+            },
+            set: function(value) {
+                return pkg.setProvider(value)
+            },
+            enumerable: true,
+            configurable: true,
+        })
+
+        // make property of pkg._provider, which can properly set providers
+        Object.defineProperty(pkg, '_provider', {
+            get: function() {
+                return pkg._requestManager.provider
             },
             set: function(value) {
                 return pkg.setProvider(value)
@@ -50,20 +62,17 @@ module.exports = {
         }
 
         pkg.providers = Manager.providers
-        pkg._provider = pkg._requestManager.provider
 
         // add SETPROVIDER function (don't overwrite if already existing)
         if (!pkg.setProvider) {
             pkg.setProvider = function(provider, net) {
                 pkg._requestManager.setProvider(provider, net)
-                pkg._provider = pkg._requestManager.provider
                 return true
             }
         }
 
         pkg.setRequestManager = function(manager) {
             pkg._requestManager = manager
-            pkg._provider = manager.provider
         }
 
         // attach batch request creation

--- a/packages/caver-kct/src/index.js
+++ b/packages/caver-kct/src/index.js
@@ -147,13 +147,7 @@ class KCT {
              */
             constructor(tokenAddress, abi) {
                 super(tokenAddress, abi)
-                const self = this // eslint-disable-line no-shadow
-                const setRequestManager = _this.setRequestManager // eslint-disable-line no-shadow
-                _this.setRequestManager = function() {
-                    setRequestManager.apply(_this, arguments)
-                    core.packageInit(self, [_this])
-                }
-
+                core.packageInit(this, [_this])
                 this.setWallet(args[0].wallet)
             }
         }
@@ -230,13 +224,7 @@ class KCT {
              */
             constructor(tokenAddress, abi) {
                 super(tokenAddress, abi)
-                const self = this // eslint-disable-line no-shadow
-                const setRequestManager = _this.setRequestManager // eslint-disable-line no-shadow
-                _this.setRequestManager = function() {
-                    setRequestManager.apply(_this, arguments)
-                    core.packageInit(self, [_this])
-                }
-
+                core.packageInit(this, [_this])
                 this.setWallet(args[0].wallet)
             }
         }

--- a/packages/caver-klay/src/index.js
+++ b/packages/caver-klay/src/index.js
@@ -145,17 +145,7 @@ const Klay = function Klay(...args) {
     const self = this
     const Contract = function Contract() {
         BaseContract.apply(this, arguments)
-
-        // when Klay.setProvider is called, call packageInit
-        // on all contract instances instantiated via this Klay
-        // instances. This will update the currentProvider for
-        // the contract instances
-        const _this = this // eslint-disable-line no-shadow
-        const setProvider = self.setProvider // eslint-disable-line no-shadow
-        self.setProvider = function() {
-            setProvider.apply(self, arguments)
-            core.packageInit(_this, [self])
-        }
+        core.packageInit(this, [self])
     }
 
     Contract.setProvider = function() {

--- a/test/setRequestManager.js
+++ b/test/setRequestManager.js
@@ -61,4 +61,65 @@ describe('setRequestManager', () => {
         expect(contract.currentProvider).to.deep.equals(newProvider)
         expect(caver.klay.currentProvider).to.deep.equals(newProvider)
     })
+
+    it('CAVERJS-UNIT-ETC-396: should set requestManager and provider well with all instances', () => {
+        const originalProvider = new Caver.providers.HttpProvider(testRPCURL)
+        const caver = new Caver(originalProvider)
+
+        expect(caver._provider).to.deep.equals(originalProvider)
+        expect(caver._requestManager.provider).to.deep.equals(originalProvider)
+        expect(caver.currentProvider).to.deep.equals(originalProvider)
+
+        const contractLegacy = new caver.klay.Contract(kip7JsonInterface)
+        const contract = new caver.contract(kip7JsonInterface)
+        const kip7 = new caver.kct.kip7()
+        const kip17 = new caver.kct.kip7()
+
+        expect(caver.klay.currentProvider).to.deep.equals(caver._provider)
+        expect(caver.kct.currentProvider).to.deep.equals(caver._provider)
+        expect(contractLegacy.currentProvider).to.deep.equals(caver._provider)
+        expect(contract.currentProvider).to.deep.equals(caver._provider)
+        expect(kip7.currentProvider).to.deep.equals(caver._provider)
+        expect(kip17.currentProvider).to.deep.equals(caver._provider)
+
+        expect(caver.klay._requestManager).to.deep.equals(caver._requestManager)
+        expect(caver.kct._requestManager).to.deep.equals(caver._requestManager)
+        expect(contractLegacy._requestManager).to.deep.equals(caver._requestManager)
+        expect(contract._requestManager).to.deep.equals(caver._requestManager)
+        expect(kip7._requestManager).to.deep.equals(caver._requestManager)
+        expect(kip17._requestManager).to.deep.equals(caver._requestManager)
+
+        expect(caver.klay._provider).to.deep.equals(caver._provider)
+        expect(caver.kct._provider).to.deep.equals(caver._provider)
+        expect(contractLegacy._provider).to.deep.equals(caver._provider)
+        expect(contract._provider).to.deep.equals(caver._provider)
+        expect(kip7._provider).to.deep.equals(caver._provider)
+        expect(kip17._provider).to.deep.equals(caver._provider)
+
+        const newProvider = new Caver.providers.HttpProvider('http://localhost:8551/')
+        caver.setProvider(newProvider)
+
+        expect(caver._provider).to.deep.equals(newProvider)
+
+        expect(caver.klay.currentProvider).to.deep.equals(caver._provider)
+        expect(caver.kct.currentProvider).to.deep.equals(caver._provider)
+        expect(contractLegacy.currentProvider).to.deep.equals(caver._provider)
+        expect(contract.currentProvider).to.deep.equals(caver._provider)
+        expect(kip7.currentProvider).to.deep.equals(caver._provider)
+        expect(kip17.currentProvider).to.deep.equals(caver._provider)
+
+        expect(caver.klay._requestManager).to.deep.equals(caver._requestManager)
+        expect(caver.kct._requestManager).to.deep.equals(caver._requestManager)
+        expect(contractLegacy._requestManager).to.deep.equals(caver._requestManager)
+        expect(contract._requestManager).to.deep.equals(caver._requestManager)
+        expect(kip7._requestManager).to.deep.equals(caver._requestManager)
+        expect(kip17._requestManager).to.deep.equals(caver._requestManager)
+
+        expect(caver.klay._provider).to.deep.equals(caver._provider)
+        expect(caver.kct._provider).to.deep.equals(caver._provider)
+        expect(contractLegacy._provider).to.deep.equals(caver._provider)
+        expect(contract._provider).to.deep.equals(caver._provider)
+        expect(kip7._provider).to.deep.equals(caver._provider)
+        expect(kip17._provider).to.deep.equals(caver._provider)
+    })
 })


### PR DESCRIPTION
## Proposed changes

An issue was reported that a memory leak occurs when using `caver.kct.kip17`.
This is the same problem that exists in the contract of web3.js.

Actually, the modified part in [this PR](https://github.com/ChainSafe/web3.js/pull/3866) is the problematic code, but if I fix it like that, the function added in the setProvider of the upper class is missing, and it does not apply even when multiple instances are created, so I had to find another way.

In `core.packageInit`, the requestManager of the received upper class is assigned to the requestManager of the corresponding class, and `_provider` and `currentProvider` are defined as Object.defineProperty so that the provider of requestManager can be viewed.
With this modification, since the same RequestManager object is viewed, if the provider of the upper requestManager is changed, the requestManager, provider, and currentProvider of the instances of the lower class all have the changed provider.

It was confirmed that there was no memory leak, and I ran all tests because of possible side effects, but no error occurred.
If you have any concerns about this PR, please leave a comment.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer https://github.com/klaytn/caver-js/issues/523

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
