### PR TITLE
Send gasPrice param to send tx via personal rpc

### DIFF
--- a/test/personal.js
+++ b/test/personal.js
@@ -347,6 +347,7 @@ describe('Personal RPC test', () => {
             to: caver.klay.accounts.create().address,
             value: 1,
             gas: 900000,
+            gasPrice: caver.utils.convertToPeb(25, 'ston'),
             chainId,
             accessList: [
                 {
@@ -367,6 +368,7 @@ describe('Personal RPC test', () => {
             from: testKeyring.address,
             value: 0,
             gas: 1000000,
+            gasPrice: caver.utils.convertToPeb(25, 'ston'),
             chainId,
             accessList: [
                 {
@@ -389,6 +391,7 @@ describe('Personal RPC test', () => {
             to: caver.wallet.keyring.generate().address,
             value: 0,
             gas: 900000,
+            gasPrice: caver.utils.convertToPeb(25, 'ston'),
             chainId,
             accessList: [
                 {


### PR DESCRIPTION
## Proposed changes

Fixed a test case to send `gasPrice` field together when send tx via Node's keystore.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
