### PR TITLE
[API] Added `getParams` API at `governance` and `klay` namespaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caver-js",
-  "version": "1.9.1",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caver-js",
-      "version": "1.9.1",
+      "version": "1.10.1",
       "license": "LGPL-3.0",
       "dependencies": {
         "@babel/runtime": "7.3.1",

--- a/packages/caver-rpc/src/governance.js
+++ b/packages/caver-rpc/src/governance.js
@@ -230,6 +230,28 @@ const Governance = function Governance(...args) {
             inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
         }),
         /**
+         * Returns governance items at a specific block.
+         * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+         *
+         * @memberof Governance
+         * @method getParams
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getParams()
+         *
+         * @param {string|number} [blockNumberOrTag] A block number, or the string `latest` or `earliest`. If omitted, `latest` will be used.
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} The governance items.
+         */
+        new Method({
+            name: 'getParams',
+            call: 'governance_getParams',
+            params: 1,
+            inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
+        }),
+
+        /**
          * Returns the list of items that have received enough number of votes but not yet finalized.
          * At the end of the current epoch, these changes will be finalized and the result will be in effect from the epoch after next epoch.
          *

--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -2281,6 +2281,27 @@ class Klay {
                 params: 1,
             }),
             /**
+             * Returns governance items at a specific block.
+             * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+             *
+             * @memberof klay
+             * @method getParams
+             * @instance
+             *
+             * @example
+             * const result = await caver.rpc.klay.getParams()
+             *
+             * @param {string|number} [blockNumberOrTag] A block number, or the string `latest` or `earliest`. If omitted, `latest` will be used.
+             * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+             * @return {Promise<object>} The governance items.
+             */
+            new Method({
+                name: 'getParams',
+                call: 'klay_getParams',
+                params: 1,
+                inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
+            }),
+            /**
              * Provides an address of the operating node.
              * It is derived from the nodekey and used to sign consensus messages.
              * And the value of "governingnode" has to be one of validator's node address.

--- a/test/packages/caver.rpc.js
+++ b/test/packages/caver.rpc.js
@@ -1212,13 +1212,13 @@ describe('caver.rpc.governance', () => {
         }).timeout(100000)
     })
 
-    context('caver.rpc.governance.getItemsAt', () => {
+    context('caver.rpc.governance.getParams', () => {
         it('CAVERJS-UNIT-RPC-017: should return governance items at specific block', async () => {
             const govRPCStub = sandbox
-                .stub(caver.rpc.governance.getItemsAt.method.requestManager, 'send')
+                .stub(caver.rpc.governance.getParams.method.requestManager, 'send')
                 .callsFake((payload, sendTxCallback) => {
                     expect(payload.method).to.equal('governance_itemsAt')
-                    expect(payload.params.length).to.equal(caver.rpc.governance.getItemsAt.method.params)
+                    expect(payload.params.length).to.equal(caver.rpc.governance.getParams.method.params)
                     const ret = {
                         'governance.governancemode': 'single',
                         'governance.governingnode': '0xa80de139de3fb29fba7e2d20bda593c5ffe63ce9',
@@ -1237,7 +1237,7 @@ describe('caver.rpc.governance', () => {
                     sendTxCallback(null, ret)
                 })
 
-            await caver.rpc.governance.getItemsAt(0)
+            await caver.rpc.governance.getParams(0)
             expect(govRPCStub.callCount).to.equal(1)
         }).timeout(100000)
     })

--- a/types/packages/caver-rpc/src/governance.d.ts
+++ b/types/packages/caver-rpc/src/governance.d.ts
@@ -81,6 +81,8 @@ export class Governance {
     getNodeAddress(callback?: (error: Error, result: string) => void): Promise<string>
     getItemsAt(callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
     getItemsAt(blockNumber: BlockNumber, callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
+    getParams(callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
+    getParams(blockNumber: BlockNumber, callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
     getStakingInfo(callback?: (error: Error, result: StakingInformation) => void): Promise<StakingInformation>
     getStakingInfo(blockNumber: BlockNumber, callback?: (error: Error, result: StakingInformation) => void): Promise<StakingInformation>
     getPendingChanges(callback?: (error: Error, result: VoteItems) => void): Promise<VoteItems>

--- a/types/packages/caver-rpc/src/klay.d.ts
+++ b/types/packages/caver-rpc/src/klay.d.ts
@@ -140,6 +140,8 @@ export class Klay {
 
     getRewards(blockNumber: BlockNumber, callback?: (error: Error, result: Header) => void): Promise<Rewards>
     getChainConfig(callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
+    getParams(callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
+    getParams(blockNumber: BlockNumber, callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
     getChainConfigAt(callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getChainConfigAt(blockNumber: BlockNumber, callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getNodeAddress(callback?: (error: Error, result: string) => void): Promise<string>

--- a/types/test/rpc-test.ts
+++ b/types/test/rpc-test.ts
@@ -1325,29 +1325,29 @@ rpc.governance.getNodeAddress()
 rpc.governance.getNodeAddress((err: Error, ret: string) => {})
 
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(0)
+rpc.governance.getParams(0)
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BigNumber(0))
+rpc.governance.getParams(new BigNumber(0))
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BN(0))
+rpc.governance.getParams(new BN(0))
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('genesis')
+rpc.governance.getParams('genesis')
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('latest')
+rpc.governance.getParams('latest')
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('hash')
+rpc.governance.getParams('hash')
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(0, (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams(0, (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BigNumber(0), (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams(new BigNumber(0), (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BN(0), (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams(new BN(0), (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('genesis', (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams('genesis', (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('latest', (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams('latest', (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('hash', (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams('hash', (err: Error, ret: GovernanceItems) => {})
 
 // $ExpectType Promise<VoteItems>
 rpc.governance.getPendingChanges()


### PR DESCRIPTION
## Proposed changes

- Following updates for the newly added API `getParams` (See: https://github.com/klaytn/klaytn/pull/1783)
- Version update from `1.9.1` to `1.10.1` in `package-lock.json`.

Do not forget to update [caver-java](https://github.com/klaytn/caver-java) as well.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
