### PR TITLE
Added logic for updating key with string key field

### DIFF
--- a/packages/caver-klay/caver-klay-accounts/src/transactionType/account.js
+++ b/packages/caver-klay/caver-klay-accounts/src/transactionType/account.js
@@ -16,6 +16,7 @@
     along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
 */
 
+const _ = require('lodash')
 const RLP = require('eth-lib/lib/rlp')
 const Bytes = require('eth-lib/lib/bytes')
 const utils = require('../../../../caver-utils')
@@ -136,6 +137,11 @@ function rlpEncodeForFeeDelegatedAccountUpdateWithRatio(transaction) {
 function resolveRawKeyToAccountKey(transaction) {
     // Handles the case where AccountForUpdate is set in key field in transaction object to update account.
     if (transaction.key) {
+        // If the key field is a string,
+        // it means that the already encoded Account Key is passed as a parameter.
+        if (_.isString(transaction.key)) {
+            return transaction.key
+        }
         if (transaction.from && transaction.from.toLowerCase() !== transaction.key.address.toLowerCase()) {
             throw new Error('The value of the from field of the transaction does not match the address of AccountForUpdate.')
         }

--- a/test/transactionType/accountUpdate.js
+++ b/test/transactionType/accountUpdate.js
@@ -1803,6 +1803,18 @@ describe('ACCOUNT_UPDATE transaction', () => {
         expect(key.keyType).to.equals(1)
     }).timeout(200000)
 
+    // Update account with legacyKey when key filed is an encoded account key string
+    it('CAVERJS-UNIT-TX-731 : If transaction object has an encoded account key in the key field, update account key correctly', async () => {
+        // '0x01c0' is AccountKeyLegacy
+        const tx = { key: '0x01c0', ...accountUpdateObject }
+
+        const receipt = await caver.klay.sendTransaction(tx)
+        expect(receipt.from).to.equals(tx.from)
+
+        const key = await caver.klay.getAccountKey(receipt.from)
+        expect(key.keyType).to.equals(1)
+    }).timeout(200000)
+
     // LegacyKey with publicKey
     it('CAVERJS-UNIT-TX-259 : If transaction object has legacyKey and publicKey, signTransaction should throw error', async () => {
         const tx = { legacyKey: true, publicKey, ...accountUpdateObject }


### PR DESCRIPTION
## Proposed changes

This PR introduces adding logic to handle when key field has an encoded account key string(for example `'0x01c0'` for AccountKeyLegacy) instead of `AccountForUpdate`.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
