### PR TITLE
Backport HttpProvider changes from web3.js to fix handling server-side errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,15 @@
       "dependencies": {
         "@babel/runtime": "7.3.1",
         "@ethersproject/abi": "5.0.7",
+        "abortcontroller-polyfill": "^1.7.3",
         "any-promise": "1.3.0",
         "bignumber.js": "8.0.2",
         "bn.js": "4.11.6",
         "constants-browserify": "^1.0.0",
+        "cross-fetch": "^3.1.5",
         "crypto-browserify": "^3.12.0",
         "elliptic": "6.5.4",
+        "es6-promise": "^4.2.8",
         "eth-lib": "0.2.8",
         "ethers": "5.4.1",
         "ethjs-unit": "0.1.6",
@@ -34,8 +37,7 @@
         "stream-http": "^3.2.0",
         "utf8": "2.1.1",
         "uuid": "8.3.2",
-        "websocket": "1.0.31",
-        "xhr2-cookies": "1.1.0"
+        "websocket": "1.0.31"
       },
       "devDependencies": {
         "@babel/core": "^7.11.0",
@@ -2812,6 +2814,11 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
+    },
     "node_modules/acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -4509,11 +4516,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
-    },
     "node_modules/core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
@@ -4571,6 +4573,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -5551,6 +5561,11 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
@@ -13373,14 +13388,6 @@
         "xhr-request": "^1.1.0"
       }
     },
-    "node_modules/xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-      "dependencies": {
-        "cookiejar": "^2.1.1"
-      }
-    },
     "node_modules/xmlcreate": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
@@ -15476,6 +15483,11 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
+    },
     "acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -16899,11 +16911,6 @@
         }
       }
     },
-    "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
-    },
     "core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
