### PR TITLE
Fixed set options in the loop

### DIFF
--- a/packages/caver-account/src/accountKey/accountKeyHelper.js
+++ b/packages/caver-account/src/accountKey/accountKeyHelper.js
@@ -66,7 +66,7 @@ const fillWeightedMultiSigOptionsForRoleBased = (lengthOfKeys, options = []) => 
 
     for (let i = 0; i < lengthOfKeys.length; i++) {
         if (options[i] && !(options[i] instanceof WeightedMultiSigOptions)) {
-            options[i] = WeightedMultiSigOptions.fromObject(options)
+            options[i] = WeightedMultiSigOptions.fromObject(options[i])
         }
         // If the WeightedMultiSigOptions instance is not empty,
         // it means that the user has defined the option parameters needed when updating to AccountKeyWeightedMultiSig.

--- a/test/packages/caver.wallet.keyring.js
+++ b/test/packages/caver.wallet.keyring.js
@@ -1644,6 +1644,22 @@ describe('keyring.toAccount', () => {
         })
     })
 
+    context('CAVERJS-UNIT-KEYRING-170: keyring type: roleBased / options: array of the object', () => {
+        it('return account instance which has AccountKeyRoleBased with weightedMultiSigOptions instances', () => {
+            const account = roleBased.toAccount([
+                { threshold: 3, weights: [2, 2] },
+                { threshold: 4, weights: [2, 2] },
+                { threshold: 5, weights: [1, 2, 3, 3] },
+            ])
+            const exepectedOptions = [
+                new caver.account.weightedMultiSigOptions(3, [2, 2]),
+                new caver.account.weightedMultiSigOptions(4, [2, 2]),
+                new caver.account.weightedMultiSigOptions(5, [1, 2, 3, 3]),
+            ]
+            validateAccount(account, { keyring: roleBased, expectedAccountKey: 'AccountKeyRoleBased', exepectedOptions })
+        })
+    })
+
     context('CAVERJS-UNIT-KEYRING-128: keyring type: roleBased / options: defined(not array format)', () => {
         it('should throw error when options is insufficient', () => {
             const options = new caver.account.weightedMultiSigOptions(5, [2, 3, 4])


### PR DESCRIPTION
## Proposed changes

This PR introduces fixing `fillWeightedMultiSigOptionsForRoleBased` to create an instance when an element is not 
`WeightedMultiSigOptions`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
