### PR TITLE
Revert "Revert "[Master] release/v1.10.2 QA Sign-off""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caver-js",
-  "version": "1.9.1",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caver-js",
-      "version": "1.9.1",
+      "version": "1.10.1",
       "license": "LGPL-3.0",
       "dependencies": {
         "@babel/runtime": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caver-js",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "caver-js is a JavaScript API library that allows developers to interact with a Klaytn node",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -82,7 +82,7 @@
     "eventemitter3": "4.0.0",
     "http": "0.0.1-security",
     "https": "^1.0.0",
-    "ipfs-http-client": "^57.0.3",
+    "ipfs-http-client": "^49.0.4",
     "lodash": "4.17.21",
     "multiformats": "^9.7.1",
     "number-to-bn": "1.7.0",

--- a/packages/caver-ipfs/src/index.js
+++ b/packages/caver-ipfs/src/index.js
@@ -19,6 +19,7 @@
 
 const lodash = require('lodash')
 const fs = require('fs')
+const ipfsClient = require('ipfs-http-client')
 const { CID } = require('multiformats/cid')
 const _ = require('lodash')
 
@@ -56,17 +57,14 @@ class IPFS {
      * @param {object}  [options]   An object contains configuration variables.
      * @return {void}
      */
-    async setIPFSNode(host, port, ssl, options = {}) {
+    setIPFSNode(host, port, ssl, options = {}) {
         const protocol = ssl ? 'https' : 'http'
-        // Use the dynamic import function to load ipfs at runtime
-        // refer to https://github.com/ipfs/js-ipfs/blob/master/docs/upgrading/v0.62-v0.63.md#esm
-        const { create } = await import('ipfs-http-client')
         const createObject = { host, port, protocol }
         if (options.headers) {
             // Copy the headers object
             createObject.headers = JSON.parse(JSON.stringify(options.headers))
         }
-        this.ipfs = await create(createObject)
+        this.ipfs = ipfsClient(createObject)
     }
 
     /**

--- a/packages/caver-rpc/src/governance.js
+++ b/packages/caver-rpc/src/governance.js
@@ -157,15 +157,18 @@ const Governance = function Governance(...args) {
          * @instance
          *
          * @example
+         * const result = await caver.rpc.governance.getChainConfig(0)
+         * // latest by default
          * const result = await caver.rpc.governance.getChainConfig()
          *
+         * @param {number|string} blockNumber A block number, or the hex number string to query chain configuration.
          * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
-         * @return {Promise<object>} The latest chain configuration
+         * @return {Promise<object>} The latest chain configuration, or chain configuration at the given block number.
          */
         new Method({
             name: 'getChainConfig',
-            call: 'governance_chainConfig',
-            params: 0,
+            call: 'governance_getChainConfig',
+            params: 1,
         }),
         /**
          * Returns the chain configuration at a specific block.
@@ -229,6 +232,28 @@ const Governance = function Governance(...args) {
             params: 1,
             inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
         }),
+        /**
+         * Returns governance items at a specific block.
+         * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+         *
+         * @memberof Governance
+         * @method getParams
+         * @instance
+         *
+         * @example
+         * const result = await caver.rpc.governance.getParams()
+         *
+         * @param {string|number} [blockNumberOrTag] A block number, or the string `latest` or `earliest`. If omitted, `latest` will be used.
+         * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+         * @return {Promise<object>} The governance items.
+         */
+        new Method({
+            name: 'getParams',
+            call: 'governance_getParams',
+            params: 1,
+            inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
+        }),
+
         /**
          * Returns the list of items that have received enough number of votes but not yet finalized.
          * At the end of the current epoch, these changes will be finalized and the result will be in effect from the epoch after next epoch.

--- a/packages/caver-rpc/src/klay.js
+++ b/packages/caver-rpc/src/klay.js
@@ -2249,15 +2249,18 @@ class Klay {
              * @instance
              *
              * @example
+             * const result = await caver.rpc.klay.getChainConfig(0)
+             * // latest by default
              * const result = await caver.rpc.klay.getChainConfig()
              *
+             * @param {number|string} blockNumber A block number, or the hex number string to query chain configuration.
              * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
-             * @return {Promise<object>} The latest chain configuration
+             * @return {Promise<object>} The latest chain configuration, or chain configuration at the given block number.
              */
             new Method({
                 name: 'getChainConfig',
-                call: 'klay_chainConfig',
-                params: 0,
+                call: 'klay_getChainConfig',
+                params: 1,
             }),
             /**
              * Returns the chain configuration at a specific block.
@@ -2279,6 +2282,27 @@ class Klay {
                 name: 'getChainConfigAt',
                 call: 'klay_chainConfigAt',
                 params: 1,
+            }),
+            /**
+             * Returns governance items at a specific block.
+             * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+             *
+             * @memberof klay
+             * @method getParams
+             * @instance
+             *
+             * @example
+             * const result = await caver.rpc.klay.getParams()
+             *
+             * @param {string|number} [blockNumberOrTag] A block number, or the string `latest` or `earliest`. If omitted, `latest` will be used.
+             * @param {function} [callback] Optional callback, returns an error object as the first parameter and the result as the second.
+             * @return {Promise<object>} The governance items.
+             */
+            new Method({
+                name: 'getParams',
+                call: 'klay_getParams',
+                params: 1,
+                inputFormatter: [formatters.inputDefaultBlockNumberFormatter],
             }),
             /**
              * Provides an address of the operating node.

--- a/test/ipfsTest.js
+++ b/test/ipfsTest.js
@@ -45,7 +45,8 @@ describe('Connect IPFS with Klaytn', () => {
     it('CAVERJS-UNIT-IPFS-001: should add file to IPFS and return hash (test with infura ipfs node)', async () => {
         // Set IPFS Node
         const options = caver.ipfs.createOptions({ projectId, projectSecret })
-        await caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true, options)
+        // await caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true, options)
+        caver.ipfs.setIPFSNode('ipfs.infura.io', 5001, true, options)
 
         // Create test txt file for IPFS
         const testFileName = './ipfsTestFile.txt'

--- a/test/packages/caver.rpc.js
+++ b/test/packages/caver.rpc.js
@@ -698,7 +698,7 @@ describe('caver.rpc.klay', () => {
             const klayRPCStub = sandbox
                 .stub(caver.rpc.klay.getChainConfig.method.requestManager, 'send')
                 .callsFake((payload, sendTxCallback) => {
-                    expect(payload.method).to.equal('klay_chainConfig')
+                    expect(payload.method).to.equal('klay_getChainConfig')
                     expect(payload.params.length).to.equal(caver.rpc.klay.getChainConfig.method.params)
                     const ret = {
                         chainId: 1001,
@@ -1098,7 +1098,7 @@ describe('caver.rpc.governance', () => {
             const govRPCStub = sandbox
                 .stub(caver.rpc.governance.getChainConfig.method.requestManager, 'send')
                 .callsFake((payload, sendTxCallback) => {
-                    expect(payload.method).to.equal('governance_chainConfig')
+                    expect(payload.method).to.equal('governance_getChainConfig')
                     expect(payload.params.length).to.equal(caver.rpc.governance.getChainConfig.method.params)
                     const ret = {
                         chainId: 1001,
@@ -1212,13 +1212,13 @@ describe('caver.rpc.governance', () => {
         }).timeout(100000)
     })
 
-    context('caver.rpc.governance.getItemsAt', () => {
+    context('caver.rpc.governance.getParams', () => {
         it('CAVERJS-UNIT-RPC-017: should return governance items at specific block', async () => {
             const govRPCStub = sandbox
-                .stub(caver.rpc.governance.getItemsAt.method.requestManager, 'send')
+                .stub(caver.rpc.governance.getParams.method.requestManager, 'send')
                 .callsFake((payload, sendTxCallback) => {
                     expect(payload.method).to.equal('governance_itemsAt')
-                    expect(payload.params.length).to.equal(caver.rpc.governance.getItemsAt.method.params)
+                    expect(payload.params.length).to.equal(caver.rpc.governance.getParams.method.params)
                     const ret = {
                         'governance.governancemode': 'single',
                         'governance.governingnode': '0xa80de139de3fb29fba7e2d20bda593c5ffe63ce9',
@@ -1237,7 +1237,7 @@ describe('caver.rpc.governance', () => {
                     sendTxCallback(null, ret)
                 })
 
-            await caver.rpc.governance.getItemsAt(0)
+            await caver.rpc.governance.getParams(0)
             expect(govRPCStub.callCount).to.equal(1)
         }).timeout(100000)
     })

--- a/types/packages/caver-klay/src/index.d.ts
+++ b/types/packages/caver-klay/src/index.d.ts
@@ -86,8 +86,6 @@ export class DeprecatedKlayRPC {
     getHeaderByHash: RpcCallToMethod['klay_getHeaderByHash']
     getBlockReceipts: RpcCallToMethod['klay_getBlockReceipts']
     getRewards: RpcCallToMethod['klay_getRewards']
-    getChainConfig: RpcCallToMethod['klay_chainConfig']
-    getChainConfigAt: RpcCallToMethod['klay_chainConfigAt']
     getNodeAddress: RpcCallToMethod['klay_nodeAddress']
     getGovParamsAt: RpcCallToMethod['klay_govParamsAt']
     getStakingInfo: RpcCallToMethod['klay_getStakingInfo']

--- a/types/packages/caver-rpc/src/governance.d.ts
+++ b/types/packages/caver-rpc/src/governance.d.ts
@@ -76,11 +76,14 @@ export class Governance {
     getMyVotingPower(callback?: (error: Error, result: number) => void): Promise<number>
     getMyVotes(callback?: (error: Error, result: MyVote[]) => void): Promise<MyVote[]>
     getChainConfig(callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
+    getChainConfig(blockNumber: BlockNumber, callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getChainConfigAt(callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getChainConfigAt(blockNumber: BlockNumber, callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getNodeAddress(callback?: (error: Error, result: string) => void): Promise<string>
     getItemsAt(callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
     getItemsAt(blockNumber: BlockNumber, callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
+    getParams(callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
+    getParams(blockNumber: BlockNumber, callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
     getStakingInfo(callback?: (error: Error, result: StakingInformation) => void): Promise<StakingInformation>
     getStakingInfo(blockNumber: BlockNumber, callback?: (error: Error, result: StakingInformation) => void): Promise<StakingInformation>
     getPendingChanges(callback?: (error: Error, result: VoteItems) => void): Promise<VoteItems>

--- a/types/packages/caver-rpc/src/klay.d.ts
+++ b/types/packages/caver-rpc/src/klay.d.ts
@@ -139,7 +139,10 @@ export class Klay {
     getHeaderByHash(blockHash: string, callback?: (error: Error, result: Header) => void): Promise<Header>
 
     getRewards(blockNumber: BlockNumber, callback?: (error: Error, result: Header) => void): Promise<Rewards>
+    getParams(callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
+    getParams(blockNumber: BlockNumber, callback?: (error: Error, result: GovernanceItems) => void): Promise<GovernanceItems>
     getChainConfig(callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
+    getChainConfig(blockNumber: BlockNumber, callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getChainConfigAt(callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getChainConfigAt(blockNumber: BlockNumber, callback?: (error: Error, result: ChainConfig) => void): Promise<ChainConfig>
     getNodeAddress(callback?: (error: Error, result: string) => void): Promise<string>

--- a/types/packages/caver-rtm/src/index.d.ts
+++ b/types/packages/caver-rtm/src/index.d.ts
@@ -136,6 +136,10 @@ export default class RpcCallToMethod {
     klay_chainConfig(
         callback?: (error: Error, result: ChainConfig) => void
     ): Promise<ChainConfig>
+    klay_getChainConfig(
+        blockNumberOrHash?: BlockNumber | string,
+        callback?: (error: Error, result: ChainConfig) => void
+    ): Promise<ChainConfig>
     klay_chainConfigAt(
         blockNumberOrHash: BlockNumber | string,
         callback?: (error: Error, result: ChainConfig) => void

--- a/types/test/rpc-test.ts
+++ b/types/test/rpc-test.ts
@@ -1191,6 +1191,11 @@ rpc.klay.getRewardbase()
 // $ExpectType Promise<string>
 rpc.klay.getRewardbase((err: Error, ret: string) => {})
 
+// $ExpectType Promise<ChainConfig>
+rpc.klay.getChainConfig()
+// $ExpectType Promise<ChainConfig>
+rpc.klay.getChainConfig((err: Error, ret: ChainConfig) => {})
+
 // $ExpectType Promise<LogObject[]>
 rpc.klay.getFilterChanges('filterId')
 // $ExpectType Promise<LogObject[]>
@@ -1325,29 +1330,29 @@ rpc.governance.getNodeAddress()
 rpc.governance.getNodeAddress((err: Error, ret: string) => {})
 
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(0)
+rpc.governance.getParams(0)
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BigNumber(0))
+rpc.governance.getParams(new BigNumber(0))
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BN(0))
+rpc.governance.getParams(new BN(0))
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('genesis')
+rpc.governance.getParams('genesis')
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('latest')
+rpc.governance.getParams('latest')
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('hash')
+rpc.governance.getParams('hash')
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(0, (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams(0, (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BigNumber(0), (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams(new BigNumber(0), (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt(new BN(0), (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams(new BN(0), (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('genesis', (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams('genesis', (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('latest', (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams('latest', (err: Error, ret: GovernanceItems) => {})
 // $ExpectType Promise<GovernanceItems>
-rpc.governance.getItemsAt('hash', (err: Error, ret: GovernanceItems) => {})
+rpc.governance.getParams('hash', (err: Error, ret: GovernanceItems) => {})
 
 // $ExpectType Promise<VoteItems>
 rpc.governance.getPendingChanges()


### PR DESCRIPTION
Reverts klaytn/caver-js#746

- Why this PR
  - caver-js release CI/CD pipeline is failed because v1.10.2 tag had been already so first I reverted the sign-off PR
  - For release, CI/CD fetch the added commits in release/v1.10.2 and make the sign-off PR to master
  - But github can't recognize the difference between the reverted master and release/v1.10.2
  - So I added a commit that slightly modifies it and tried to recognize the difference, but the result is that only the commit is included and other commits for version up are reverted.
  - As a result I reverted again to add the version up commit.