### PR TITLE
Fixed error when check transaction type

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -430,8 +430,8 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
             } else if (key === 'account') {
                 tx.key = payload.params[0][key].getRLPEncodingAccountKey()
             } else if (key === 'chainId') {
-                if (payload.params[0][key].type !== undefined && payload.params[0][key].type.includes('Ethereum')) {
-                    tx[key] = payload.params[0][key].toObject()
+                if (payload.params[0].type !== undefined && payload.params[0].type.includes('Ethereum')) {
+                    tx[key] = payload.params[0][key]
                 }
             } else if (key === 'accessList') {
                 tx[key] = payload.params[0][key].toObject()


### PR DESCRIPTION
## Proposed changes

Sorry for making you confuse, but there was my mistake to check transaction type when send tx object to network.
`payload.params[0]` will be a transaction, so need to check `type` of that.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
