### PR TITLE
Allows not define key when does not have to

### DIFF
--- a/packages/caver-core-helpers/src/formatters.js
+++ b/packages/caver-core-helpers/src/formatters.js
@@ -263,8 +263,8 @@ const inputAccountKeyFormatter = function(accountKey) {
         return { keyType: 5, key }
     }
 
-    const keyTypesWithoutKeyDefinition = [ 1, 3 ] // AccountKeyLegacy, AccountKeyFail
-    if (accountKey.keyType === undefined || (accountKey.key === undefined && !keyTypesWithoutKeyDefinition.includes(accountKey.keyType) )) {
+    const keyTypesWithoutKeyDefinition = [1, 3] // AccountKeyLegacy, AccountKeyFail
+    if (accountKey.keyType === undefined || (accountKey.key === undefined && !keyTypesWithoutKeyDefinition.includes(accountKey.keyType))) {
         throw new Error(`AccountKey obejct should define 'keyType' and 'key'`)
     }
 


### PR DESCRIPTION
## Proposed changes

Allows undefined `key` when keyType is `AccountKeyLegacy` or `AccountKeyFail` 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
