### PR TITLE
Use multiformats instead of multihashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caver-js",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caver-js",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "LGPL-3.0",
       "dependencies": {
         "@babel/runtime": "7.3.1",
@@ -28,7 +28,7 @@
         "https": "^1.0.0",
         "ipfs-http-client": "^57.0.3",
         "lodash": "4.17.21",
-        "multihashes": "4.0.2",
+        "multiformats": "^9.7.1",
         "number-to-bn": "1.7.0",
         "oboe": "2.1.3",
         "os": "^0.1.2",
@@ -2456,11 +2456,6 @@
       "dependencies": {
         "multiformats": "^9.4.2"
       }
-    },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "node_modules/@multiformats/multiaddr": {
       "version": "10.3.3",
@@ -9538,42 +9533,10 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/multiformats": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.7.1.tgz",
+      "integrity": "sha512-TaVmGEBt0fhxiNJMGphBfB+oGvUxFs8KgGvgl8d3C+GWtrFcvXdJ2196eg+dYhmSFClmgFfSfJEklo+SZzdNuw=="
     },
     "node_modules/nan": {
       "version": "2.15.0",
@@ -12417,14 +12380,6 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
-    "node_modules/uint8arrays": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-      "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
     "node_modules/umd": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
@@ -14730,11 +14685,6 @@
           }
         }
       }
-    },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "@multiformats/multiaddr": {
       "version": "10.3.3",
@@ -20402,35 +20352,10 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "requires": {
-        "@multiformats/base-x": "^4.0.1"
-      }
-    },
     "multiformats": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
-    },
-    "multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "requires": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-        }
-      }
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.7.1.tgz",
+      "integrity": "sha512-TaVmGEBt0fhxiNJMGphBfB+oGvUxFs8KgGvgl8d3C+GWtrFcvXdJ2196eg+dYhmSFClmgFfSfJEklo+SZzdNuw=="
     },
     "nan": {
       "version": "2.15.0",
@@ -22690,14 +22615,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
-    },
-    "uint8arrays": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-      "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-      "requires": {
-        "multiformats": "^9.4.2"
-      }
     },
     "umd": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "https": "^1.0.0",
     "ipfs-http-client": "^57.0.3",
     "lodash": "4.17.21",
-    "multihashes": "4.0.2",
+    "multiformats": "^9.7.1",
     "number-to-bn": "1.7.0",
     "oboe": "2.1.3",
     "os": "^0.1.2",

--- a/packages/caver-ipfs/src/index.js
+++ b/packages/caver-ipfs/src/index.js
@@ -19,7 +19,7 @@
 
 const lodash = require('lodash')
 const fs = require('fs')
-const multihash = require('multihashes')
+const { CID } = require('multiformats/cid')
 
 /**
  * Representing a class for uploading and loading files to IPFS.
@@ -146,8 +146,8 @@ class IPFS {
      * @return {string}
      */
     toHex(hash) {
-        const buf = multihash.fromB58String(hash)
-        return `0x${multihash.toHexString(buf)}`
+        const cid = CID.parse(hash)
+        return `0x${Buffer.from(cid.toJSON().hash).toString('hex')}`
     }
 
     /**
@@ -162,8 +162,9 @@ class IPFS {
      */
     fromHex(contentHash) {
         const hex = contentHash.substring(2)
-        const buf = multihash.fromHexString(hex)
-        return multihash.toB58String(buf)
+        // convert hex string to Uint8Array type
+        const buf = Uint8Array.from(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
+        return CID.decode(buf).toString()
     }
 }
 


### PR DESCRIPTION
## Proposed changes

This PR introduces using `multiformats` library instead of `multihashes` which is [archived](https://github.com/multiformats/js-multihash).
Nothing changes for usage.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related to https://github.com/klaytn/caver-js/issues/676

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
