### PR TITLE
Added ethereum dynamic fee tx type for getTransactionByHash

### DIFF
--- a/packages/caver-transaction/src/index.js
+++ b/packages/caver-transaction/src/index.js
@@ -149,6 +149,9 @@ async function getTransactionByHash(transactionHash) {
         case 'TxTypeEthereumAccessList':
             txObject = new EthereumAccessList(txObject)
             break
+        case 'TxTypeEthereumDynamicFee':
+            txObject = new EthereumDynamicFee(txObject)
+            break
     }
     return txObject
 }

--- a/packages/caver-wallet/src/keyring/signatureData.js
+++ b/packages/caver-wallet/src/keyring/signatureData.js
@@ -67,7 +67,7 @@ class SignatureData {
     set v(v) {
         v = v.slice(0, 2) === '0x' ? v : `0x${v}`
         // If v of Signature is 0, '0x' is returned when RLP decoded.
-        // However, the Bytes.toNumber function used for recover public key cannot convert '0x' to 0, 
+        // However, the Bytes.toNumber function used for recover public key cannot convert '0x' to 0,
         // so to handle this case, v is converted to '0x0' in case of '0x' (makeEven converts '0x0' to '0x00').
         v = v === '0x' ? '0x0' : v
         this._v = utils.makeEven(v)

--- a/packages/caver-wallet/src/keyring/signatureData.js
+++ b/packages/caver-wallet/src/keyring/signatureData.js
@@ -66,6 +66,10 @@ class SignatureData {
 
     set v(v) {
         v = v.slice(0, 2) === '0x' ? v : `0x${v}`
+        // If v of Signature is 0, '0x' is returned when RLP decoded.
+        // However, the Bytes.toNumber function used for recover public key cannot convert '0x' to 0, 
+        // so to handle this case, v is converted to '0x0' in case of '0x' (makeEven converts '0x0' to '0x00').
+        v = v === '0x' ? '0x0' : v
         this._v = utils.makeEven(v)
     }
 

--- a/test/packages/caver.transaction/caver.transaction.js
+++ b/test/packages/caver.transaction/caver.transaction.js
@@ -292,6 +292,30 @@ describe('caver.transaction.getTransactionByHash', () => {
             expect(txObj.type).to.equal('TxTypeFeeDelegatedChainDataAnchoringWithRatio')
         })
     })
+
+    context('ethereumAccessList', () => {
+        it('CAVERJS-UNIT-TRANSACTION-552: should return an ethereumAccessList instance', async () => {
+            getTransactionByHashSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionByHash')
+            getTransactionByHashSpy.returns(txSamples.ethereumAccessList)
+
+            const txObj = await caver.transaction.getTransactionByHash(txSamples.ethereumAccessList.hash)
+
+            expect(getTransactionByHashSpy).to.have.been.called
+            expect(txObj.type).to.equal('TxTypeEthereumAccessList')
+        })
+    })
+
+    context('ethereumDynamicFee', () => {
+        it('CAVERJS-UNIT-TRANSACTION-553: should return an ethereumDynamicFee instance', async () => {
+            getTransactionByHashSpy = sandbox.stub(AbstractTransaction._klaytnCall, 'getTransactionByHash')
+            getTransactionByHashSpy.returns(txSamples.ethereumDynamicFee)
+
+            const txObj = await caver.transaction.getTransactionByHash(txSamples.ethereumDynamicFee.hash)
+
+            expect(getTransactionByHashSpy).to.have.been.called
+            expect(txObj.type).to.equal('TxTypeEthereumDynamicFee')
+        })
+    })
 })
 
 describe('caver.transaction.recoverPublicKeys and caver.transaction.recoverFeePayerPublicKeys', () => {
@@ -697,6 +721,32 @@ describe('caver.transaction.recoverPublicKeys and caver.transaction.recoverFeePa
             for (let i = 0; i < feePayerPublicKeys.length; i++) {
                 expect(feePayerPublicKeys[i].toLowerCase()).to.equal(expectedFeePayerPublicKeyArray[i].toLowerCase())
             }
+        })
+    })
+
+    context('ethereumAccessList', () => {
+        it('CAVERJS-UNIT-TRANSACTION-554: recoverPublciKeys should recover public keys from signatures', async () => {
+            const expected =
+                '0xde8009313a986ec6d21dca780bd0bd12f0f8b177a29f50e833e5b3187391319cae9a5c8d179601417aeba6330b69b436f01f55d1c89ebb705adafd55d9636573'
+            const rawTx =
+                '0x7801f90109822710238505d21dba00829c4094c5fb1386b60160614a8151dcd4b0ae41325d1cb801b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f85bf859945430192ae264b3feff967fc08982b9c6f5694023f842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000701a05ac25e47591243af2d6b8e7f54d608e9e0e0aeb5194d34c17852bd7e376f4857a0095a40394f33e95cce9695d5badf4270f4cc8aff0b5395cefc3a0fe213be1f30'
+
+            const publicKeys = caver.transaction.recoverPublicKeys(rawTx)
+
+            expect(publicKeys[0].toLowerCase()).to.equal(expected)
+        })
+    })
+
+    context('ethereumDynamicFee', () => {
+        it('CAVERJS-UNIT-TRANSACTION-555: recoverPublciKeys should recover public keys from signatures', async () => {
+            const expected =
+                '0xde8009313a986ec6d21dca780bd0bd12f0f8b177a29f50e833e5b3187391319cae9a5c8d179601417aeba6330b69b436f01f55d1c89ebb705adafd55d9636573'
+            const rawTx =
+                '0x7802f9010f822710258505d21dba008505d21dba00829c40941fc92c23f71a7de4cdb4394a37fc636986a0f48401b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f85bf8599467116062f1626f7b3019631f03d301b8f701f709f842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000780a04fc52da183020a27dc4b684a45404445630e946b0c1a37edeb538d4bdae63040a07d56dbcc61f42ffcbced105f838d20b8fe71e85a4d0344c7f60815fddfeae4cc'
+
+            const publicKeys = caver.transaction.recoverPublicKeys(rawTx)
+
+            expect(publicKeys[0].toLowerCase()).to.equal(expected)
         })
     })
 })

