### PR TITLE
Fix return type definition of `getNetworkId` to `Promise<number>`

### DIFF
--- a/types/packages/caver-rpc/src/net.d.ts
+++ b/types/packages/caver-rpc/src/net.d.ts
@@ -25,8 +25,8 @@ export interface PeerCountByType {
 export class Net {
     constructor(...args: any[])
 
-    getNetworkId(callback?: (error: Error, result: string) => void): Promise<string>
-    getNetworkID(callback?: (error: Error, result: string) => void): Promise<string>
+    getNetworkId(callback?: (error: Error, result: string) => void): Promise<number>
+    getNetworkID(callback?: (error: Error, result: string) => void): Promise<number>
     isListening(callback?: (error: Error, result: boolean) => void): Promise<boolean>
     getPeerCount(callback?: (error: Error, result: string) => void): Promise<string>
     getPeerCountByType(callback?: (error: Error, result: PeerCountByType) => void): Promise<PeerCountByType>

--- a/types/test/rpc-test.ts
+++ b/types/test/rpc-test.ts
@@ -1244,13 +1244,13 @@ rpc.klay.sha3('data')
 // $ExpectType Promise<string>
 rpc.klay.sha3('data', (err: Error, ret: string) => {})
 
-// $ExpectType Promise<string>
+// $ExpectType Promise<number>
 rpc.net.getNetworkID()
-// $ExpectType Promise<string>
+// $ExpectType Promise<number>
 rpc.net.getNetworkID((err: Error, ret: string) => {})
-// $ExpectType Promise<string>
+// $ExpectType Promise<number>
 rpc.net.getNetworkId()
-// $ExpectType Promise<string>
+// $ExpectType Promise<number>
 rpc.net.getNetworkId((err: Error, ret: string) => {})
 
 // $ExpectType Promise<boolean>


### PR DESCRIPTION
## Proposed changes

```ts
getNetworkId(callback?: (error: Error, result: string) => void): Promise<string>
getNetworkID(callback?: (error: Error, result: string) => void): Promise<string>
```

> `Promise<string>` should be `Promise<number>`

```ts
/**
 * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
 * @return {Promise<number>} The network id.
 */
```

> JSDoc

- The return type of `getNetworkId` and `getNetworkID` is `Promise<number>` on implementation and JSDoc, but the type definition uses `Promise<string>`
- This PR corrects these wrong type definitions

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
