### PR TITLE
Modified type for Caver and Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caver-js",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "caver-js is a JavaScript API library that allows developers to interact with a Klaytn node",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,7 +60,7 @@ export interface Providers {
     IpcProvider: typeof IpcProvider
 }
 
-export default class Caver {
+export class AbstractCaver {
     static providers: Providers
     static utils: Utils
     static abi: ABI
@@ -83,4 +83,8 @@ export default class Caver {
     middleware: Middleware
     ipfs: IPFS
     contract: typeof Contract
+}
+
+export default class Caver extends AbstractCaver {
+    wallet: KeyringContainer
 }

--- a/types/packages/caver-wallet/src/index.d.ts
+++ b/types/packages/caver-wallet/src/index.d.ts
@@ -46,6 +46,7 @@ export class KeyringContainer implements IWallet {
     length: number
     keyring: KeyringFactory
 
+    generate(num: number): string[]
     generate(numberOfKeyrings: number, entropy?: string): string[]
     newKeyring(address: string, key: string): SingleKeyring
     newKeyring(address: string, key: string[]): MultipleKeyring
@@ -56,6 +57,7 @@ export class KeyringContainer implements IWallet {
     add(keyring: Keyring): Keyring
     remove(address: string): boolean
     signMessage(address: string, data: string, role: number, index?: number): SignedMessage
+    sign(address: string, transaction: Transaction): Promise<AbstractTransaction>
     sign(
         address: string,
         transaction: AbstractTransaction,
@@ -67,6 +69,7 @@ export class KeyringContainer implements IWallet {
         index: number,
         hasher?: (transaction: AbstractTransaction) => string
     ): Promise<AbstractTransaction>
+    signAsFeePayer(address: string, transaction: FeeDelegatedTransaction): Promise<AbstractFeeDelegatedTransaction>
     signAsFeePayer(
         address: string,
         transaction: AbstractFeeDelegatedTransaction,
@@ -78,4 +81,6 @@ export class KeyringContainer implements IWallet {
         index: number,
         hasher?: (transaction: AbstractFeeDelegatedTransaction) => string
     ): Promise<AbstractFeeDelegatedTransaction>
+    isExisted(address: string): boolean
+    remove(address: string): boolean
 }

--- a/types/test/caver-test.ts
+++ b/types/test/caver-test.ts
@@ -46,7 +46,7 @@ caver.formatters
 // $ExpectType CoreHelpers
 caver.helpers
 
-// $ExpectType IWallet
+// $ExpectType KeyringContainer
 caver.wallet
 
 // $ExpectType TransactionModule

--- a/types/test/wallet-test.ts
+++ b/types/test/wallet-test.ts
@@ -49,7 +49,7 @@ import { PrivateKey } from 'packages/caver-wallet/src/keyring/privateKey'
 
 const caver = new Caver()
 
-// $ExpectType IWallet
+// $ExpectType KeyringContainer
 caver.wallet
 
 // $ExpectType KeyringContainer


### PR DESCRIPTION
## Proposed changes

This PR introduces fixing type issue.
Because type of `caver.wallet` is `IWallet` in type file, user cannot access `caver.wallet.keyring` (included in KeyringContainer, not in IWallet).
So i separate AbstractCaver and Caver to set `wallet` property of Caver is `KeyringContainer`.

To make extension of Caver, you can extends `AbstractCaver`, not `Caver`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