@@ -16954,6 +16961,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -17753,6 +17768,11 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -23839,14 +23859,6 @@
       "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
       "requires": {
         "xhr-request": "^1.1.0"
-      }
-    },
-    "xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-      "requires": {
-        "cookiejar": "^2.1.1"
       }
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -67,12 +67,15 @@
   "dependencies": {
     "@babel/runtime": "7.3.1",
     "@ethersproject/abi": "5.0.7",
+    "abortcontroller-polyfill": "^1.7.3",
     "any-promise": "1.3.0",
     "bignumber.js": "8.0.2",
     "bn.js": "4.11.6",
     "constants-browserify": "^1.0.0",
+    "cross-fetch": "^3.1.5",
     "crypto-browserify": "^3.12.0",
     "elliptic": "6.5.4",
+    "es6-promise": "^4.2.8",
     "eth-lib": "0.2.8",
     "ethers": "5.4.1",
     "ethjs-unit": "0.1.6",
@@ -90,8 +93,7 @@
     "stream-http": "^3.2.0",
     "utf8": "2.1.1",
     "uuid": "8.3.2",
-    "websocket": "1.0.31",
-    "xhr2-cookies": "1.1.0"
+    "websocket": "1.0.31"
   },
   "devDependencies": {
     "@babel/core": "^7.11.0",

--- a/packages/caver-core-requestmanager/caver-providers-http/src/index.js
+++ b/packages/caver-core-requestmanager/caver-providers-http/src/index.js
@@ -23,12 +23,17 @@
  *   Marek Kotewicz <marek@parity.io>
  *   Marian Oancea
  *   Fabian Vogelsteller <fabian@ethereum.org>
+ *   AyanamiTech <ayanami0330@protonmail.com>
  * @date 2015
  */
 
-const XHR2 = require('xhr2-cookies').XMLHttpRequest
+const fetch = require('cross-fetch')
 const http = require('http')
 const https = require('https')
+
+// Apply missing polyfill for IE
+require('es6-promise').polyfill()
+require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
 
 const errors = require('../../../caver-core-helpers').errors
 
@@ -43,8 +48,11 @@ const errors = require('../../../caver-core-helpers').errors
 const HttpProvider = function HttpProvider(host, options) {
     options = options || {}
     this.host = host || 'http://localhost:8545'
+
+    this.withCredentials = options.withCredentials
     this.timeout = options.timeout || 0
     this.headers = options.headers
+    this.agent = options.agent
     this.connected = false
 
     // keepAlive is true unless explicitly set to false
@@ -60,43 +68,6 @@ const HttpProvider = function HttpProvider(host, options) {
 }
 
 /**
- * _prepareRequest create request instance
- */
-HttpProvider.prototype._prepareRequest = function() {
-    let request
-
-    // the current runtime is a browser
-    if (typeof XMLHttpRequest !== 'undefined') {
-        // eslint-disable-next-line no-undef
-        request = new XMLHttpRequest()
-    } else {
-        request = new XHR2()
-        const agents = { httpsAgent: this.httpsAgent, httpAgent: this.httpAgent, baseUrl: this.baseUrl }
-
-        if (this.agent) {
-            agents.httpsAgent = this.agent.https
-            agents.httpAgent = this.agent.http
-            agents.baseUrl = this.agent.baseUrl
-        }
-
-        request.nodejsSet(agents)
-    }
-
-    request.open('POST', this.host, true)
-    request.setRequestHeader('Content-Type', 'application/json')
-    request.timeout = this.timeout
-    request.withCredentials = this.withCredentials
-
-    if (this.headers) {
-        this.headers.forEach(function(header) {
-            request.setRequestHeader(header.name, header.value)
-        })
-    }
-
-    return request
-}
-
-/**
  * Should be used to make async request
  *
  * @method send
@@ -104,36 +75,111 @@ HttpProvider.prototype._prepareRequest = function() {
  * @param {Function} callback triggered on end with (err, result)
  */
 HttpProvider.prototype.send = function(payload, callback) {
-    const _this = this
-    const request = this._prepareRequest()
+    const options = {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    }
+    const headers = {}
+    let controller
 
-    request.onreadystatechange = function() {
-        if (request.readyState === 4 && request.timeout !== 1) {
-            let result = request.responseText
-            let error = null
+    if (typeof AbortController !== 'undefined') {
+        controller = new AbortController()
+        // eslint-disable-next-line no-undef
+    } else if (typeof AbortController === 'undefined' && typeof window !== 'undefined' && typeof window.AbortController !== 'undefined') {
+        // Some chrome version doesn't recognize new AbortController(); so we are using it from window instead
+        // https://stackoverflow.com/questions/55718778/why-abortcontroller-is-not-defined
+        // eslint-disable-next-line no-undef
+        controller = new window.AbortController()
+    } else {
+        // Disable user defined timeout
+        this.timeout = 0
+    }
 
-            try {
-                result = JSON.parse(result)
-            } catch (e) {
-                error = errors.InvalidResponse(request.responseText)
-            }
+    // the current runtime is node
+    if (typeof XMLHttpRequest === 'undefined') {
+        // https://github.com/node-fetch/node-fetch#custom-agent
+        const agents = { httpsAgent: this.httpsAgent, httpAgent: this.httpAgent }
 
-            _this.connected = true
-            callback(error, result)
+        if (this.agent) {
+            agents.httpsAgent = this.agent.https
+            agents.httpAgent = this.agent.http
+        }
+
+        if (this.host.substring(0, 5) === 'https') {
+            options.agent = agents.httpsAgent
+        } else {
+            options.agent = agents.httpAgent
         }
     }
 
-    request.ontimeout = function() {
-        _this.connected = false
-        callback(errors.ConnectionTimeout(this.timeout))
+    if (this.headers) {
+        this.headers.forEach(function(header) {
+            headers[header.name] = header.value
+        })
     }
 
-    try {
-        request.send(JSON.stringify(payload))
-    } catch (error) {
-        this.connected = false
+    // Default headers
+    if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json'
+    }
+
+    // As the Fetch API supports the credentials as following options 'include', 'omit', 'same-origin'
+    // https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials
+    // To avoid breaking change in 1.x we override this value based on boolean option.
+    if (this.withCredentials) {
+        options.credentials = 'include'
+    } else {
+        options.credentials = 'omit'
+    }
+
+    options.headers = headers
+
+    if (this.timeout > 0) {
+        this.timeoutId = setTimeout(function() {
+            controller.abort()
+        }, this.timeout)
+    }
+
+    // Prevent global leak of connected
+    const _this = this
+
+    const success = function(response) {
+        if (this.timeoutId !== undefined) {
+            clearTimeout(this.timeoutId)
+        }
+        let result = response
+        const error = null
+
+        try {
+            // Response is a stream data so should be awaited for json response
+            result.json().then(function(data) {
+                result = data
+                _this.connected = true
+                callback(error, result)
+            })
+        } catch (e) {
+            _this.connected = false
+            callback(errors.InvalidResponse(result))
+        }
+    }
+
+    const failed = function(error) {
+        if (this.timeoutId !== undefined) {
+            clearTimeout(this.timeoutId)
+        }
+
+        if (error.name === 'AbortError') {
+            _this.connected = false
+            callback(errors.ConnectionTimeout(this.timeout))
+        }
+
+        _this.connected = false
         callback(errors.InvalidConnection(this.host))
     }
+
+    fetch(this.host, options)
+        .then(success.bind(this))
+        .catch(failed.bind(this))
 }
 
 HttpProvider.prototype.disconnect = function() {

--- a/test/invalidResponse.js
+++ b/test/invalidResponse.js
@@ -31,26 +31,24 @@ describe('Connection error test', () => {
             expect(err.message).to.equals("CONNECTION ERROR: Couldn't connect to node invalid:1234.")
         }
     }).timeout(10000)
-})
 
-describe('Invalid response test', () => {
-    it('CAVERJS-UNIT-ETC-052: without timeout return Invalid response: null error.', async () => {
+    it('CAVERJS-UNIT-ETC-052: without timeout return connection error.', async () => {
         caver = new Caver('http://localhost:1234/')
         try {
             await caver.klay.getNodeInfo()
             assert(false)
         } catch (err) {
-            expect(err.message).to.equals('Invalid JSON RPC response: ""')
+            expect(err.message).to.equals("CONNECTION ERROR: Couldn't connect to node http://localhost:1234/.")
         }
     })
 
-    it('CAVERJS-UNIT-ETC-053: with timeout return Invalid response: null error.', async () => {
+    it('CAVERJS-UNIT-ETC-053: with timeout return connection error.', async () => {
         caver = new Caver(new Caver.providers.HttpProvider('http://localhost:1234/', { timeout: 5000 }))
         try {
             await caver.klay.getNodeInfo()
             assert(false)
         } catch (err) {
-            expect(err.message).to.equals('Invalid JSON RPC response: ""')
+            expect(err.message).to.equals("CONNECTION ERROR: Couldn't connect to node http://localhost:1234/.")
         }
     })
 })

--- a/types/packages/caver-core-requestmanager/caver-providers-http/src/index.d.ts
+++ b/types/packages/caver-core-requestmanager/caver-providers-http/src/index.d.ts
@@ -16,9 +16,8 @@
     along with the caver-js. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { XMLHttpRequest } from 'xhr2-cookies'
-import * as http from 'http'
-import * as https from 'https'
+import type { Agent as HTTPAgent } from 'http'
+import type { Agent as HTTPSAgent } from 'https'
 import { JsonRpcResponse } from '../../../caver-core-helpers/src'
 
 export interface HttpHeader {
@@ -27,9 +26,8 @@ export interface HttpHeader {
 }
 
 export interface HttpProviderAgent {
-    baseUrl?: string
-    http?: http.Agent
-    https?: https.Agent
+    http?: HTTPAgent
+    https?: HTTPSAgent
 }
 
 export interface HttpProviderOptions {
@@ -45,12 +43,11 @@ export class HttpProvider {
 
     host: string
     connected: boolean
-    withCredentials: boolean
+    withCredentials?: boolean
     timeout: number
     headers?: HttpHeader[]
     agent?: HttpProviderAgent
 
-    _prepareRequest?(): any
     send(payload: object, callback?: (error: Error | null, result: JsonRpcResponse | undefined) => void): void
     supportsSubscriptions(): boolean
     disconnect(): boolean


### PR DESCRIPTION
closes #637

Backported changes from PR https://github.com/ChainSafe/web3.js/pull/5085 https://github.com/ChainSafe/web3.js/pull/5179 to fix handling server-side errors that return timeouts, rate limits ( 429 ), etc.