### PR TITLE
validateSignedMessage bug fix when signed in Korean message

### DIFF
--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -1426,7 +1426,7 @@ const hashMessage = data => {
  * @return {string}
  */
 const recoverPublicKey = (message, signature, isHashed = false) => {
-    if (!isHashed) message = hashMessage(message)
+    if (!isHashed) message = hashMessage(utf8ToHex(message))
 
     if (_.isArray(signature)) signature = { v: signature[0], r: signature[1], s: signature[2] }
     const vrs = { v: parseInt(signature.v.slice(2), 16), r: signature.r.slice(2), s: signature.s.slice(2) }
@@ -1453,7 +1453,7 @@ const recoverPublicKey = (message, signature, isHashed = false) => {
  */
 const recover = (message, signature, isHashed = false) => {
     if (!isHashed) {
-        message = hashMessage(message)
+        message = hashMessage(utf8ToHex(message))
     }
 
     return Account.recover(message, Account.encodeSignature(resolveSignature(signature))).toLowerCase()

--- a/packages/caver-utils/src/utils.js
+++ b/packages/caver-utils/src/utils.js
@@ -1399,9 +1399,10 @@ const isEmptySig = sig => {
  * @return {string} The hashed message with Klaytn specific prefix.
  */
 const hashMessage = data => {
-    const message = isHexStrict(data) ? hexToBytes(data) : data
-    const messageBuffer = Buffer.from(message)
-    const preamble = `\x19Klaytn Signed Message:\n${message.length}`
+    const messageHex = isHexStrict(data) ? data : utf8ToHex(data)
+    const messageBytes = hexToBytes(messageHex)
+    const messageBuffer = Buffer.from(messageBytes)
+    const preamble = `\x19Klaytn Signed Message:\n${messageBytes.length}`
     const preambleBuffer = Buffer.from(preamble)
     // klayMessage is concatenated buffer (preambleBuffer + messageBuffer)
     const klayMessage = Buffer.concat([preambleBuffer, messageBuffer])
@@ -1426,7 +1427,7 @@ const hashMessage = data => {
  * @return {string}
  */
 const recoverPublicKey = (message, signature, isHashed = false) => {
-    if (!isHashed) message = hashMessage(utf8ToHex(message))
+    if (!isHashed) message = hashMessage(message)
 
     if (_.isArray(signature)) signature = { v: signature[0], r: signature[1], s: signature[2] }
     const vrs = { v: parseInt(signature.v.slice(2), 16), r: signature.r.slice(2), s: signature.s.slice(2) }
@@ -1453,7 +1454,7 @@ const recoverPublicKey = (message, signature, isHashed = false) => {
  */
 const recover = (message, signature, isHashed = false) => {
     if (!isHashed) {
-        message = hashMessage(utf8ToHex(message))
+        message = hashMessage(message)
     }
 
     return Account.recover(message, Account.encodeSignature(resolveSignature(signature))).toLowerCase()

--- a/test/packages/caver.validator.js
+++ b/test/packages/caver.validator.js
@@ -113,6 +113,26 @@ describe('caver.validator.validateSignedMessage', () => {
             const ret = await caver.validator.validateSignedMessage(message, invalid, keyring.address)
             expect(ret).to.be.false
         }).timeout(100000)
+
+        it('CAVERJS-UNIT-VALIDATOR-006: should return true when korean-format message are passed as a parameter', async () => {
+            const getAccoutKeyStub = sandbox.stub(caver.validator.klaytnCall, 'getAccountKey')
+            getAccoutKeyStub.resolves(getAccountKeyResult)
+
+            const kMessage = '하이'
+            const kAddress = '0x82B4deC52696c7777b4453986496612a0a2B1e99'
+            const kSignedMessage =
+                '0x85e6ae815bb80814ba8f63b3b16941f0740f471a048efb79b31428dcb61345132bd48cbf9594a243243a97951fbd3cc555101158c76168bbcb0b2e1a0de08b2d1b'
+            // pub key
+            // "0xf2a480ed864b9fa3856e2841aa0851463ce34ba9c43a503d08e9ab5dcfd4136cc5fddab6ea35271f43fb75597eed634056c8b0e211a134e26ed1e01b9161a132"
+
+            const v = `0x${kSignedMessage.substring(2).substring(128, 130)}`
+            const r = `0x${kSignedMessage.substring(2).substring(0, 64)}`
+            const s = `0x${kSignedMessage.substring(2).substring(64, 128)}`
+            const sig = [v, r, s]
+
+            const ret = await caver.validator.validateSignedMessage(kMessage, sig, kAddress)
+            expect(ret).to.be.true
+        }).timeout(100000)
     })
 
     context('caver.validator.validateSignedMessage with AccountKeyPublic', () => {
@@ -189,21 +209,6 @@ describe('caver.validator.validateSignedMessage', () => {
 
             const ret = await caver.validator.validateSignedMessage(message, [new SignatureData(invalidSig)], keyring.address)
             expect(ret).to.be.false
-        }).timeout(100000)
-
-        it('CAVERJS-UNIT-VALIDATOR-011: should return true when korean-format message are passed as a parameter', async () => {
-            const kMessage = '하이'
-            const kAddress = '0x82B4deC52696c7777b4453986496612a0a2B1e99'
-            const kSignedMessage =
-                '0x85e6ae815bb80814ba8f63b3b16941f0740f471a048efb79b31428dcb61345132bd48cbf9594a243243a97951fbd3cc555101158c76168bbcb0b2e1a0de08b2d1b'
-            // pub key
-            // "0xf2a480ed864b9fa3856e2841aa0851463ce34ba9c43a503d08e9ab5dcfd4136cc5fddab6ea35271f43fb75597eed634056c8b0e211a134e26ed1e01b9161a132"
-            const v = `0x${kSignedMessage.substring(2).substring(128, 130)}`
-            const r = `0x${kSignedMessage.substring(2).substring(0, 64)}`
-            const s = `0x${kSignedMessage.substring(2).substring(64, 128)}`
-            const sig = [v, r, s]
-            const ret = await caver.validator.validateSignedMessage(kMessage, sig, kAddress)
-            expect(ret).to.be.true
         }).timeout(100000)
     })
 

--- a/test/packages/caver.validator.js
+++ b/test/packages/caver.validator.js
@@ -190,6 +190,21 @@ describe('caver.validator.validateSignedMessage', () => {
             const ret = await caver.validator.validateSignedMessage(message, [new SignatureData(invalidSig)], keyring.address)
             expect(ret).to.be.false
         }).timeout(100000)
+
+        it('CAVERJS-UNIT-VALIDATOR-011: should return true when korean-format message are passed as a parameter', async () => {
+            const kMessage = '하이'
+            const kAddress = '0x82B4deC52696c7777b4453986496612a0a2B1e99'
+            const kSignedMessage =
+                '0x85e6ae815bb80814ba8f63b3b16941f0740f471a048efb79b31428dcb61345132bd48cbf9594a243243a97951fbd3cc555101158c76168bbcb0b2e1a0de08b2d1b'
+            // pub key
+            // "0xf2a480ed864b9fa3856e2841aa0851463ce34ba9c43a503d08e9ab5dcfd4136cc5fddab6ea35271f43fb75597eed634056c8b0e211a134e26ed1e01b9161a132"
+            const v = `0x${kSignedMessage.substring(2).substring(128, 130)}`
+            const r = `0x${kSignedMessage.substring(2).substring(0, 64)}`
+            const s = `0x${kSignedMessage.substring(2).substring(64, 128)}`
+            const sig = [v, r, s]
+            const ret = await caver.validator.validateSignedMessage(kMessage, sig, kAddress)
+            expect(ret).to.be.true
+        }).timeout(100000)
     })
 
     context('caver.validator.validateSignedMessage with AccountKeyFail', () => {


### PR DESCRIPTION
## Proposed changes

- When Korean text message is signed, the signature is not properly verified with the validateSignedMessage function.
- Add logic to change encoding with utf8ToHex function if it is not Hex encoding.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://krustuniverse.atlassian.net/browse/CDAP-36

## Further comments

- none
