### PR TITLE
Added handling for send account update tx with key field

### DIFF
--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -38,6 +38,7 @@ const POLLINGTIMEOUT = AVERAGE_BLOCK_TIME * TIMEOUTBLOCK // ~average block time 
 
 const TransactionDecoder = require('../../caver-transaction/src/transactionDecoder/transactionDecoder')
 const { TX_TYPE_STRING } = require('../../caver-transaction/src/transactionHelper/transactionHelper')
+const { resolveRawKeyToAccountKey } = require('../../caver-klay/caver-klay-accounts/src/transactionType/account')
 
 function Method(options) {
     // call, name should be existed to create a method.
@@ -427,6 +428,10 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                 }
             } else if (key === 'codeFormat') {
                 tx[key] = utils.hexToNumber(payload.params[0][key])
+            } else if (key === 'key' && _.isObject(payload.params[0][key])) {
+                // If key field is `AccountForUpdate`, resolve this to raw encoded account key string.
+                keyForUpdate = payload.params[0][key]
+                tx.key = resolveRawKeyToAccountKey(payload.params[0])
             } else if (key === 'account') {
                 tx.key = payload.params[0][key].getRLPEncodingAccountKey()
             } else if (key === 'chainId') {

--- a/packages/caver-core-method/src/index.js
+++ b/packages/caver-core-method/src/index.js
@@ -430,7 +430,6 @@ const buildSendRequestFunc = (defer, sendSignedTx, sendTxCallback) => (payload, 
                 tx[key] = utils.hexToNumber(payload.params[0][key])
             } else if (key === 'key' && _.isObject(payload.params[0][key])) {
                 // If key field is `AccountForUpdate`, resolve this to raw encoded account key string.
-                keyForUpdate = payload.params[0][key]
                 tx.key = resolveRawKeyToAccountKey(payload.params[0])
             } else if (key === 'account') {
                 tx.key = payload.params[0][key].getRLPEncodingAccountKey()

--- a/packages/caver-klay/caver-klay-accounts/src/transactionType/account.js
+++ b/packages/caver-klay/caver-klay-accounts/src/transactionType/account.js
@@ -243,4 +243,5 @@ module.exports = {
     rlpEncodeForFeeDelegatedAccountUpdate,
     rlpEncodeForFeeDelegatedAccountUpdateWithRatio,
     parseAccountKey,
+    resolveRawKeyToAccountKey,
 }

--- a/packages/caver-transaction/src/transactionHelper/transactionHelper.js
+++ b/packages/caver-transaction/src/transactionHelper/transactionHelper.js
@@ -175,6 +175,36 @@ const TX_TYPE_TAG = {
     '0x7802': TX_TYPE_STRING.TxTypeEthereumDynamicFee,
 }
 
+const TX_TYPE_TAG_LEGACY_TX_TYPES = {
+    ACCOUNT_UPDATE: TX_TYPE_TAG.TxTypeAccountUpdate,
+    FEE_DELEGATED_ACCOUNT_UPDATE: TX_TYPE_TAG.TxTypeFeeDelegatedAccountUpdate,
+    FEE_DELEGATED_ACCOUNT_UPDATE_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedAccountUpdateWithRatio,
+
+    VALUE_TRANFSER: TX_TYPE_TAG.TxTypeValueTransfer,
+    FEE_DELEGATED_VALUE_TRANSFER: TX_TYPE_TAG.TxTypeFeeDelegatedValueTransfer,
+    FEE_DELEGATED_VALUE_TRANSFER_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedValueTransferWithRatio,
+
+    VALUE_TRANSFER_MEMO: TX_TYPE_TAG.TxTypeValueTransferMemo,
+    FEE_DELEGATED_VALUE_TRANSFER_MEMO: TX_TYPE_TAG.TxTypeFeeDelegatedValueTransferMemo,
+    FEE_DELEGATED_VALUE_TRANSFER_MEMO_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedValueTransferMemoWithRatio,
+
+    SMART_CONTRACT_DEPLOY: TX_TYPE_TAG.TxTypeSmartContractDeploy,
+    FEE_DELEGATED_SMART_CONTRACT_DEPLOY: TX_TYPE_TAG.TxTypeFeeDelegatedSmartContractDeploy,
+    FEE_DELEGATED_SMART_CONTRACT_DEPLOY_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedSmartContractDeployWithRatio,
+
+    SMART_CONTRACT_EXECUTION: TX_TYPE_TAG.TxTypeSmartContractExecution,
+    FEE_DELEGATED_SMART_CONTRACT_EXECUTION: TX_TYPE_TAG.TxTypeFeeDelegatedSmartContractExecution,
+    FEE_DELEGATED_SMART_CONTRACT_EXECUTION_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedSmartContractExecutionWithRatio,
+
+    CANCEL: TX_TYPE_TAG.TxTypeCancel,
+    FEE_DELEGATED_CANCEL: TX_TYPE_TAG.TxTypeFeeDelegatedCancel,
+    FEE_DELEGATED_CANCEL_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedCancelWithRatio,
+
+    CHAIN_DATA_ANCHORING: TX_TYPE_TAG.TxTypeChainDataAnchoring,
+    FEE_DELEGATED_CHAIN_DATA_ANCHORING: TX_TYPE_TAG.TxTypeFeeDelegatedChainDataAnchoring,
+    FEE_DELEGATED_CHAIN_DATA_ANCHORING_WITH_RATIO: TX_TYPE_TAG.TxTypeFeeDelegatedChainDataAnchoringWithRatio,
+}
+
 const CODE_FORMAT = {
     EVM: '0x0',
 }
@@ -186,7 +216,12 @@ const CODE_FORMAT = {
  * @return {number}
  */
 const getTypeInt = type => {
-    return utils.hexToNumber(TX_TYPE_TAG[type])
+    let typeInt = TX_TYPE_TAG[type]
+    // If type int cannot be found from TX_TYPE_TAG, means old type string.
+    if (typeInt === undefined) {
+        typeInt = TX_TYPE_TAG_LEGACY_TX_TYPES[type]
+    }
+    return utils.hexToNumber(typeInt)
 }
 
 /**

--- a/test/personal.js
+++ b/test/personal.js
@@ -136,6 +136,28 @@ describe('Personal RPC test', () => {
         expect(receipt.type).to.equals('TxTypeLegacyTransaction')
     }).timeout(50000)
 
+    // sendTransaction with account update tx
+    it('CAVERJS-UNIT-ETC-404: sendTransaction should format a transaction to send tx with account in Node.', async () => {
+        try {
+            // If account is already existed in node, return error.
+            const address = await caver.klay.personal.importRawKey(senderPrvKey, password)
+            expect(address.toLowerCase()).to.equals(senderAddress.toLowerCase())
+        } catch (e) {}
+
+        const receipt = await caver.klay.personal.sendTransaction(
+            {
+                type: 'ACCOUNT_UPDATE',
+                from: senderAddress,
+                key: caver.klay.accounts.createAccountForUpdateWithLegacyKey(senderAddress),
+                gas: 900000,
+            },
+            password
+        )
+        console.log(receipt)
+        expect(receipt).not.to.be.null
+        expect(receipt.type).to.equals('TxTypeAccountUpdate')
+    }).timeout(50000)
+
     // signTransaction
     it('CAVERJS-UNIT-ETC-088: signTransaction should send a signed transaction using an account in the node.', async () => {
         const testAccount = caver.klay.accounts.create()


### PR DESCRIPTION
## Proposed changes

When send tx to Klaytn Node, an AccountKeyUpdate object in the `key` field which is used in old transaction type should be resolve to raw encoded account key string.

Also, when format a tx to send to Klaytn Node, typeInt field should be filled.
To fill typeInt with old transaction object, i added `TX_TYPE_TAG_LEGACY_TX_TYPES`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
