### PR TITLE
Added optional fields for rpc transaction objects

### DIFF
--- a/types/packages/caver-core/src/index.d.ts
+++ b/types/packages/caver-core/src/index.d.ts
@@ -16,10 +16,10 @@
     along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AbiItem } from '../../caver-utils/src'
 import { Account } from '../../caver-account/src'
 import BN = require('bn.js')
 import BigNumber from 'bignumber.js'
+import { AccessListObject } from '../../caver-transaction/src'
 
 export interface SignatureForRPC {
     V: string
@@ -76,6 +76,7 @@ export interface BlockWithConsensusInfo extends Block {
 }
 
 export interface TransactionForSendRPC {
+    accessList?: AccessListObject
     type?: string
     from?: string | number
     signatures?: SignatureForRPC[]
@@ -83,6 +84,8 @@ export interface TransactionForSendRPC {
     value?: number | string
     gas?: number | string
     gasPrice?: number | string
+    maxPriorityFeePerGas?: string | number
+    maxFeePerGas?: string | number
     data?: string
     input?: string
     nonce?: number
@@ -98,15 +101,19 @@ export interface TransactionForSendRPC {
 }
 
 export interface TransactionForRPC {
+    accessList?: AccessListObject
     blockHash: string
     blockNumber: string
     codeFormat?: string
+    chainId?: string
     feePayer?: string
     feePayerSignatures?: SignatureForRPC[]
     feeRatio?: string
     from: string
     gas: string | number
-    gasPrice: string | number
+    gasPrice?: string
+    maxPriorityFeePerGas?: string
+    maxFeePerGas?: string
     hash: string
     humanReadable?: boolean
     key?: string
@@ -122,15 +129,19 @@ export interface TransactionForRPC {
 }
 
 export interface TransactionReceipt {
+    accessList?: AccessListObject
     blockHash: string
     blockNumber: string
     codeFormat?: string
+    chainId?: string
     feePayer?: string
     feePayerSignatures?: SignatureForRPC[]
     feeRatio?: string
     from: string
     gas: string | number
-    gasPrice: string | number
+    gasPrice?: string | number
+    maxPriorityFeePerGas?: string
+    maxFeePerGas?: string
     humanReadable?: boolean
     key?: string
     input?: string

--- a/types/packages/caver-transaction/src/utils/accessList.d.ts
+++ b/types/packages/caver-transaction/src/utils/accessList.d.ts
@@ -15,6 +15,14 @@
 
 import { AccessTuple, AccessTupleObject, EncodedAccessTuple } from './accessTuple'
 
+export type AccessListObject = AccessTupleObject[]
+
+export interface AccessListResult {
+    accessList: AccessListObject
+    gasUsed: string
+    error: string
+}
+
 export class AccessList extends Array {
     static create(items: AccessTuple[] | AccessTupleObject[]): AccessList
     static decode(encoded: string): AccessList

--- a/types/packages/caver-transaction/src/utils/accessTuple.d.ts
+++ b/types/packages/caver-transaction/src/utils/accessTuple.d.ts
@@ -13,12 +13,6 @@
     along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export interface AccessListResult {
-    accessList: AccessTupleObject[]
-    gasUsed: string
-    error: string
-}
-
 export interface AccessTupleObject {
     address: string
     storageKeys: string[]


### PR DESCRIPTION
## Proposed changes

This PR introduces adding optional rpc transaction fields(maxPriorityFeePerGas, maxFeePerGas, chianId and accessList) to type files.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
