### PR TITLE
Added validation logic for big number type

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -379,7 +379,7 @@ const numberToHex = function(value) {
         const bn = toBN(value)
         try {
             bn.toNumber()
-        } catch(e) {
+        } catch (e) {
             throw new Error(`${e.message}: Number type cannot handle big number. Please use hex string or BigNumber/BN.`)
         }
     }

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -375,6 +375,15 @@ const hexToNumberString = function(value) {
  * @return {string} The HEX value of the given number.
  */
 const numberToHex = function(value) {
+    if (_.isNumber(value)) {
+        const bn = toBN(value)
+        try {
+            bn.toNumber()
+        } catch(e) {
+            throw new Error(`${e.message}: Number type cannot handle big number. Please use hex string or BigNumber/BN.`)
+        }
+    }
+
     if (_.isNull(value) || _.isUndefined(value)) {
         return value
     }

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -703,8 +703,9 @@ describe('caver.utils.numberToHex', () => {
 
     context('CAVERJS-UNIT-ETC-397: input: number that Number type cannot handle', () => {
         it('should throw an error', () => {
-            const expectedErrorMsg = 'Error: Number can only safely store up to 53 bits: Number type cannot handle big number. Please use hex string or BigNumber/BN.'
-            
+            const expectedErrorMsg =
+                'Error: Number can only safely store up to 53 bits: Number type cannot handle big number. Please use hex string or BigNumber/BN.'
+
             let invalid = 0x303f3b2c93f1a7ffff
             expect(() => caver.utils.numberToHex(invalid)).to.throw(expectedErrorMsg)
 

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -700,6 +700,18 @@ describe('caver.utils.numberToHex', () => {
             expect(() => caver.utils.numberToHex(invalid)).to.throw(errorMessage)
         })
     })
+
+    context('CAVERJS-UNIT-ETC-397: input: number that Number type cannot handle', () => {
+        it('should throw an error', () => {
+            const expectedErrorMsg = 'Error: Number can only safely store up to 53 bits: Number type cannot handle big number. Please use hex string or BigNumber/BN.'
+            
+            let invalid = 0x303f3b2c93f1a7ffff
+            expect(() => caver.utils.numberToHex(invalid)).to.throw(expectedErrorMsg)
+
+            invalid = 889999999999999999999
+            expect(() => caver.utils.numberToHex(invalid)).to.throw(expectedErrorMsg)
+        })
+    })
 })
 
 describe('caver.utils.hexToUtf8', () => {

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -704,7 +704,7 @@ describe('caver.utils.numberToHex', () => {
     context('CAVERJS-UNIT-ETC-397: input: number that Number type cannot handle', () => {
         it('should throw an error', () => {
             const expectedErrorMsg =
-                'Error: Number can only safely store up to 53 bits: Number type cannot handle big number. Please use hex string or BigNumber/BN.'
+                'Number can only safely store up to 53 bits: Number type cannot handle big number. Please use hex string or BigNumber/BN.'
 
             let invalid = 0x303f3b2c93f1a7ffff
             expect(() => caver.utils.numberToHex(invalid)).to.throw(expectedErrorMsg)


### PR DESCRIPTION
## Proposed changes

This PR introduces adding validation logic for valid number type.
If number type variable is too big to handle by Number type in javascript, return an error.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
