### PR TITLE
Added newly added klay APIs for upper/lower bound gas price

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-prettier": "3.1.1",
         "eslint-plugin-react": "^7.28.0",
         "exorcist": "2.0.0",
+        "fetch-mock": "^9.11.0",
         "jsdoc": "^3.6.7",
         "jsdoc-typeof-plugin": "^1.0.0",
         "jshint": "^2.13.4",
@@ -6829,6 +6830,82 @@
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
     },
+    "node_modules/fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock/node_modules/core-js": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.4.tgz",
+      "integrity": "sha512-vjsKqRc1RyAJC3Ye2kYqgfdThb3zYnx9CrqoCcjMOENMtQPC7ZViBvlDxwYU/2z2NI/IPuiXw5mT4hWhddqjzQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8377,6 +8454,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
+    },
     "node_modules/is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -9203,6 +9286,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
@@ -9213,6 +9302,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -18700,6 +18795,64 @@
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
     },
+    "fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.23.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.4.tgz",
+          "integrity": "sha512-vjsKqRc1RyAJC3Ye2kYqgfdThb3zYnx9CrqoCcjMOENMtQPC7ZViBvlDxwYU/2z2NI/IPuiXw5mT4hWhddqjzQ==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -19882,6 +20035,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -20545,6 +20704,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
@@ -20555,6 +20720,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
     "log-symbols": {

--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -2007,6 +2007,42 @@ class Klay {
                 params: 0,
             }),
             /**
+             * Returns an upper bound gas price.
+             *
+             * @memberof Klay
+             * @method getUpperBoundGasPrice
+             * @instance
+             *
+             * @example
+             * const result = await caver.rpc.klay.getUpperBoundGasPrice()
+             *
+             * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+             * @return {Promise<string>} An upper bound gas price
+             */
+            new Method({
+                name: 'getUpperBoundGasPrice',
+                call: 'klay_upperBoundGasPrice',
+                params: 0,
+            }),
+            /**
+             * Returns a lower bound gas price.
+             *
+             * @memberof Klay
+             * @method getLowerBoundGasPrice
+             * @instance
+             *
+             * @example
+             * const result = await caver.rpc.klay.getLowerBoundGasPrice()
+             *
+             * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+             * @return {Promise<string>} A lower bound gas price
+             */
+            new Method({
+                name: 'getLowerBoundGasPrice',
+                call: 'klay_lowerBoundGasPrice',
+                params: 0,
+            }),
+            /**
              * An object defines an access list result that includes accessList and gasUsed.
              *
              * @typedef {object} Klay.AccessListResult

--- a/test/packages/caver.rpc.js
+++ b/test/packages/caver.rpc.js
@@ -576,6 +576,42 @@ describe('caver.rpc.klay', () => {
         }).timeout(100000)
     })
 
+    context('caver.rpc.klay.getUpperBoundGasPrice', () => {
+        it('CAVERJS-UNIT-RPC-035: should call klay_upperBoundGasPrice', async () => {
+            sandbox.stub(caver.rpc.klay._requestManager, 'send').callsFake((data, callback) => {
+                expect(data.method).to.equal('klay_upperBoundGasPrice')
+                callback(undefined, {})
+            })
+
+            await caver.rpc.klay.getUpperBoundGasPrice()
+        }).timeout(100000)
+
+        it('CAVERJS-UNIT-RPC-036: should return an upper bound gas price', async () => {
+            const ret = await caver.rpc.klay.getUpperBoundGasPrice()
+            const gasPrice = await caver.rpc.klay.getGasPrice()
+            expect(_.isString(ret)).to.be.true
+            expect(ret).to.equal(gasPrice)
+        }).timeout(100000)
+    })
+
+    context('caver.rpc.klay.getLowerBoundGasPrice', () => {
+        it('CAVERJS-UNIT-RPC-037: should call klay_lowerBoundGasPrice', async () => {
+            sandbox.stub(caver.rpc.klay._requestManager, 'send').callsFake((data, callback) => {
+                expect(data.method).to.equal('klay_lowerBoundGasPrice')
+                callback(undefined, {})
+            })
+
+            await caver.rpc.klay.getLowerBoundGasPrice()
+        }).timeout(100000)
+
+        it('CAVERJS-UNIT-RPC-038: should return an lower bound gas price', async () => {
+            const ret = await caver.rpc.klay.getLowerBoundGasPrice()
+            const gasPrice = await caver.rpc.klay.getGasPrice()
+            expect(_.isString(ret)).to.be.true
+            expect(ret).to.equal(gasPrice)
+        }).timeout(100000)
+    })
+
     context('caver.rpc.klay.createAccessList', () => {
         const txArgs = {
             from: '0x3bc5885c2941c5cda454bdb4a8c88aa7f248e312',

--- a/test/packages/caver.rpc.js
+++ b/test/packages/caver.rpc.js
@@ -590,7 +590,7 @@ describe('caver.rpc.klay', () => {
             const ret = await caver.rpc.klay.getUpperBoundGasPrice()
             const gasPrice = await caver.rpc.klay.getGasPrice()
             expect(_.isString(ret)).to.be.true
-            expect(ret).to.equal(gasPrice)
+            expect(caver.utils.hexToNumber(ret) >= caver.utils.hexToNumber(gasPrice)).to.be.true
         }).timeout(100000)
     })
 
@@ -608,7 +608,7 @@ describe('caver.rpc.klay', () => {
             const ret = await caver.rpc.klay.getLowerBoundGasPrice()
             const gasPrice = await caver.rpc.klay.getGasPrice()
             expect(_.isString(ret)).to.be.true
-            expect(ret).to.equal(gasPrice)
+            expect(caver.utils.hexToNumber(ret) <= caver.utils.hexToNumber(gasPrice)).to.be.true
         }).timeout(100000)
     })
 

--- a/types/packages/caver-rpc/src/klay.d.ts
+++ b/types/packages/caver-rpc/src/klay.d.ts
@@ -251,6 +251,12 @@ export class Klay {
     getMaxPriorityFeePerGas(
         callback?: (error: Error, result: string) => void
     ): Promise<string>
+    getUpperBoundGasPrice(
+        callback?: (error: Error, result: string) => void
+    ): Promise<string>
+    getLowerBoundGasPrice(
+        callback?: (error: Error, result: string) => void
+    ): Promise<string>
     createAccessList(
         callObject: CallObject,
         blockNumber: BlockNumber,

--- a/types/test/rpc-test.ts
+++ b/types/test/rpc-test.ts
@@ -1134,6 +1134,19 @@ rpc.klay.getGasPrice()
 rpc.klay.getGasPrice((err: Error, ret: string) => {})
 
 // $ExpectType Promise<string>
+rpc.klay.getMaxPriorityFeePerGas()
+// $ExpectType Promise<string>
+rpc.klay.getMaxPriorityFeePerGas((err: Error, ret: string) => {})
+// $ExpectType Promise<string>
+rpc.klay.getUpperBoundGasPrice()
+// $ExpectType Promise<string>
+rpc.klay.getUpperBoundGasPrice((err: Error, ret: string) => {})
+// $ExpectType Promise<string>
+rpc.klay.getLowerBoundGasPrice()
+// $ExpectType Promise<string>
+rpc.klay.getLowerBoundGasPrice((err: Error, ret: string) => {})
+
+// $ExpectType Promise<string>
 rpc.klay.getGasPriceAt(0)
 // $ExpectType Promise<string>
 rpc.klay.getGasPriceAt(new BigNumber(0))


### PR DESCRIPTION
## Proposed changes

This PR added `caver.rpc.klay.getUpperBoundGasPrice` and `caver.rpc.klay.getLowerBoundGasPrice`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related to https://github.com/klaytn/caver-js/issues/662

## Further comments

refer to https://github.com/klaytn/klaytn/pull/1520