### PR TITLE
Fix jsonrpc payload and response types

### DIFF
--- a/types/packages/caver-core-helpers/src/index.d.ts
+++ b/types/packages/caver-core-helpers/src/index.d.ts
@@ -34,9 +34,13 @@ export interface JsonRpcPayload {
 
 export interface JsonRpcResponse {
     jsonrpc: string
-    id: number
+    id: string | number
     result?: any
-    error?: string
+    error?: {
+        readonly code?: number
+        readonly data?: unknown
+        readonly message: string
+    }
 }
 
 export interface WebsocketProviderOptions {

--- a/types/packages/caver-core-requestmanager/caver-providers-http/src/index.d.ts
+++ b/types/packages/caver-core-requestmanager/caver-providers-http/src/index.d.ts
@@ -50,7 +50,7 @@ export class HttpProvider {
     headers?: HttpHeader[]
     agent?: HttpProviderAgent
 
-    _prepareRequest(): XMLHttpRequest
+    _prepareRequest?(): any
     send(payload: object, callback?: (error: Error | null, result: JsonRpcResponse | undefined) => void): void
     supportsSubscriptions(): boolean
     disconnect(): boolean


### PR DESCRIPTION
Backported from https://github.com/ChainSafe/web3.js/pull/4743

Also changed the type of return value of _prepareRequest function to any since the type definition is not defined for the original Web3.js https://github.com/ChainSafe/web3.js/blob/1.x/packages/web3-providers-http/types/index.d.ts#L57 which could result in ts compiler error for alternative caver-js providers ( Some could return void, some could return Promise, etc )