### PR TITLE
Support options to set auth with Infura projectId and projectSecret

### DIFF
--- a/packages/caver-ipfs/src/index.js
+++ b/packages/caver-ipfs/src/index.js
@@ -71,7 +71,7 @@ class IPFS {
 
     /**
      * Makes an options object to use with ipfs request
-     * 
+     *
      * @example
      * // You can create an option object with projectId and projectSecret for Infura IPFS Node
      * const options = caver.ipfs.createOptions({projectId, projectSecret})
@@ -86,8 +86,8 @@ class IPFS {
 
         const options = {}
         if (opts.projectId && opts.projectSecret) {
-            const auth = 'Basic ' + Buffer.from(opts.projectId + ':' + opts.projectSecret).toString('base64')
-            options.headers = options.headers? options.headers : {}
+            const auth = `Basic ${Buffer.from(`${opts.projectId}:${opts.projectSecret}`).toString('base64')}`
+            options.headers = options.headers ? options.headers : {}
             options.headers.authorization = auth
         }
         return options

--- a/packages/caver-ipfs/src/index.js
+++ b/packages/caver-ipfs/src/index.js
@@ -20,6 +20,7 @@
 const lodash = require('lodash')
 const fs = require('fs')
 const { CID } = require('multiformats/cid')
+const _ = require('lodash')
 
 /**
  * Representing a class for uploading and loading files to IPFS.
@@ -29,13 +30,14 @@ const { CID } = require('multiformats/cid')
 class IPFS {
     /**
      * Create an IPFS instance.
-     * @param {string} [host] The IPFS Node url to connect with.
-     * @param {number} [port] The port number to use.
-     * @param {boolean} [ssl] With or without SSL. If true, the https protocol is used. Otherwise, the http protocol is used.
+     * @param {string} [host]       The IPFS Node url to connect with.
+     * @param {number} [port]       The port number to use.
+     * @param {boolean} [ssl]       With or without SSL. If true, the https protocol is used. Otherwise, the http protocol is used.
+     * @param {object} [options]    An object contains configuration variables.
      */
-    constructor(host, port, ssl) {
-        if (host !== undefined && port !== undefined && ssl !== undefined) {
-            this.setIPFSNode(host, port, ssl)
+    constructor(host, port, ssl, options) {
+        if (host !== undefined && port !== undefined && ssl !== undefined && options !== undefined) {
+            this.setIPFSNode(host, port, ssl, options)
         }
     }
 
@@ -45,18 +47,50 @@ class IPFS {
      *
      * @example
      * caver.ipfs.setIPFSNode('localhost', 5001, false)
+     * caver.ipfs.setIPFSNode('localhost', 5001, false, { ... })
+     * caver.ipfs.setIPFSNode('localhost', 5001, false, caver.ipfs.createOptions({projectId, projectSecret}))
      *
-     * @param {string} host The IPFS Node url to connect with.
-     * @param {number} port The port number to use.
-     * @param {boolean} ssl With or without SSL. If true, the https protocol is used. Otherwise, the http protocol is used.
+     * @param {string}  host        The IPFS Node url to connect with.
+     * @param {number}  port        The port number to use.
+     * @param {boolean} ssl         With or without SSL. If true, the https protocol is used. Otherwise, the http protocol is used.
+     * @param {object}  [options]   An object contains configuration variables.
      * @return {void}
      */
-    async setIPFSNode(host, port, ssl) {
+    async setIPFSNode(host, port, ssl, options = {}) {
         const protocol = ssl ? 'https' : 'http'
         // Use the dynamic import function to load ipfs at runtime
         // refer to https://github.com/ipfs/js-ipfs/blob/master/docs/upgrading/v0.62-v0.63.md#esm
         const { create } = await import('ipfs-http-client')
-        this.ipfs = await create({ host, port, protocol })
+        const createObject = { host, port, protocol }
+        if (options.headers) {
+            // Copy the headers object
+            createObject.headers = JSON.parse(JSON.stringify(options.headers))
+        }
+        this.ipfs = await create(createObject)
+    }
+
+    /**
+     * Makes an options object to use with ipfs request
+     * 
+     * @example
+     * // You can create an option object with projectId and projectSecret for Infura IPFS Node
+     * const options = caver.ipfs.createOptions({projectId, projectSecret})
+     *
+     * @param {object} opts     An object that contains various configuration variables.
+     * @return {object}
+     */
+    createOptions(opts) {
+        if (!opts || !_.isObject(opts)) {
+            throw new Error(`Invalid parameter. Please send an object `)
+        }
+
+        const options = {}
+        if (opts.projectId && opts.projectSecret) {
+            const auth = 'Basic ' + Buffer.from(opts.projectId + ':' + opts.projectSecret).toString('base64')
+            options.headers = options.headers? options.headers : {}
+            options.headers.authorization = auth
+        }
+        return options
     }
 
     /**

--- a/test/ipfsTest.js
+++ b/test/ipfsTest.js
@@ -27,6 +27,8 @@ const Caver = require('../index')
 const caver = new Caver(testRPCURL)
 
 let sender
+let projectId
+let projectSecret
 
 before(() => {
     const privateKey =
@@ -34,12 +36,17 @@ before(() => {
             ? `0x${process.env.privateKey}`
             : process.env.privateKey
     sender = caver.wallet.add(caver.wallet.keyring.createFromPrivateKey(privateKey))
+
+
+    projectId = process.env.infuraProjectId
+    projectSecret = process.env.infuraProjectSecret
 })
 
 describe('Connect IPFS with Klaytn', () => {
-    it('CAVERJS-UNIT-IPFS-001: should add file to IPFS and return hash', async () => {
+    it('CAVERJS-UNIT-IPFS-001: should add file to IPFS and return hash (test with infura ipfs node)', async () => {
         // Set IPFS Node
-        await caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true)
+        const options = caver.ipfs.createOptions({projectId, projectSecret})
+        await caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true, options)
 
         // Create test txt file for IPFS
         const testFileName = './ipfsTestFile.txt'

--- a/test/ipfsTest.js
+++ b/test/ipfsTest.js
@@ -37,7 +37,6 @@ before(() => {
             : process.env.privateKey
     sender = caver.wallet.add(caver.wallet.keyring.createFromPrivateKey(privateKey))
 
-
     projectId = process.env.infuraProjectId
     projectSecret = process.env.infuraProjectSecret
 })
@@ -45,7 +44,7 @@ before(() => {
 describe('Connect IPFS with Klaytn', () => {
     it('CAVERJS-UNIT-IPFS-001: should add file to IPFS and return hash (test with infura ipfs node)', async () => {
         // Set IPFS Node
-        const options = caver.ipfs.createOptions({projectId, projectSecret})
+        const options = caver.ipfs.createOptions({ projectId, projectSecret })
         await caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true, options)
 
         // Create test txt file for IPFS


### PR DESCRIPTION
## Proposed changes

This PR makes using Infura IPFS node possible.
You can set auth like below with Infura projectId and projectSecret.

```
const options = caver.ipfs.createOptions({projectId, projectSecret})
await caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true, options)
```

I will implement more features for nft.storage after this.
For now, to support users, i will deploy this feature fist.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
