### PR TITLE
Change wallet type in Caver class

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,7 +74,7 @@ export default class Caver {
     helpers: CoreHelpers
     Method: typeof Method
     account: typeof Account
-    wallet: IWallet
+    wallet: KeyringContainer
     transaction: Transaction
     kct: KCT
     klay: DeprecatedKlayRPC

--- a/types/test/caver-test.ts
+++ b/types/test/caver-test.ts
@@ -46,7 +46,7 @@ caver.formatters
 // $ExpectType CoreHelpers
 caver.helpers
 
-// $ExpectType IWallet
+// $ExpectType KeyringContainer
 caver.wallet
 
 // $ExpectType TransactionModule

--- a/types/test/wallet-test.ts
+++ b/types/test/wallet-test.ts
@@ -49,7 +49,7 @@ import { PrivateKey } from 'packages/caver-wallet/src/keyring/privateKey'
 
 const caver = new Caver()
 
-// $ExpectType IWallet
+// $ExpectType KeyringContainer
 caver.wallet
 
 // $ExpectType KeyringContainer


### PR DESCRIPTION
## Proposed changes

- I got type error when I used caver-js with TS.

![image](https://user-images.githubusercontent.com/50140505/150780229-cc8146dc-e872-4071-8864-78661ac6c7f4.png)

- There should be keyring type under `caver.wallet`. So I just changed type of wallet from `IWallet` to `KeyringContainer`. Fixed this, I can solve my typescript error.
- I also changed test files caver-test.ts, wallet-test.ts. Changed types, the test files also needed to change `ExpectType`

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

- I'm not sure why you need a KeyringContainer. It would also be nice to restructure the IWallet and KeryingContainer for naming clarity.