### PR TITLE
DeprecatedTransactionObject add rawTransaction type

### DIFF
--- a/types/packages/caver-klay/caver-klay-accounts/src/index.d.ts
+++ b/types/packages/caver-klay/caver-klay-accounts/src/index.d.ts
@@ -45,6 +45,7 @@ export interface DeprecatedTransactionObject extends KeyForUpdateObject {
     humanReadable?: boolean
     feeRatio?: string
     key?: AccountForUpdate
+    rawTransaction? : string
 }
 
 export interface UpdateOptionsObject {

--- a/types/packages/caver-klay/caver-klay-accounts/src/index.d.ts
+++ b/types/packages/caver-klay/caver-klay-accounts/src/index.d.ts
@@ -45,7 +45,7 @@ export interface DeprecatedTransactionObject extends KeyForUpdateObject {
     humanReadable?: boolean
     feeRatio?: string
     key?: AccountForUpdate
-    rawTransaction? : string
+    rawTransaction?: string
 }
 
 export interface UpdateOptionsObject {


### PR DESCRIPTION
## Proposed changes

```
const { rawTransaction } = await this.caver.klay.accounts.signTransaction(tx, senderPrvKey)
const receipt = await this.caver.klay.sendSignedTransaction(rawTransaction);
```

```
TS2339: Property 'rawTransaction' does not exist on type 'DeprecatedTransactionObject'
```
do not welcome the error

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
