### PR TITLE
Supports subscribe function for events in caver.contract

### DIFF
--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -1453,7 +1453,7 @@ Contract.prototype._processExecuteArguments = function _processExecuteArguments(
     }
 
     // get the options. need to copy the options object
-    processedArgs.options = _.isObject(args[args.length - 1]) ? Object.assign({}, args.pop()) : {}
+    processedArgs.options = _.isObject(args[args.length - 1]) ? { ...args.pop() } : {}
 
     // get the generateRequest argument for batch requests
     processedArgs.generateRequest = args[args.length - 1] === true ? args.pop() : false

--- a/packages/caver-contract/src/index.js
+++ b/packages/caver-contract/src/index.js
@@ -1010,7 +1010,8 @@ Contract.prototype.send = function() {
     const args = Array.prototype.slice.call(arguments)
 
     // contract.send({from, gas, ...}, 'functionName', parameters)
-    const sendOptions = args[0]
+    // need to copy sendOptions to not modify original data object
+    const sendOptions = JSON.parse(JSON.stringify(args[0]))
     const functionName = args[1]
     const params = args.slice(2)
 
@@ -1241,6 +1242,47 @@ Contract.prototype.once = function(event, options, callback) {
 /**
  * Adds event listeners and creates a subscription.
  *
+ * @example
+ * contract.subscribe('MyEvent', {
+ *     filter: { myIndexedParam: [20,23], myOtherIndexedParam: '0x123456789...' }, // Using an array means OR: e.g. 20 or 23
+ *     fromBlock: 0
+ * }, function(error, event){ console.log(event) })
+ *
+ * @param {string} event The name of the event in the contract, or "allEvents" to get all events.
+ * @param {object} options The options used for subscription.
+ * @param {object} [options.filter] Lets you filter events by indexed parameters, e.g., `{ filter: {mynumber: [12,13]} }` means all events where "mynumber" is 12 or 13.
+ * @param {Array.<string>} [options.topics] This allows you to manually set the topics for the event filter. Given the filter property and event signature, `topic[0]` would not be set automatically.
+ * @param {function} callback This callback will be fired for the first event as the second argument, or an error as the first argument. The event is returned as an {@link Contract.EventObject} type.
+ * @return {object} the event subscription
+ */
+Contract.prototype.subscribe = function(event, options, callback) {
+    const args = Array.prototype.slice.call(arguments)
+
+    // get the callback
+    callback = this._getCallback(args)
+
+    if (!callback) {
+        throw new Error('Once requires a callback as the second parameter.')
+    }
+
+    // don't allow fromBlock
+    if (options) {
+        delete options.fromBlock
+    }
+
+    // don't return as once shouldn't provide "on"
+    const subscription = this._on(event, options, function(err, res, sub) {
+        if (_.isFunction(callback)) {
+            callback(err, res, sub)
+        }
+    })
+
+    return subscription
+}
+
+/**
+ * Adds event listeners and creates a subscription.
+ *
  * @ignore
  * @method _on
  * @param {string} event
@@ -1410,8 +1452,8 @@ Contract.prototype._processExecuteArguments = function _processExecuteArguments(
         processedArgs.defaultBlock = args.pop()
     }
 
-    // get the options
-    processedArgs.options = _.isObject(args[args.length - 1]) ? args.pop() : {}
+    // get the options. need to copy the options object
+    processedArgs.options = _.isObject(args[args.length - 1]) ? Object.assign({}, args.pop()) : {}
 
     // get the generateRequest argument for batch requests
     processedArgs.generateRequest = args[args.length - 1] === true ? args.pop() : false

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -117,7 +117,7 @@ describe('subscription should work well with websocket connection', () => {
         })
     }).timeout(30000)
 
-    it('contract.subscribe should subscribe the event of the contract with caver.klay.Contract', async () => {
+    it('CAVERJS-UNIT-ETC-410: contract.subscribe should subscribe the event of the contract with caver.klay.Contract', async () => {
         const byteCode =
             '0x6080604052348015600f57600080fd5b5060e98061001e6000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063954ab4b2146044575b600080fd5b348015604f57600080fd5b5060566058565b005b7f90a042becc42ba1b13a5d545701bf5ceff20b24d9e5cc63b67f96ef814d80f0933604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390a15600a165627a7a723058200ebb53e9d575350ceb2d92263b7d4920888706b5221f024e7bbc10e3dbb8e18d0029'
         const helloContractABI = [

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -167,8 +167,7 @@ describe('subscription should work well with websocket connection', () => {
         await deployed.methods.say().send(options)
         await deployed.methods.say().send(options)
 
-        while(eventCount < 2)
-
+        while (eventCount < 2) {}
         subscription.unsubscribe()
 
         expect(dataVariable).not.to.null
@@ -186,8 +185,7 @@ describe('subscription should work well with websocket connection', () => {
         await commonContract.methods.say().send(options)
         await commonContract.methods.say().send(options)
 
-        while(eventCount < 2)
-
+        while (eventCount < 2) {}
         subscription.unsubscribe()
 
         expect(dataVariable).not.to.null

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -117,6 +117,82 @@ describe('subscription should work well with websocket connection', () => {
         })
     }).timeout(30000)
 
+    it('contract.subscribe should subscribe the event of the contract with caver.klay.Contract', async () => {
+        const byteCode =
+            '0x6080604052348015600f57600080fd5b5060e98061001e6000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063954ab4b2146044575b600080fd5b348015604f57600080fd5b5060566058565b005b7f90a042becc42ba1b13a5d545701bf5ceff20b24d9e5cc63b67f96ef814d80f0933604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390a15600a165627a7a723058200ebb53e9d575350ceb2d92263b7d4920888706b5221f024e7bbc10e3dbb8e18d0029'
+        const helloContractABI = [
+            {
+                constant: false,
+                inputs: [],
+                name: 'say',
+                outputs: [],
+                payable: false,
+                stateMutability: 'nonpayable',
+                type: 'function',
+            },
+            {
+                anonymous: false,
+                inputs: [
+                    {
+                        indexed: false,
+                        name: 'who',
+                        type: 'address',
+                    },
+                ],
+                name: 'callevent',
+                type: 'event',
+            },
+        ]
+
+        const contractInst = caver.contract.create(helloContractABI)
+        const deployed = await contractInst.deploy({ data: byteCode }).send({
+            from: senderAddress,
+            gas: 100000000,
+            value: 0,
+        })
+
+        let dataVariable
+        let eventCount = 0
+        let subscription = deployed.subscribe('callevent', (error, data) => {
+            expect(error).to.be.null
+            dataVariable = data
+            eventCount++
+        })
+
+        const options = {
+            from: senderAddress,
+            gas: 30000,
+        }
+
+        await deployed.methods.say().send(options)
+        await deployed.methods.say().send(options)
+
+        while(eventCount < 2)
+
+        subscription.unsubscribe()
+
+        expect(dataVariable).not.to.null
+
+        const commonContract = caver.contract.create(helloContractABI, deployed.options.address)
+
+        dataVariable = null
+        eventCount = 0
+        subscription = commonContract.subscribe('callevent', (error, data) => {
+            expect(error).to.be.null
+            dataVariable = data
+            eventCount++
+        })
+
+        await commonContract.methods.say().send(options)
+        await commonContract.methods.say().send(options)
+
+        while(eventCount < 2)
+
+        subscription.unsubscribe()
+
+        expect(dataVariable).not.to.null
+    }).timeout(200000)
+
     // Regression test for a race-condition where a fresh caver instance
     // subscribing to past events would have its call parameters deleted while it
     // made initial Websocket handshake and return an incorrect response.


### PR DESCRIPTION
## Proposed changes

This PR introduces `contract.subscribe(eventName, filterOptions, callback)` function to subscribe events via contract instance.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
