### PR TITLE
Fix hexToNumber and hexToNumberString prefix validation

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -338,6 +338,11 @@ const hexToUtf8 = function(hex) {
  */
 const hexToNumber = function(value) {
     if (!value) return value
+
+    if (typeof value === 'string' && !isHexStrict(value)) {
+        throw new Error(`Given value "${value}" is not a valid hex string.`)
+    }
+
     return toBN(value).toNumber()
 }
 
@@ -355,6 +360,10 @@ const hexToNumber = function(value) {
  */
 const hexToNumberString = function(value) {
     if (!value) return value
+
+    if (_.isString(value) && !isHexStrict(value)) {
+        throw new Error(`Given value "${value}" is not a valid hex string.`)
+    }
 
     return toBN(value).toString(10)
 }

--- a/test/packages/caver.utils.js
+++ b/test/packages/caver.utils.js
@@ -641,11 +641,10 @@ describe('caver.utils.hexToNumberString', () => {
     })
 
     context('CAVERJS-UNIT-ETC-121: input: numberString', () => {
-        const tests = [{ value: '1234', expected: (1234).toString() }]
-        it('should return numberString', () => {
-            for (const test of tests) {
-                expect(caver.utils.hexToNumberString(test.value)).to.be.equal(test.expected)
-            }
+        it('should throw an error', () => {
+            const invalid = '1234'
+            const errorMessage = `Given value "${invalid}" is not a valid hex string.`
+            expect(() => caver.utils.hexToNumberString(invalid)).to.throw(errorMessage)
         })
     })
 
@@ -665,7 +664,7 @@ describe('caver.utils.hexToNumberString', () => {
     context('CAVERJS-UNIT-ETC-123: input: invalid hexString', () => {
         it('should throw an error', () => {
             const invalid = 'zzzz'
-            const errorMessage = `Error: [number-to-bn] while converting number "${invalid}" to BN.js instance, error: invalid number value. Value must be an integer, hex string, BN or BigNumber instance. Note, decimals are not supported. Given value: "${invalid}"`
+            const errorMessage = `Given value "${invalid}" is not a valid hex string.`
             expect(() => caver.utils.hexToNumberString(invalid)).to.throw(errorMessage)
         })
     })
@@ -676,7 +675,6 @@ describe('caver.utils.hexToNumber', () => {
     context('CAVERJS-UNIT-ETC-124: input: valid value', () => {
         const tests = [
             { value: 1234, expected: 1234 },
-            { value: '1234', expected: 1234 },
             { value: 0x1234, expected: 4660 },
             { value: 0xea, expected: 234 },
             { value: '0xea', expected: 234 },
@@ -690,9 +688,13 @@ describe('caver.utils.hexToNumber', () => {
 
     context('CAVERJS-UNIT-ETC-125: input: invalid value', () => {
         it('should throw an error', () => {
-            const invalid = 'zzzz'
-            const errorMessage = `Error: [number-to-bn] while converting number "${invalid}" to BN.js instance, error: invalid number value. Value must be an integer, hex string, BN or BigNumber instance. Note, decimals are not supported. Given value: "${invalid}"`
-            expect(() => caver.utils.hexToNumber(invalid)).to.throw(errorMessage)
+            let invalid = '1234'
+            let errorMessage = `Given value "${invalid}" is not a valid hex string.`
+            expect(() => caver.utils.hexToBytes(invalid)).to.throw(errorMessage)
+
+            invalid = 'zzzz'
+            errorMessage = `Given value "${invalid}" is not a valid hex string.`
+            expect(() => caver.utils.hexToBytes(invalid)).to.throw(errorMessage)
         })
     })
 })


### PR DESCRIPTION
* Bugfix
* Allow compatibility
* Modify tests

## Proposed changes

- Throw error when argument of hexToNumber and hexToNumberString is not prefixed with 0x.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://forum.klaytn.com/t/caver-utils-hextonumber/2867/7
- https://github.com/klaytn/caver-js/issues/563

## Further comments
- Edit package.json for lint on windows

"lint": "./node_modules/.bin/eslint --ext .js .",
"lintFix": "./node_modules/.bin/eslint --fix --ext .js .",