--- a/test/packages/caver.transaction/transactionSamples.js
+++ b/test/packages/caver.transaction/transactionSamples.js
@@ -645,6 +645,73 @@ const txSamples = {
         type: 'TxTypeFeeDelegatedChainDataAnchoringWithRatio',
         typeInt: 74,
     },
+    ethereumAccessList: {
+        blockHash: '0x7025add64d3619e12a90b1d11e21647b55cd672edc5bfd72f5ae0b5d196e7833',
+        blockNumber: '0x3aa3806',
+        gas: '0x9c40',
+        gasPrice: '0x5d21dba00',
+        hash: '0x4744f34dc127bfdb89549f15e60f144d8ac9ede573d6a1b6738b28b83d4de9dd',
+        input:
+            '0xa9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039',
+        nonce: '0x23',
+        senderTxHash: '0x4744f34dc127bfdb89549f15e60f144d8ac9ede573d6a1b6738b28b83d4de9dd',
+        signatures: [
+            {
+                V: '0x1',
+                R: '0x5ac25e47591243af2d6b8e7f54d608e9e0e0aeb5194d34c17852bd7e376f4857',
+                S: '0x095a40394f33e95cce9695d5badf4270f4cc8aff0b5395cefc3a0fe213be1f30',
+            },
+        ],
+        chainId: '0x2710',
+        to: '0xc5fb1386b60160614a8151dcd4b0ae41325d1cb8',
+        transactionIndex: '0x0',
+        type: 'TxTypeEthereumAccessList',
+        typeInt: 30721,
+        value: '0x1',
+        accessList: [
+            {
+                address: '0x5430192ae264b3feff967fc08982b9c6f5694023',
+                storageKeys: [
+                    '0x0000000000000000000000000000000000000000000000000000000000000003',
+                    '0x0000000000000000000000000000000000000000000000000000000000000007',
+                ],
+            },
+        ],
+    },
+    ethereumDynamicFee: {
+        blockHash: '0x7025add64d3619e12a90b1d11e21647b55cd672edc5bfd72f5ae0b5d196e7833',
+        blockNumber: '0x3aa3806',
+        gas: '0x9c40',
+        maxPriorityFeePerGas: '0x5d21dba00',
+        maxFeePerGas: '0x5d21dba00',
+        hash: '0x4744f34dc127bfdb89549f15e60f144d8ac9ede573d6a1b6738b28b83d4de9dd',
+        input:
+            '0xa9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039',
+        nonce: '0x25',
+        senderTxHash: '0x4744f34dc127bfdb89549f15e60f144d8ac9ede573d6a1b6738b28b83d4de9dd',
+        signatures: [
+            {
+                V: '0x0',
+                R: '0x4fc52da183020a27dc4b684a45404445630e946b0c1a37edeb538d4bdae63040',
+                S: '0x7d56dbcc61f42ffcbced105f838d20b8fe71e85a4d0344c7f60815fddfeae4cc',
+            },
+        ],
+        chainId: '0x2710',
+        to: '0x1fc92c23f71a7de4cdb4394a37fc636986a0f484',
+        transactionIndex: '0x0',
+        type: 'TxTypeEthereumDynamicFee',
+        typeInt: 30722,
+        value: '0x1',
+        accessList: [
+            {
+                address: '0x67116062f1626f7b3019631f03d301b8f701f709',
+                storageKeys: [
+                    '0x0000000000000000000000000000000000000000000000000000000000000003',
+                    '0x0000000000000000000000000000000000000000000000000000000000000007',
+                ],
+            },
+        ],
+    },
 }
 
 module.exports = txSamples


### PR DESCRIPTION
## Proposed changes

This PR introduces adding EthereumDynamicFee transaction case in `caver.transactin.getTransactionByHash`.
And also, when decode a tx which has `v` of the signature as '0x0', decode will return '0x' for `v`.
So if you try to recover public key with '0x', `Bytes.toNumber` function will return `NaN` instead of `0`.
To handle this case, i added conversion in `v` setter in SignatureData.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
