### PR TITLE
Remove gasPrice variable from AbstractTransaction

### DIFF
--- a/packages/caver-transaction/src/transactionHelper/transactionHelper.js
+++ b/packages/caver-transaction/src/transactionHelper/transactionHelper.js
@@ -329,10 +329,21 @@ const getCodeFormatTag = cf => {
     throw new Error(`Unsupported code format : ${cf}`)
 }
 
+/**
+ * Returns `true` value is undefined or null.
+ *
+ * @param {*} value - The value to check.
+ * @return {string}
+ */
+const isNot = function(value) {
+    return _.isUndefined(value) || _.isNull(value)
+}
+
 module.exports = {
     TX_TYPE_STRING,
     TX_TYPE_TAG,
     CODE_FORMAT,
+    isNot,
     refineSignatures,
     typeDetectionFromRLPEncoding,
     getCodeFormatTag,

--- a/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/abstractTransaction.js
@@ -43,6 +43,21 @@ const SignatureData = require('../../../caver-wallet/src/keyring/signatureData')
  * @abstract
  */
 class AbstractTransaction {
+    static async getChainId() {
+        const chainId = await AbstractTransaction._klaytnCall.getChainId()
+        return chainId
+    }
+
+    static async getGasPrice() {
+        const gasPrice = await AbstractTransaction._klaytnCall.getGasPrice()
+        return gasPrice
+    }
+
+    static async getNonce(from) {
+        const nonce = await AbstractTransaction._klaytnCall.getTransactionCount(from, 'pending')
+        return nonce
+    }
+
     /**
      * Abstract class that implements common logic for each transaction type.
      * In this constructor, type, tag, nonce, gasPrice, chainId, gas and signatures are set as transaction member variables.
@@ -65,7 +80,6 @@ class AbstractTransaction {
 
         // The variables below are values that the user does not need to pass to the parameter.
         if (createTxObj.nonce !== undefined) this.nonce = createTxObj.nonce
-        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
         if (createTxObj.chainId !== undefined) this.chainId = createTxObj.chainId
 
         this.signatures = createTxObj.signatures || []
@@ -117,17 +131,6 @@ class AbstractTransaction {
 
     set gas(g) {
         this._gas = utils.numberToHex(g)
-    }
-
-    /**
-     * @type {string}
-     */
-    get gasPrice() {
-        return this._gasPrice
-    }
-
-    set gasPrice(g) {
-        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -390,15 +393,7 @@ class AbstractTransaction {
      * await tx.fillTransaction()
      */
     async fillTransaction() {
-        const [chainId, gasPrice, nonce] = await Promise.all([
-            isNot(this.chainId) ? AbstractTransaction._klaytnCall.getChainId() : this.chainId,
-            isNot(this.gasPrice) ? AbstractTransaction._klaytnCall.getGasPrice() : this.gasPrice,
-            isNot(this.nonce) ? AbstractTransaction._klaytnCall.getTransactionCount(this.from, 'pending') : this.nonce,
-        ])
-
-        this.chainId = chainId
-        this.gasPrice = gasPrice
-        this.nonce = nonce
+        throw new Error(`Not implemented.`)
     }
 
     /**
@@ -408,8 +403,6 @@ class AbstractTransaction {
      * @ignore
      */
     validateOptionalValues() {
-        if (this.gasPrice === undefined)
-            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
         if (this.nonce === undefined)
             throw new Error(`nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
@@ -437,10 +430,6 @@ class AbstractTransaction {
 
         return { keyring, hash, role }
     }
-}
-
-const isNot = function(value) {
-    return _.isUndefined(value) || _.isNull(value)
 }
 
 module.exports = AbstractTransaction

--- a/packages/caver-transaction/src/transactionTypes/accountUpdate/accountUpdate.js
+++ b/packages/caver-transaction/src/transactionTypes/accountUpdate/accountUpdate.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const Account = require('../../../../caver-account/src')
 const utils = require('../../../../caver-utils/src')
 
@@ -88,6 +88,18 @@ class AccountUpdate extends AbstractTransaction {
 
         super(TX_TYPE_STRING.TxTypeAccountUpdate, createTxObj)
         this.account = createTxObj.account
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -151,6 +163,39 @@ class AccountUpdate extends AbstractTransaction {
             this.from.toLowerCase(),
             this.account.getRLPEncodingAccountKey(),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdate.js
+++ b/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdate.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 const Account = require('../../../../caver-account')
 
@@ -91,6 +92,18 @@ class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
 
         super(TX_TYPE_STRING.TxTypeFeeDelegatedAccountUpdate, createTxObj)
         this.account = createTxObj.account
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -157,6 +170,39 @@ class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
             this.from.toLowerCase(),
             this.account.getRLPEncodingAccountKey(),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdateWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdateWithRatio.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 const Account = require('../../../../caver-account')
 
@@ -93,6 +94,18 @@ class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWithRatioTr
 
         super(TX_TYPE_STRING.TxTypeFeeDelegatedAccountUpdateWithRatio, createTxObj)
         this.account = createTxObj.account
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -161,6 +174,39 @@ class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWithRatioTr
             this.account.getRLPEncodingAccountKey(),
             Bytes.fromNat(this.feeRatio),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/cancel/cancel.js
+++ b/packages/caver-transaction/src/transactionTypes/cancel/cancel.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -79,6 +79,18 @@ class Cancel extends AbstractTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeCancel, createTxObj)
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -125,6 +137,39 @@ class Cancel extends AbstractTransaction {
             Bytes.fromNat(this.gas),
             this.from.toLowerCase(),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancel.js
+++ b/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancel.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -81,6 +82,18 @@ class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedCancel, createTxObj)
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -130,6 +143,39 @@ class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
             Bytes.fromNat(this.gas),
             this.from.toLowerCase(),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancelWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancelWithRatio.js
@@ -19,7 +19,8 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
 const utils = require('../../../../caver-utils/src')
 
@@ -84,6 +85,18 @@ class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTransacti
     constructor(createTxObj) {
         if (_.isString(createTxObj)) createTxObj = _decode(createTxObj)
         super(TX_TYPE_STRING.TxTypeFeeDelegatedCancelWithRatio, createTxObj)
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -135,6 +148,39 @@ class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTransacti
             this.from.toLowerCase(),
             Bytes.fromNat(this.feeRatio),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/chainDataAnchoring.js
+++ b/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/chainDataAnchoring.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils')
 
 function _decode(rlpEncoded) {
@@ -85,6 +85,18 @@ class ChainDataAnchoring extends AbstractTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -145,6 +157,39 @@ class ChainDataAnchoring extends AbstractTransaction {
             this.from.toLowerCase(),
             this.input,
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoring.js
+++ b/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoring.js
@@ -19,8 +19,9 @@
 const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils')
 
 function _decode(rlpEncoded) {
@@ -89,6 +90,18 @@ class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -152,6 +165,39 @@ class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransaction {
             this.from.toLowerCase(),
             this.input,
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoringWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoringWithRatio.js
@@ -19,8 +19,9 @@
 const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils')
 
 function _decode(rlpEncoded) {
@@ -90,6 +91,18 @@ class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegatedWithRa
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -155,6 +168,39 @@ class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegatedWithRa
             this.input,
             Bytes.fromNat(this.feeRatio),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/ethereumTypedTransaction/ethereumAccessList.js
+++ b/packages/caver-transaction/src/transactionTypes/ethereumTypedTransaction/ethereumAccessList.js
@@ -26,6 +26,7 @@ const {
     TX_TYPE_TAG,
     refineSignatures,
     getTypeTagWithoutEthereumTxTypeEnvelopeTag,
+    isNot,
 } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 const AccessList = require('../../utils/accessList')
@@ -110,6 +111,19 @@ class EthereumAccessList extends AbstractTransaction {
         this.value = createTxObj.value || '0x0'
 
         this.accessList = createTxObj.accessList || []
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -345,6 +359,27 @@ class EthereumAccessList extends AbstractTransaction {
     }
 
     /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
      * Checks that member variables that can be defined by the user are defined.
      * If there is an undefined variable, an error occurs.
      *
@@ -352,6 +387,8 @@ class EthereumAccessList extends AbstractTransaction {
      */
     validateOptionalValues() {
         super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
         if (this.chainId === undefined)
             throw new Error(`chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.`)
     }

--- a/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
+++ b/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.js
@@ -21,7 +21,7 @@ const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const Hash = require('eth-lib/lib/hash')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -87,6 +87,18 @@ class LegacyTransaction extends AbstractTransaction {
         this.input = createTxObj.input || createTxObj.data || '0x'
 
         this.value = createTxObj.value || '0x0'
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -239,6 +251,39 @@ class LegacyTransaction extends AbstractTransaction {
         publicKeys.push(utils.recoverPublicKey(hasedSigningData, this.signatures, true))
 
         return publicKeys
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.js
@@ -19,8 +19,9 @@
 const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG, CODE_FORMAT, getCodeFormatTag } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, CODE_FORMAT, getCodeFormatTag, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -102,6 +103,19 @@ class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
 
         this.humanReadable = createTxObj.humanReadable !== undefined ? createTxObj.humanReadable : false
         this.codeFormat = createTxObj.codeFormat !== undefined ? createTxObj.codeFormat : CODE_FORMAT.EVM
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -230,6 +244,39 @@ class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
             Bytes.fromNat(this.humanReadable === true ? '0x1' : '0x0'),
             Bytes.fromNat(this.codeFormat),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG, CODE_FORMAT, getCodeFormatTag } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, CODE_FORMAT, getCodeFormatTag, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -115,6 +116,19 @@ class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegatedWithR
 
         this.humanReadable = createTxObj.humanReadable !== undefined ? createTxObj.humanReadable : false
         this.codeFormat = createTxObj.codeFormat !== undefined ? createTxObj.codeFormat : CODE_FORMAT.EVM
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -245,6 +259,39 @@ class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegatedWithR
             Bytes.fromNat(this.feeRatio),
             Bytes.fromNat(this.codeFormat),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG, CODE_FORMAT, getCodeFormatTag } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, CODE_FORMAT, getCodeFormatTag, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -99,6 +99,19 @@ class SmartContractDeploy extends AbstractTransaction {
 
         this.humanReadable = createTxObj.humanReadable !== undefined ? createTxObj.humanReadable : false
         this.codeFormat = createTxObj.codeFormat !== undefined ? createTxObj.codeFormat : CODE_FORMAT.EVM
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -224,6 +237,39 @@ class SmartContractDeploy extends AbstractTransaction {
             Bytes.fromNat(this.humanReadable === true ? '0x1' : '0x0'),
             Bytes.fromNat(this.codeFormat),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.js
@@ -19,8 +19,9 @@
 const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -95,6 +96,19 @@ class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTransaction
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -196,6 +210,39 @@ class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTransaction
             this.from.toLowerCase(),
             this.input,
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecutionWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecutionWithRatio.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -96,6 +97,19 @@ class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDelegatedWi
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -199,6 +213,39 @@ class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDelegatedWi
             this.input,
             Bytes.fromNat(this.feeRatio),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.js
+++ b/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -91,6 +91,19 @@ class SmartContractExecution extends AbstractTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -189,6 +202,39 @@ class SmartContractExecution extends AbstractTransaction {
             this.from.toLowerCase(),
             this.input,
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransfer.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransfer.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils')
 
 function _decode(rlpEncoded) {
@@ -87,6 +88,19 @@ class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         super(TX_TYPE_STRING.TxTypeFeeDelegatedValueTransfer, createTxObj)
         this.to = createTxObj.to
         this.value = createTxObj.value
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -163,6 +177,39 @@ class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
             Bytes.fromNat(this.value),
             this.from.toLowerCase(),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransferWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransferWithRatio.js
@@ -19,7 +19,8 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
 const utils = require('../../../../caver-utils/src')
 
@@ -88,6 +89,19 @@ class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWithRatioTr
         super(TX_TYPE_STRING.TxTypeFeeDelegatedValueTransferWithRatio, createTxObj)
         this.to = createTxObj.to
         this.value = createTxObj.value
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -166,6 +180,39 @@ class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWithRatioTr
             this.from.toLowerCase(),
             Bytes.fromNat(this.feeRatio),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/valueTransfer/valueTransfer.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransfer/valueTransfer.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils')
 
 function _decode(rlpEncoded) {
@@ -84,6 +84,19 @@ class ValueTransfer extends AbstractTransaction {
 
         this.to = createTxObj.to
         this.value = createTxObj.value
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -157,6 +170,39 @@ class ValueTransfer extends AbstractTransaction {
             Bytes.fromNat(this.value),
             this.from.toLowerCase(),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.js
@@ -19,8 +19,9 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedTransaction = require('../abstractFeeDelegatedTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -93,6 +94,19 @@ class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -194,6 +208,39 @@ class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
             this.from.toLowerCase(),
             this.input,
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.js
@@ -19,7 +19,8 @@
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const _ = require('lodash')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
+const AbstractTransaction = require('../abstractTransaction')
 const AbstractFeeDelegatedWithRatioTransaction = require('../abstractFeeDelegatedWithRatioTransaction')
 const utils = require('../../../../caver-utils/src')
 
@@ -94,6 +95,19 @@ class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegatedWithRat
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -197,6 +211,39 @@ class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegatedWithRat
             this.input,
             Bytes.fromNat(this.feeRatio),
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.js
+++ b/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.js
@@ -20,7 +20,7 @@ const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const AbstractTransaction = require('../abstractTransaction')
-const { TX_TYPE_STRING, TX_TYPE_TAG } = require('../../transactionHelper/transactionHelper')
+const { TX_TYPE_STRING, TX_TYPE_TAG, isNot } = require('../../transactionHelper/transactionHelper')
 const utils = require('../../../../caver-utils/src')
 
 function _decode(rlpEncoded) {
@@ -89,6 +89,19 @@ class ValueTransferMemo extends AbstractTransaction {
             throw new Error(`'input' and 'data' properties cannot be defined at the same time, please use either 'input' or 'data'.`)
 
         this.input = createTxObj.input || createTxObj.data
+
+        if (createTxObj.gasPrice !== undefined) this.gasPrice = createTxObj.gasPrice
+    }
+
+    /**
+     * @type {string}
+     */
+    get gasPrice() {
+        return this._gasPrice
+    }
+
+    set gasPrice(g) {
+        this._gasPrice = utils.numberToHex(g)
     }
 
     /**
@@ -187,6 +200,39 @@ class ValueTransferMemo extends AbstractTransaction {
             this.from.toLowerCase(),
             this.input,
         ])
+    }
+
+    /**
+     * Fills in the optional variables in transaction.
+     *
+     * If the `gasPrice`, `nonce`, or `chainId` of the transaction are not defined, this method asks the default values for these optional variables and preset them by sending JSON RPC call to the connected Klaytn Node.
+     * Use {@link Klay#getGasPrice|caver.rpc.klay.getGasPrice} to get gasPrice, {@link Klay#getTransactionCount|caver.rpc.klay.getTransactionCount} to get nonce and {@link Klay#getChainId|caver.rpc.klay.getChainId} call to get chainId.
+     *
+     * @example
+     * await tx.fillTransaction()
+     */
+    async fillTransaction() {
+        const [chainId, gasPrice, nonce] = await Promise.all([
+            isNot(this.chainId) ? AbstractTransaction.getChainId() : this.chainId,
+            isNot(this.gasPrice) ? AbstractTransaction.getGasPrice() : this.gasPrice,
+            isNot(this.nonce) ? AbstractTransaction.getNonce(this.from) : this.nonce,
+        ])
+
+        this.chainId = chainId
+        this.gasPrice = gasPrice
+        this.nonce = nonce
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     *
+     * @ignore
+     */
+    validateOptionalValues() {
+        super.validateOptionalValues()
+        if (this.gasPrice === undefined)
+            throw new Error(`gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.`)
     }
 }
 

--- a/types/packages/caver-transaction/src/transactionTypes/abstractTransaction.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/abstractTransaction.d.ts
@@ -35,6 +35,8 @@ export interface CreateTransactionObject {
     humanReadable?: boolean
     codeFormat?: string | number
     accessList?: AccessList
+    maxPriorityFeePerGas?: string | number
+    maxFeePerGas?: string | number
 }
 
 export class AbstractTransaction {
@@ -60,13 +62,11 @@ export class AbstractTransaction {
     from: string
     nonce: string
     gas: string
-    gasPrice: string
     chainId: string
     signatures: SignatureData | SignatureData[]
     private _from: string
     private _nonce: string
     private _gas: string
-    private _gasPrice: string
     private _chainId: string
     private _signatures: SignatureData | SignatureData[]
 }

--- a/types/packages/caver-transaction/src/transactionTypes/accountUpdate/accountUpdate.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/accountUpdate/accountUpdate.d.ts
@@ -24,7 +24,11 @@ export class AccountUpdate extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     account: Account
+    gasPrice: string
     private _account: Account
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdate.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdate.d.ts
@@ -25,7 +25,11 @@ export class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     account: Account
+    gasPrice: string
     private _account: Account
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdateWithRatio.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/accountUpdate/feeDelegatedAccountUpdateWithRatio.d.ts
@@ -25,7 +25,11 @@ export class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     account: Account
+    gasPrice: string
     private _account: Account
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/cancel/cancel.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/cancel/cancel.d.ts
@@ -23,4 +23,9 @@ export class Cancel extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
+
+    gasPrice: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancel.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancel.d.ts
@@ -24,4 +24,9 @@ export class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
+
+    gasPrice: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancelWithRatio.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/cancel/feeDelegatedCancelWithRatio.d.ts
@@ -24,4 +24,9 @@ export class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
+
+    gasPrice: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/chainDataAnchoring.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/chainDataAnchoring.d.ts
@@ -23,7 +23,11 @@ export class ChainDataAnchoring extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     input: string
+    gasPrice: string
     private _input: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoring.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoring.d.ts
@@ -24,7 +24,11 @@ export class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     input: string
+    gasPrice: string
     private _input: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoringWithRatio.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/chainDataAnchoring/feeDelegatedChainDataAnchoringWithRatio.d.ts
@@ -24,7 +24,11 @@ export class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     input: string
+    gasPrice: string
     private _input: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/ethereumTypedTransaction/ethereumAccessList.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/ethereumTypedTransaction/ethereumAccessList.d.ts
@@ -28,15 +28,19 @@ export class EthereumAccessList extends AbstractTransaction {
     getRLPEncodingForSignature(): string
     getCommonRLPEncodingForSignature(): string
     recoverPublicKeys(): string[]
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
     accessList: AccessList
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
     private _accessList: AccessList
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/ethereumTypedTransaction/ethereumDynamicFee.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/ethereumTypedTransaction/ethereumDynamicFee.d.ts
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 The caver-js Authors
+    Copyright 2022 The caver-js Authors
     This file is part of the caver-js library.
     The caver-js library is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -13,17 +13,21 @@
     along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AbstractFeeDelegatedWithRatioTransaction } from '../abstractFeeDelegatedWithRatioTransaction'
-import { CreateTransactionObject } from '../abstractTransaction'
+import { AbstractTransaction, CreateTransactionObject } from '../abstractTransaction'
+import { SignatureData } from '../../../../caver-wallet/src'
+import { AccessList } from 'ethers/lib/utils'
 
-export class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDelegatedWithRatioTransaction {
-    static create(createTxObj: string | CreateTransactionObject): FeeDelegatedSmartContractExecutionWithRatio
-    static decode(rlpEncoded: string): FeeDelegatedSmartContractExecutionWithRatio
+export class EthereumDynamicFee extends AbstractTransaction {
+    static create(createTxObj: CreateTransactionObject | string): EthereumDynamicFee
+    static decode(rlpEncoded: string): EthereumDynamicFee
 
-    constructor(createTxObj: string | CreateTransactionObject)
+    constructor(createTxObj: CreateTransactionObject | string)
 
+    appendSignatures(sig: string[] | string[][] | SignatureData | SignatureData[]): void
     getRLPEncoding(): string
+    getRLPEncodingForSignature(): string
     getCommonRLPEncodingForSignature(): string
+    recoverPublicKeys(): string[]
     fillTransaction(): Promise<void>
     validateOptionalValues(): void
 
@@ -31,10 +35,14 @@ export class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
     value: string
     input: string
     data: string
-    gasPrice: string
+    maxPriorityFeePerGas: string
+    maxFeePerGas: string
+    accessList: AccessList
     private _to: string
     private _value: string
     private _input: string
     private _data: string
-    private _gasPrice: string
+    private _maxPriorityFeePerGas: string
+    private _maxFeePerGas: string
+    private _accessList: AccessList
 }

--- a/types/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/legacyTransaction/legacyTransaction.d.ts
@@ -27,13 +27,17 @@ export class LegacyTransaction extends AbstractTransaction {
     getRLPEncodingForSignature(): string
     getCommonRLPEncodingForSignature(): string
     recoverPublicKeys(): string[]
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeploy.d.ts
@@ -24,6 +24,8 @@ export class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
@@ -31,10 +33,12 @@ export class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
     data: string
     humanReadable: boolean
     codeFormat: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
     private _humanReadable: boolean
     private _codeFormat: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/smartContractDeploy/feeDelegatedSmartContractDeployWithRatio.d.ts
@@ -24,6 +24,8 @@ export class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
@@ -31,10 +33,12 @@ export class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
     data: string
     humanReadable: boolean
     codeFormat: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
     private _humanReadable: boolean
     private _codeFormat: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/smartContractDeploy/smartContractDeploy.d.ts
@@ -23,6 +23,8 @@ export class SmartContractDeploy extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
@@ -30,10 +32,12 @@ export class SmartContractDeploy extends AbstractTransaction {
     data: string
     humanReadable: boolean
     codeFormat: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
     private _humanReadable: boolean
     private _codeFormat: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/smartContractExecution/feeDelegatedSmartContractExecution.d.ts
@@ -24,13 +24,17 @@ export class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/smartContractExecution/smartContractExecution.d.ts
@@ -23,13 +23,17 @@ export class SmartContractExecution extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransfer.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransfer.d.ts
@@ -23,9 +23,13 @@ export class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
     static decode(rlpEncoded: string): FeeDelegatedValueTransfer
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
+    gasPrice: string
     private _to: string
     private _value: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransferWithRatio.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/valueTransfer/feeDelegatedValueTransferWithRatio.d.ts
@@ -23,9 +23,13 @@ export class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
     static decode(rlpEncoded: string): FeeDelegatedValueTransferWithRatio
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
+    gasPrice: string
     private _to: string
     private _value: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/valueTransfer/valueTransfer.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/valueTransfer/valueTransfer.d.ts
@@ -23,9 +23,13 @@ export class ValueTransfer extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
+    gasPrice: string
     private _to: string
     private _value: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemo.d.ts
@@ -24,13 +24,17 @@ export class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/valueTransferMemo/feeDelegatedValueTransferMemoWithRatio.d.ts
@@ -24,13 +24,17 @@ export class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.d.ts
+++ b/types/packages/caver-transaction/src/transactionTypes/valueTransferMemo/valueTransferMemo.d.ts
@@ -23,13 +23,17 @@ export class ValueTransferMemo extends AbstractTransaction {
 
     getRLPEncoding(): string
     getCommonRLPEncodingForSignature(): string
+    fillTransaction(): Promise<void>
+    validateOptionalValues(): void
 
     to: string
     value: string
     input: string
     data: string
+    gasPrice: string
     private _to: string
     private _value: string
     private _input: string
     private _data: string
+    private _gasPrice: string
 }

--- a/types/packages/caver-wallet/src/index.d.ts
+++ b/types/packages/caver-wallet/src/index.d.ts
@@ -34,8 +34,8 @@ export interface SignedMessage {
 
 export class IWallet {
     generate(num: number): string[]
-    sign(address: string, transaction: Transaction): Promise<Transaction>
-    signAsFeePayer(address: string, transaction: FeeDelegatedTransaction): Promise<FeeDelegatedTransaction>
+    sign(address: string, transaction: AbstractTransaction): Promise<AbstractTransaction>
+    signAsFeePayer(address: string, transaction: AbstractFeeDelegatedTransaction): Promise<AbstractFeeDelegatedTransaction>
     isExisted(address: string): boolean
     remove(address: string): boolean
 }
@@ -57,7 +57,7 @@ export class KeyringContainer implements IWallet {
     add(keyring: Keyring): Keyring
     remove(address: string): boolean
     signMessage(address: string, data: string, role: number, index?: number): SignedMessage
-    sign(address: string, transaction: Transaction): Promise<AbstractTransaction>
+    sign(address: string, transaction: AbstractTransaction): Promise<AbstractTransaction>
     sign(
         address: string,
         transaction: AbstractTransaction,


### PR DESCRIPTION
## Proposed changes

This PR introduces deleting the `gasPrice` variable from `AbstractTransaction`.
This is for EthereumDynamicFee transaction which does not have `gasPrice`.
This PR includes https://github.com/klaytn/caver-js/pull/600, so please review https://github.com/klaytn/caver-js/pull/600 first.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

refer https://github.com/klaytn/caver-js/issues/592

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
