### PR TITLE
Used even v value in SignatureData

### DIFF
--- a/packages/caver-wallet/src/keyring/privateKey.js
+++ b/packages/caver-wallet/src/keyring/privateKey.js
@@ -90,7 +90,9 @@ class PrivateKey {
         // `AccountLib.makeSigner` makes a sign function that adds addToV to `v`, so use 0.
         const addToV = 0
         const signature = AccountLib.makeSigner(addToV)(hash, this.privateKey)
-        const [v, r, s] = AccountLib.decodeSignature(signature).map(sig => utils.makeEven(utils.trimLeadingZero(sig)))
+        let [v, r, s] = AccountLib.decodeSignature(signature).map(sig => utils.makeEven(utils.trimLeadingZero(sig)))
+        // This is for converting '0x' to '0x0'
+        v = utils.toHex(utils.hexToNumber(v))
 
         return new SignatureData([v, r, s])
     }

--- a/packages/caver-wallet/src/keyring/signatureData.js
+++ b/packages/caver-wallet/src/keyring/signatureData.js
@@ -66,7 +66,7 @@ class SignatureData {
 
     set v(v) {
         v = v.slice(0, 2) === '0x' ? v : `0x${v}`
-        this._v = v
+        this._v = utils.makeEven(v)
     }
 
     /**
@@ -77,7 +77,7 @@ class SignatureData {
     }
 
     set V(v) {
-        this.v = v
+        this.v = utils.makeEven(v)
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

This PR introduces setting v value with makeEven function.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
